### PR TITLE
TRestEventProcess::InitFromConfigFile. 

### DIFF
--- a/source/framework/core/inc/TRestEventProcess.h
+++ b/source/framework/core/inc/TRestEventProcess.h
@@ -168,7 +168,8 @@ class TRestEventProcess : public TRestMetadata {
     virtual void InitFromConfigFile() {
         map<string, string> parameters = GetParametersList();
 
-        for (auto& p : parameters) p.second = fRunInfo->ReplaceMetadataMembers(p.second);
+        for (auto& p : parameters)
+            p.second = ReplaceMathematicalExpressions(fRunInfo->ReplaceMetadataMembers(p.second));
 
         ReadParametersList(parameters);
     }


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![2](https://badgen.net/badge/Size/2/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/version_2.3.8/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/version_2.3.8) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now mathematical expressions are also evaluated

Even if not yet merged to master, this commit was tagged as v2.3.8 and it belongs to release v2.3.8.

Notice that the tag is not connected with master, and the best way to download the tag is `git checkout tags/v2.3.8`