### PR TITLE
Removed permissons for others at REST_PATH

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,4 +183,4 @@ include(thisREST)
 
 # Add permissions
 install(CODE "execute_process(COMMAND chmod 755 ${CMAKE_INSTALL_PREFIX}/bin/rest-config)")
-install(CODE "execute_process(COMMAND chmod 777 ${CMAKE_INSTALL_PREFIX})")
+install(CODE "execute_process(COMMAND chmod 755 ${CMAKE_INSTALL_PREFIX})")


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![1](https://badgen.net/badge/Size/1/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/install_permissons/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/install_permissons) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Changes proposed in this pull-request:
- Remove the 777 permissons at REST_PATH by 755. That should be enough


@rest-for-physics/core_dev