### PR TITLE
A recent fix on the --f arguments causes the trexdm validation to fail

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -337,20 +337,13 @@ trexDM_data_latest:
     - . ${CI_PROJECT_DIR}/install_latest/thisREST.sh
     - cd ${CI_PROJECT_DIR}/pipeline/trex
     - wget https://sultan.unizar.es/trexdm-readouts/readouts_v2.3.root
-    - cp R01928_tagTest_Vm_250_Vd_160_Pr_6_Gain_0x0_Shape_0xF_Clock_0x4-068.aqs R01929_tagTest_Vm_250_Vd_160_Pr_6_Gain_0x0_Shape_0xF_Clock_0x4-068.aqs
-    - restManager --fork --c 01_raw.rml --f "*.aqs"
-    - sleep 30
-    - restManager --fork --c 02_signal.rml --f "RawData*.root"
-    - sleep 30
-    - restManager --fork --c 03_hits.rml --f "Signals*.root"
-    - sleep 30
+      #    - cp R01928_tagTest_Vm_250_Vd_160_Pr_6_Gain_0x0_Shape_0xF_Clock_0x4-068.aqs R01929_tagTest_Vm_250_Vd_160_Pr_6_Gain_0x0_Shape_0xF_Clock_0x4-068.aqs
+    - restManager --c 01_raw.rml --f "R01928_tagTest_Vm_250_Vd_160_Pr_6_Gain_0x0_Shape_0xF_Clock_0x4-068.aqs"
+    - restManager --c 02_signal.rml --f "RawData_01928.root"
+    - restManager --c 03_hits.rml --f "Signals_01928.root"
     - restRoot -b -q ../MakeBasicTree.C'("Hits_01928.root")'
     - rm RawData_01928.root
     - rm Signals_01928.root
-    - root -b -q ../ValidateTrees.C'("validation.root")'
-    - restRoot -b -q ../MakeBasicTree.C'("Hits_01929.root")'
-    - rm RawData_01929.root
-    - rm Signals_01929.root
     - root -b -q ../ValidateTrees.C'("validation.root")'
     - restRoot -b -q ValidateDetectorParams.C'("Hits_01929.root")'
   artifacts:

--- a/source/bin/restManager.cxx
+++ b/source/bin/restManager.cxx
@@ -91,7 +91,7 @@ std::vector<std::string> input_files;
 void ParseInputFileArgs(const char* argv) {
     if (argv == NULL) return;
 
-    if (REST_ARGS.count("inputFileName") > 0) {
+    if (REST_ARGS.count("inputFile") > 0) {
         string input_old = REST_ARGS["inputFileName"];
         input_old += "\n" + string(argv);
 


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![5](https://badgen.net/badge/Size/5/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/mistery_bug/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/mistery_bug) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This reverts commit 15951eb37523cf486a45fff6915170c9de4856e1.