### PR TITLE
TRestDummyMetadata template class added

### DIFF
--- a/source/framework/core/inc/TRestDummyMetadata.h
+++ b/source/framework/core/inc/TRestDummyMetadata.h
@@ -32,6 +32,10 @@ class TRestDummyMetadata : public TRestMetadata {
     Double_t fDummy = 0;
     /// Dummy string
     TString fDummyString = "";
+    /// Dummy CONSTANT member
+    // It is better to use 'const' class members whenever possible (they won't be modified).
+    // These members do not need a Setter.
+    const Int_t fDummyConstNumber;  // const members can be initialized here, but... (see constructor)
 
    public:
     void Initialize();
@@ -42,7 +46,7 @@ class TRestDummyMetadata : public TRestMetadata {
     void PrintMetadata();
 
     // Constructor & Destructor
-    TRestDummyMetadata();
+    TRestDummyMetadata(Int_t dummyConstNumber);
     ~TRestDummyMetadata();
 
     // Setters & Getters
@@ -56,6 +60,8 @@ class TRestDummyMetadata : public TRestMetadata {
     // Avoid copying large objects!
     // All types, except built-in types (such as int, double...) should be passed via const reference
     inline void SetDummyString(const TString& dummyString) { fDummyString = dummyString; }
+
+    inline Int_t GetDummyConstNumber() const { return fDummyConstNumber; }
 
     ClassDef(TRestDummyMetadata, 1);
 };

--- a/source/framework/core/inc/TRestDummyMetadata.h
+++ b/source/framework/core/inc/TRestDummyMetadata.h
@@ -1,0 +1,49 @@
+/*************************************************************************
+ * This file is part of the REST software framework.                     *
+ *                                                                       *
+ * Copyright (C) 2016 GIFNA/TREX (University of Zaragoza)                *
+ * For more information see http://gifna.unizar.es/trex                  *
+ *                                                                       *
+ * REST is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * REST is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ * GNU General Public License for more details.                          *
+ *                                                                       *
+ * You should have a copy of the GNU General Public License along with   *
+ * REST in $REST_PATH/LICENSE.                                           *
+ * If not, see http://www.gnu.org/licenses/.                             *
+ * For the list of contributors see $REST_PATH/CREDITS.                  *
+ *************************************************************************/
+
+#ifndef RestCore_TRestDummyMetadata
+#define RestCore_TRestDummyMetadata
+
+#include "TRestMetadata.h"
+
+/// The most simple metadata class to be used as a template
+class TRestDummyMetadata : public TRestMetadata {
+   protected:
+    /// Documentation of my dummy member
+    Double_t fDummy = 0;
+
+   public:
+    void Initialize();
+
+    // Implement only if necessary
+    // void InitFromConfigFile();
+
+    void PrintMetadata();
+
+    // Constructor & Destructor
+    TRestDummyMetadata();
+    ~TRestDummyMetadata();
+
+    ClassDef(TRestDummyMetadata, 1);
+};
+
+#endif

--- a/source/framework/core/inc/TRestDummyMetadata.h
+++ b/source/framework/core/inc/TRestDummyMetadata.h
@@ -30,6 +30,8 @@ class TRestDummyMetadata : public TRestMetadata {
    protected:
     /// Documentation of my dummy member
     Double_t fDummy = 0;
+    /// Dummy string
+    TString fDummyString = "";
 
    public:
     void Initialize();
@@ -44,8 +46,16 @@ class TRestDummyMetadata : public TRestMetadata {
     ~TRestDummyMetadata();
 
     // Setters & Getters
+    // Should use "inline" when defining functions in the header
     inline Double_t GetDummy() const { return fDummy; }
+    // Here you don't pass as const reference since its a built-in type (Double_t = double)
     inline void SetDummy(Double_t dummy) { fDummy = dummy; }
+
+    inline TString GetDummyString() const { return fDummyString; }
+    // IMPORTANT! you should use const references whenever possible, such as in this case.
+    // Avoid copying large objects!
+    // All types, except built-in types (such as int, double...) should be passed via const reference
+    inline void SetDummyString(const TString& dummyString) { fDummyString = dummyString; }
 
     ClassDef(TRestDummyMetadata, 1);
 };

--- a/source/framework/core/inc/TRestDummyMetadata.h
+++ b/source/framework/core/inc/TRestDummyMetadata.h
@@ -43,6 +43,10 @@ class TRestDummyMetadata : public TRestMetadata {
     TRestDummyMetadata();
     ~TRestDummyMetadata();
 
+    // Setters & Getters
+    inline Double_t GetDummy() const { return fDummy; }
+    inline void SetDummy(Double_t dummy) { fDummy = dummy; }
+
     ClassDef(TRestDummyMetadata, 1);
 };
 

--- a/source/framework/core/src/TRestDummyMetadata.cxx
+++ b/source/framework/core/src/TRestDummyMetadata.cxx
@@ -63,5 +63,7 @@ void TRestDummyMetadata::PrintMetadata() {
     TRestMetadata::PrintMetadata();
 
     metadata << "Dummy : " << fDummy << endl;
+    metadata << "Dummy String : " << fDummyString << endl;
+
     metadata << endl;
 }

--- a/source/framework/core/src/TRestDummyMetadata.cxx
+++ b/source/framework/core/src/TRestDummyMetadata.cxx
@@ -1,0 +1,68 @@
+/*************************************************************************
+ * This file is part of the REST software framework.                     *
+ *                                                                       *
+ * Copyright (C) 2016 GIFNA/TREX (University of Zaragoza)                *
+ * For more information see http://gifna.unizar.es/trex                  *
+ *                                                                       *
+ * REST is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * REST is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ * GNU General Public License for more details.                          *
+ *                                                                       *
+ * You should have a copy of the GNU General Public License along with   *
+ * REST in $REST_PATH/LICENSE.                                           *
+ * If not, see http://www.gnu.org/licenses/.                             *
+ * For the list of contributors see $REST_PATH/CREDITS.                  *
+ *************************************************************************/
+
+////////////////////////////////////////////////////////////////////////////
+///
+/// A TRestMetadata template
+///
+/// \class TRestDummyMetadata
+///
+///--------------------------------------------------------------------------
+///
+/// RESTsoft - Software for Rare Event Searches with TPCs
+///
+/// History of developments:
+///
+/// 2021-Jun:  First implementation
+///			Javier Galan
+///
+/// <hr>
+//////////////////////////////////////////////////////////////////////////
+
+#include "TRestDummyMetadata.h"
+
+ClassImp(TRestDummyMetadata);
+
+TRestDummyMetadata::TRestDummyMetadata() { Initialize(); }
+
+TRestDummyMetadata::~TRestDummyMetadata() {}
+
+///////////////////////////////////////////////
+/// \brief Set variables by default during initialization.
+///
+void TRestDummyMetadata::Initialize() { SetSectionName(this->ClassName()); }
+
+///////////////////////////////////////////////
+/// Implement this only if necessary
+/// void TRestDummyMetadata::InitFromConfigFile() {
+/// }
+
+///////////////////////////////////////////////
+/// Printing metadata member values on screen
+///
+void TRestDummyMetadata::PrintMetadata() {
+    TRestMetadata::PrintMetadata();
+
+    metadata << "Dummy : " << fDummy << endl;
+    metadata << endl;
+}
+

--- a/source/framework/core/src/TRestDummyMetadata.cxx
+++ b/source/framework/core/src/TRestDummyMetadata.cxx
@@ -44,7 +44,7 @@ ClassImp(TRestDummyMetadata);
 
 TRestDummyMetadata::TRestDummyMetadata() { Initialize(); }
 
-TRestDummyMetadata::~TRestDummyMetadata() {}
+TRestDummyMetadata::~TRestDummyMetadata() = default;
 
 ///////////////////////////////////////////////
 /// \brief Set variables by default during initialization.
@@ -65,4 +65,3 @@ void TRestDummyMetadata::PrintMetadata() {
     metadata << "Dummy : " << fDummy << endl;
     metadata << endl;
 }
-

--- a/source/framework/core/src/TRestDummyMetadata.cxx
+++ b/source/framework/core/src/TRestDummyMetadata.cxx
@@ -42,7 +42,10 @@
 
 ClassImp(TRestDummyMetadata);
 
-TRestDummyMetadata::TRestDummyMetadata() { Initialize(); }
+// Initialize a const class member in the constructor
+TRestDummyMetadata::TRestDummyMetadata(Int_t dummyConstNumber = 0) : fDummyConstNumber(dummyConstNumber) {
+    Initialize();
+}
 
 TRestDummyMetadata::~TRestDummyMetadata() = default;
 
@@ -64,6 +67,7 @@ void TRestDummyMetadata::PrintMetadata() {
 
     metadata << "Dummy : " << fDummy << endl;
     metadata << "Dummy String : " << fDummyString << endl;
+    metadata << "Dummy Const Number : " << fDummyConstNumber << endl;
 
     metadata << endl;
 }


### PR DESCRIPTION
![Large](https://badgen.net/badge/PR%20Size/Large/red) ![KonradAltenmueller](https://badgen.net/badge/PR%20submitted%20by%3A/KonradAltenmueller/blue) ![142](https://badgen.net/badge/Size/142/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/TRestDummyMetadata/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/TRestDummyMetadata) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

TRestDummyMetadata class added to serve as template for new Metadata classes