### PR TITLE
CMakeLists.txt update (compatibility with C++17)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,8 +13,27 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
         message(FATAL_ERROR "Clang version must be at least 3.2!")
     endif ()
 endif ()
-set(CMAKE_CXX_STANDARD 14)
+
+find_package(ROOT REQUIRED)
+# TODO: Simplify this with CMAKE STRING (REGEX ...) (https://cmake.org/cmake/help/latest/command/string.html)
+execute_process(COMMAND root-config --has-cxx20 OUTPUT_VARIABLE HASCXX20)
+execute_process(COMMAND root-config --has-cxx17 OUTPUT_VARIABLE HASCXX17)
+execute_process(COMMAND root-config --has-cxx14 OUTPUT_VARIABLE HASCXX14)
+execute_process(COMMAND root-config --has-cxx11 OUTPUT_VARIABLE HASCXX11)
+
+if (${HASCXX20} MATCHES "yes")
+    set(CMAKE_CXX_STANDARD 20)
+elseif (${HASCXX17} MATCHES "yes")
+    set(CMAKE_CXX_STANDARD 17)
+elseif (${HASCXX14} MATCHES "yes")
+    set(CMAKE_CXX_STANDARD 14)
+elseif (${HASCXX11} MATCHES "yes")
+    set(CMAKE_CXX_STANDARD 11)
+endif ()
+
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
+message("SETTING CMAKE_CXX_STANDARD TO C++${CMAKE_CXX_STANDARD}, matching the one used to compile ROOT")
+
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
     SET(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-stdlib=libc++")
 endif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
@@ -46,14 +65,13 @@ if (NOT DEFINED REST_WELCOME)
     set(REST_WELCOME ON)
 endif ()
 
-# Find ROOT libs and includes
 set(external_include_dirs)
 set(external_libs)
 
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${DECAY_PATH}/cmake ${CMAKE_MODULE_PATH})
 set(CMAKE_MACOSX_RPATH 1)
 
-find_package(ROOT REQUIRED)
+# ROOT libs and includes
 set(external_include_dirs ${external_include_dirs} ${ROOT_INCLUDE_DIRS})
 set(external_libs ${external_libs} "${ROOT_LIBRARIES} -lGui -lGeom -lGdml -lMinuit -lSpectrum")
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,25 +14,6 @@ elseif (CMAKE_CXX_COMPILER_ID STREQUAL "Clang")
     endif ()
 endif ()
 
-find_package(ROOT REQUIRED)
-# TODO: Simplify this with CMAKE STRING (REGEX ...) (https://cmake.org/cmake/help/latest/command/string.html)
-execute_process(COMMAND root-config --has-cxx20 OUTPUT_VARIABLE HASCXX20)
-execute_process(COMMAND root-config --has-cxx17 OUTPUT_VARIABLE HASCXX17)
-execute_process(COMMAND root-config --has-cxx14 OUTPUT_VARIABLE HASCXX14)
-execute_process(COMMAND root-config --has-cxx11 OUTPUT_VARIABLE HASCXX11)
-
-if (${HASCXX20} MATCHES "yes")
-    set(CMAKE_CXX_STANDARD 20)
-elseif (${HASCXX17} MATCHES "yes")
-    set(CMAKE_CXX_STANDARD 17)
-elseif (${HASCXX14} MATCHES "yes")
-    set(CMAKE_CXX_STANDARD 14)
-elseif (${HASCXX11} MATCHES "yes")
-    set(CMAKE_CXX_STANDARD 11)
-endif ()
-
-set(CMAKE_CXX_STANDARD_REQUIRED YES)
-message("SETTING CMAKE_CXX_STANDARD TO C++${CMAKE_CXX_STANDARD}, matching the one used to compile ROOT")
 
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
     SET(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-stdlib=libc++")
@@ -72,8 +53,29 @@ set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${DECAY_PATH}/cmake ${CM
 set(CMAKE_MACOSX_RPATH 1)
 
 # ROOT libs and includes
+
+find_package(ROOT REQUIRED)
+
+execute_process(COMMAND root-config --has-cxx20 OUTPUT_VARIABLE HASCXX20)
+execute_process(COMMAND root-config --has-cxx17 OUTPUT_VARIABLE HASCXX17)
+execute_process(COMMAND root-config --has-cxx14 OUTPUT_VARIABLE HASCXX14)
+execute_process(COMMAND root-config --has-cxx11 OUTPUT_VARIABLE HASCXX11)
+
+set(CMAKE_CXX_STANDARD_REQUIRED YES)
+
+if (${HASCXX20} MATCHES "yes")
+    set(CMAKE_CXX_STANDARD 20)
+elseif (${HASCXX17} MATCHES "yes")
+    set(CMAKE_CXX_STANDARD 17)
+elseif (${HASCXX14} MATCHES "yes")
+    set(CMAKE_CXX_STANDARD 14)
+elseif (${HASCXX11} MATCHES "yes")
+    set(CMAKE_CXX_STANDARD 11)
+endif ()
+
 set(external_include_dirs ${external_include_dirs} ${ROOT_INCLUDE_DIRS})
 set(external_libs ${external_libs} "${ROOT_LIBRARIES} -lGui -lGeom -lGdml -lMinuit -lSpectrum")
+
 
 # Switch to enable ROOT Eve functionality.
 if (NOT DEFINED REST_EVE)


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![24](https://badgen.net/badge/Size/24/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/cpp17/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/cpp17) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The goal of this PR is to make REST compatible with C++17 (and not break anything in between).

I just updated the CMakeLists.txt file to set the CXX standard dynamically to match the one used to compiled ROOT.

I tried to do this using REGEX which are implemented in CMake but I failed, its not very well documented. Added TODO to the file.

```
# TODO: Simplify this with CMAKE STRING (REGEX ...) (https://cmake.org/cmake/help/latest/command/string.html)
```

Looks like this is enough to allow building REST with C++17 if ROOT was also built using C++17.