### PR TITLE
TRestReflector::ToString() for basic types now read cout precision

### DIFF
--- a/source/framework/core/src/startup.cpp
+++ b/source/framework/core/src/startup.cpp
@@ -102,7 +102,10 @@ REST_Verbose_Level gVerbose = REST_Warning;
 // initialize converter methods
 template <class T>
 string ToStringSimple(T source) {
-    return ToString(source);
+    ostringstream ss1;
+    ss1.precision(cout.precision());
+    ss1 << source;
+    return ss1.str();
 }
 AddConverter(ToStringSimple, StringToInteger, int);
 AddConverter(ToStringSimple, StringToDouble, double);


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![4](https://badgen.net/badge/Size/4/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/issue76/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/issue76) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is a quick fix related to issue #76

Now TRestReflector::ToString() converts double/float to string with the same precision as we set for cout.

```
root [0] cout<<M_PI<<endl;
3.14159
root [1] any(M_PI).ToString()
(std::string) "3.14159"
root [2] cout.precision(16)
(long) 6
root [3] cout<<M_PI<<endl;
3.141592653589793
root [4] any(M_PI).ToString()
(std::string) "3.141592653589793"
```