### PR TITLE
.gitlab-ci.yml. Recovering validation pipelines that only were execut…

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -236,9 +236,6 @@ GenerateReadout:
     - restManager --c generateReadout.rml --o readout.root
     - restRoot -b -q PrintReadout.C'("readout.root")' > /dev/null
     - diff validation.txt print.txt
-  only:
-      variables:
-        - $CI_SERVER_HOST == "lfna.unizar.es"
 
 BasicReadout:
   type: metadata 
@@ -250,9 +247,6 @@ BasicReadout:
     - git log
     - restRoot --m 1 -b -q GenerateReadouts.C'("basic.root")'
     - restRoot -b -q BasicValidation.C'("basic.root", "pixelDecoding")'
-  only:
-      variables:
-        - $CI_SERVER_HOST == "lfna.unizar.es"       
 
 testMeta:
   type: restManager_generate


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![0](https://badgen.net/badge/Size/0/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/recover_metadata_pipelines/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/recover_metadata_pipelines) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Just recovering missing metadata pipeline validation jobs. There are also missing a couple of jobs that are only available to be executed at LFNA.