### PR TITLE
Pull submodules exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,12 +67,18 @@ on top of that, you might get the latest state of each submodule by executing
 python3 pull-submodules.py --lfna --latest
 ```
 
-But, if you wish to remain at the reference/official release, and get the latest state from a particular submodule, it is possible to move to the given submodule and checkout its `master` branch.
+But, if you wish to remain at the reference/official release, and get just the latest state from a particular submodule, it is possible to move to the given submodule and checkout its `master` branch.
 
 ```
 cd source/libraries/xlib
 git checkout master
 git pull
+```
+
+It is also possible to exclude submodules from being pulled by using the `--exclude:` directive and comma separated submodule names.
+
+```
+python3 pull-submodules.py --exclude:axionlib,geant4lib,restG4
 ```
 
 ### Recovering a clean git state of rest-framework and submodules

--- a/pull-submodules.py
+++ b/pull-submodules.py
@@ -47,6 +47,11 @@ for x in range(narg - 1):
     if (sys.argv[x + 1] == "--clean"):
         force = 1
         clean = 1
+    if (sys.argv[x + 1].find("--exclude:")>=0 ):
+        exclude_elems = sys.argv[x + 1][10:].split(",")
+
+
+
 
 def main():
 # The following command may fail
@@ -80,9 +85,17 @@ def main():
                         fullpath = fullpath[fullpath.find("packages"):]
                      if fullpath.find("scripts") >= 0:
                         fullpath = fullpath[fullpath.find("scripts"):]
+
+
                   if 'url=' in line:
                      url = line.replace('url=', '').strip()
-                     if (url.find("github") != -1) or (url.find("lfna.unizar.es") != -1 and lfna == 1) or (url.find("gitlab.pandax.sjtu.edu.cn") != -1 and sjtu == 1):
+
+                     exclude = False
+                     for x in exclude_elems:
+                        if url.lower().find( x.lower() )>0:
+                          exclude = True
+
+                     if (not exclude and url.find("github") != -1) or (url.find("lfna.unizar.es") != -1 and lfna == 1) or (url.find("gitlab.pandax.sjtu.edu.cn") != -1 and sjtu == 1):
                          print (fullpath.rstrip(), end='')
                          # init
                          p = subprocess.run('cd {} && git submodule init {}'.format(root, submodule), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)


### PR DESCRIPTION
A simple patch at `pull-submodules.py` so that we are allowed to specify submodules that should be ignored trhough the command line.

I.e. the following command will avoid pulling geant4lib, restG4 and axionlib.

```
python3 pull-submodules.py --exclude:geant4lib,restG4,axionlib
```

In principle, it will also apply to submodules from submodules. So the following command will pull `axionlib` excluding the internal submodule `SolarAxionFlux` which contains big size data.

```
python3 pull-submodules.py --exclude:solarAxionFlux
```