### PR TITLE
Validating the framework against a specific submodule branch

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -121,7 +121,7 @@ build_latest:
   type: build
   script:
     - cd ${CI_PROJECT_DIR}/
-    - python3 pull-submodules.py --force --dontask --latest
+    - python3 pull-submodules.py --force --dontask --latest:${CI_COMMIT_BRANCH}
     - if [ -d ${CI_PROJECT_DIR}/build_latest ]; then rm -Rf ${CI_PROJECT_DIR}/build_latest; fi
     - mkdir ${CI_PROJECT_DIR}/build_latest && cd ${CI_PROJECT_DIR}/build_latest/
     - if [ -d ${CI_PROJECT_DIR}/install_latest ]; then rm -Rf ${CI_PROJECT_DIR}/install_latest; fi
@@ -364,7 +364,7 @@ trexDM_data_latest:
 pandaXIII_Topological: 
   type: restManager_process
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - . ${CI_PROJECT_DIR}/install_latest/thisREST.sh
     - cd ${CI_PROJECT_DIR}/pipeline/pandaxiii_MC
     - restManager --c AllProcesses.rml --i testInput.root --o testOutput.root --j 1 --e 10
     - restRoot -b -q ../MakeBasicTree.C'("testOutput.root")'
@@ -381,7 +381,7 @@ pandaXIII_Topological:
 pandaXIII_Topological_fromG4: 
   type: restManager_process
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - . ${CI_PROJECT_DIR}/install_latest/thisREST.sh
     - cd ${CI_PROJECT_DIR}/pipeline/pandaxiii_MC
     - echo "using just-generated g4 file"
     - restManager --c AllProcesses.rml --i Xe136bb0n_n2E06.root --o testOutput.root --j 1 --e 10
@@ -398,7 +398,7 @@ pandaXIII_Topological_fromG4:
 pandaXIII_data: 
   type: restManager_process
   script:
-    - . ${CI_PROJECT_DIR}/install/thisREST.sh
+    - . ${CI_PROJECT_DIR}/install_latest/thisREST.sh
     - cd ${CI_PROJECT_DIR}/pipeline/pandaxiii_data
     - restManager --c P3AutoChain.rml --i CoBo_AsAd0_2019-03-15.graw --o testOutput.root --j 1
     - restRoot -b -q ../MakeBasicTree.C'("testOutput.root")'

--- a/pull-submodules.py
+++ b/pull-submodules.py
@@ -51,9 +51,6 @@ for x in range(narg - 1):
     if (sys.argv[x + 1].find("--exclude:")>=0 ):
         exclude_elems = sys.argv[x + 1][10:].split(",")
 
-
-
-
 def main():
 # The following command may fail
 #   os.system('cd {} && git submodule update --init
@@ -66,6 +63,9 @@ def main():
 
    if( force ):
       print("Force pulling submodules.")
+
+   bNamePcs = subprocess.run('git rev-parse --abbrev-ref HEAD', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+   frameworkBranchName = bNamePcs.stdout.decode("utf-8").rstrip("\n")
 
 # In case the above command failed, also go through all submodules and update
 # them individually
@@ -142,7 +142,14 @@ def main():
                          # if latest, pull the latest commit instead of the one
                          # recorded in the main repo
                          if latest == 1:
-                             p = subprocess.run('cd {}/{} && git pull --tags origin master'.format(root, submodule), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+                             command = 'git ls-remote --heads ' + url + ' ' + frameworkBranchName + ' | wc -l'
+                             branchExistsPcs = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+                             branchToPull = "master"
+                             if( branchExistsPcs.stdout.decode("utf-8").rstrip("\n") != "0"):
+                                 branchToPull = frameworkBranchName
+ 
+                             p = subprocess.run('cd {}/{} && git pull --tags origin {}'.format(root, submodule, branchToPull), shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                              if(debug):
                                  print (p.stdout.decode("utf-8"))
                                  print (p.stderr.decode("utf-8"))

--- a/pull-submodules.py
+++ b/pull-submodules.py
@@ -66,6 +66,7 @@ def main():
 
    bNamePcs = subprocess.run('git rev-parse --abbrev-ref HEAD', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
    frameworkBranchName = bNamePcs.stdout.decode("utf-8").rstrip("\n")
+   print( "Framework branch name: " + frameworkBranchName )
 
 # In case the above command failed, also go through all submodules and update
 # them individually
@@ -144,6 +145,8 @@ def main():
                          if latest == 1:
                              command = 'git ls-remote --heads ' + url + ' ' + frameworkBranchName + ' | wc -l'
                              branchExistsPcs = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+                             print ( "##" + branchExistsPcs.stdout.decode("utf-8").rstrip("\n") + "##" )
 
                              branchToPull = "master"
                              if( branchExistsPcs.stdout.decode("utf-8").rstrip("\n") != "0"):

--- a/pull-submodules.py
+++ b/pull-submodules.py
@@ -152,8 +152,6 @@ def main():
                              command = 'git ls-remote --heads ' + url + ' ' + frameworkBranchName + ' | wc -l'
                              branchExistsPcs = subprocess.run(command, shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
 
-                             print ( "##" + branchExistsPcs.stdout.decode("utf-8").rstrip("\n") + "##" )
-
                              branchToPull = "master"
                              if( branchExistsPcs.stdout.decode("utf-8").rstrip("\n") != "0"):
                                  branchToPull = frameworkBranchName

--- a/pull-submodules.py
+++ b/pull-submodules.py
@@ -27,6 +27,7 @@ debug = 0
 force = 0
 dontask = 0
 clean = 0
+fbName = ""
 
 exclude_elems = ""
 for x in range(narg - 1):
@@ -36,9 +37,11 @@ for x in range(narg - 1):
     if (sys.argv[x + 1] == "--sjtu"):
         sjtu = 1
         print("Adding submodules from sjtu repositories. You may be asked to enter password for it.")
-    if (sys.argv[x + 1] == "--latest"):
-        latest = 1
-        print("Pulling latest submodules from their git repository, instead of the version recorded by REST. This may cause the submodules to be uncompilable.")
+    if ( sys.argv[x + 1].find("--latest") >= 0 ):
+        if( sys.argv[x + 1].find("--latest:") >= 0 ):
+            latest = 1
+            fbName = sys.argv[x + 1][9:]
+            print("Pulling latest submodules from their git repository, instead of the version recorded by REST. This may cause the submodules to be uncompilable.")
     if (sys.argv[x + 1] == "--debug"):
         debug = 1
     if (sys.argv[x + 1] == "--dontask"):
@@ -64,8 +67,11 @@ def main():
    if( force ):
       print("Force pulling submodules.")
 
-   bNamePcs = subprocess.run('git rev-parse --abbrev-ref HEAD', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-   frameworkBranchName = bNamePcs.stdout.decode("utf-8").rstrip("\n")
+   if( fbName == "" ):
+       bNamePcs = subprocess.run('git rev-parse --abbrev-ref HEAD', shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+       frameworkBranchName = bNamePcs.stdout.decode("utf-8").rstrip("\n")
+   else:
+       frameworkBranchName = fbName
    print( "Framework branch name: " + frameworkBranchName )
 
 # In case the above command failed, also go through all submodules and update


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![25](https://badgen.net/badge/Size/25/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/revert_rawsignal/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/revert_rawsignal) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I have modified `pull-submodules.py` so that when the `--latest` argument is present, it will pull the `master` branch of each submodule by default, except if a branch with the same name as in the `framework` is found at that submodule.

That enables me to check the framework pipeline at this particular branch, while applying changes at a submodule branch with the same name, i.e. `revert_rawsignal`, thats PR rest-for-physics/rawlib#21.