### PR TITLE
Checkout bash script

### DIFF
--- a/scripts/checkoutRemoteBranch.sh
+++ b/scripts/checkoutRemoteBranch.sh
@@ -1,0 +1,6 @@
+
+var=$(git ls-remote --heads origin ${1})
+
+var2="${var:1:3}"
+
+if [ -z $var2 ]; then echo "Checking out master"; git checkout master; else echo "Checking out ${1}"; git checkout ${1}; fi


### PR DESCRIPTION
I added a script that will allow us to checkout a remote branch if it exists, if it does not exist it will just checkout the `master` branch.

This can be used at libraries pipelines so that when we name the branch at `geant4lib` and `restG4` using the same name, the pipeline will test one against the other.

I.e. if `restG4` is validating branch `bbxx`, it will attempt to pull branch `bbxx` from `geant4lib` if it exists.