### PR TITLE
TRestReflector::InitDictionary(): fixed a bug when new dict is loaded…

### DIFF
--- a/source/framework/tools/src/TRestReflector.cxx
+++ b/source/framework/tools/src/TRestReflector.cxx
@@ -190,6 +190,8 @@ int TRestReflector::InitDictionary() {
             cout << "Loading external dictionary for: \"" << type << "\":" << endl;
             cout << sofilename << endl;
             gSystem->Load(sofilename.c_str());
+            RESTListOfClasses_typeid.clear();
+            RESTListOfClasses_typename.clear();
             cl = GetClassQuick(type);  // reset the TClass after loading external library.
             return 0;
         }
@@ -248,6 +250,8 @@ int TRestReflector::InitDictionary() {
         }
 
         gSystem->Load(Form("%s", sofilename.c_str()));
+        RESTListOfClasses_typeid.clear();
+        RESTListOfClasses_typename.clear();
         cl = GetClassQuick(type);  // reset the TClass after loading external library.
     }
 


### PR DESCRIPTION
This is to solve the seg.fault when dynamically loading the type's root dictionary. The problem is that, after loaded the so file, the TClass map, i.e., `RESTListOfClasses_typeid` and `RESTListOfClasses_typename` is not updated. TRestReflector is still using the old TClass without the type's root dictionary. See

https://github.com/rest-for-physics/rawlib/pull/14