### PR TITLE
Rest manager fix

### DIFF
--- a/source/bin/restManager.cxx
+++ b/source/bin/restManager.cxx
@@ -91,7 +91,7 @@ std::vector<std::string> input_files;
 void ParseInputFileArgs(const char* argv) {
     if (argv == NULL) return;
 
-    if (REST_ARGS.count("inputFile") > 0) {
+    if (REST_ARGS.count("inputFileName") > 0) {
         string input_old = REST_ARGS["inputFileName"];
         input_old += "\n" + string(argv);
 


### PR DESCRIPTION
This fixes a problem when reading `restManager` with several `--f` arguments, such as `restManager --f xx.root --f yy.root --f zz.root`.

There was a bug and it would just catch the latest input file. 