### PR TITLE
Error notifications

### DIFF
--- a/source/bin/restManager.cxx
+++ b/source/bin/restManager.cxx
@@ -47,7 +47,7 @@ int fork_n_execute(string command) {
 }
 
 void PrintHelp() {
-    TRestStringOutput fout(COLOR_BOLDYELLOW, "", kHeaderedLeft);
+    TRestStringOutput fout(COLOR_BOLDYELLOW, "", kLeft);
     fout << " " << endl;
 
     fout.setheader("Usage1 : ./restManager ");

--- a/source/framework/core/inc/TRestMetadata.h
+++ b/source/framework/core/inc/TRestMetadata.h
@@ -174,19 +174,20 @@ class TRestMetadata : public TNamed {
     /// It can be used as a way to identify that something went wrong using SetError method.
     Bool_t fError = false;  //!
 
+    /// It counts the number of errors notified
+    Int_t fNErrors = 0;  //!
+
     /// It can be used as a way to identify that something went wrong using SetWarning method.
     Bool_t fWarning = false;  //!
+
+    /// It counts the number of warnings notified
+    Int_t fNWarnings = 0;  //!
 
     /// A string to store an optional error message through method SetError.
     TString fErrorMessage = "";  //!
 
     /// It can be used as a way to identify that something went wrong using SetWarning method.
     TString fWarningMessage = "";  //!
-
-    /// It allows to modify the error message. Only if SetError was called previously.
-    void SetErrorMessage(TString message) {
-        if (GetError()) fErrorMessage = message;
-    }
 
     std::map<string, string> GetParametersList();
     void ReadAllParameters();
@@ -202,12 +203,14 @@ class TRestMetadata : public TNamed {
     void SetError(TString message = "") {
         fError = true;
         fErrorMessage = message;
+        fNErrors++;
     }
 
     /// A metadata class may use this method to signal that something went wrong
     void SetWarning(TString message = "") {
         fWarning = true;
         fWarningMessage = message;
+        fNWarnings++;
     }
 
     /// Returns a string containing the error message
@@ -225,6 +228,10 @@ class TRestMetadata : public TNamed {
         else
             return "No warning!";
     }
+
+    Int_t GetNumberOfErrors() { return fNErrors; }
+
+    Int_t GetNumberOfWarnings() { return fNWarnings; }
 
     Int_t LoadConfigFromElement(TiXmlElement* eSectional, TiXmlElement* eGlobal,
                                 map<string, string> envs = {});

--- a/source/framework/core/inc/TRestMetadata.h
+++ b/source/framework/core/inc/TRestMetadata.h
@@ -177,12 +177,6 @@ class TRestMetadata : public TNamed {
     /// A string to store an optional error message through method SetError.
     TString fErrorMessage = "";  //!
 
-    /// A metadata class may use this method to signal that something went wrong
-    void SetError(TString message = "") {
-        fError = true;
-        fErrorMessage = message;
-    }
-
     /// It allows to modify the error message. Only if SetError was called previously.
     void SetErrorMessage(TString message) {
         if (GetError()) fErrorMessage = message;
@@ -194,6 +188,12 @@ class TRestMetadata : public TNamed {
    public:
     /// It returns true if an error was identified by a derived metadata class
     Bool_t GetError() { return fError; }
+
+    /// A metadata class may use this method to signal that something went wrong
+    void SetError(TString message = "") {
+        fError = true;
+        fErrorMessage = message;
+    }
 
     /// Returns a string containing the error message
     TString GetErrorMessage() {

--- a/source/framework/core/inc/TRestMetadata.h
+++ b/source/framework/core/inc/TRestMetadata.h
@@ -172,22 +172,22 @@ class TRestMetadata : public TNamed {
     map<string, string> fConstants;  //!
 
     /// It can be used as a way to identify that something went wrong using SetError method.
-    Bool_t fError = false;  //!
+    Bool_t fError = false;
 
     /// It counts the number of errors notified
-    Int_t fNErrors = 0;  //!
+    Int_t fNErrors = 0;
 
     /// It can be used as a way to identify that something went wrong using SetWarning method.
-    Bool_t fWarning = false;  //!
+    Bool_t fWarning = false;
 
     /// It counts the number of warnings notified
-    Int_t fNWarnings = 0;  //!
+    Int_t fNWarnings = 0;
 
     /// A string to store an optional error message through method SetError.
-    TString fErrorMessage = "";  //!
+    TString fErrorMessage = "";
 
     /// It can be used as a way to identify that something went wrong using SetWarning method.
-    TString fWarningMessage = "";  //!
+    TString fWarningMessage = "";
 
     std::map<string, string> GetParametersList();
     void ReadAllParameters();
@@ -326,7 +326,7 @@ class TRestMetadata : public TNamed {
     TRestMetadata(const char* cfgFileNamecfgFileName);
 
     /// Call CINT to generate streamers for this class
-    ClassDef(TRestMetadata, 8);
+    ClassDef(TRestMetadata, 9);
 };
 
 #endif

--- a/source/framework/core/inc/TRestMetadata.h
+++ b/source/framework/core/inc/TRestMetadata.h
@@ -203,6 +203,7 @@ class TRestMetadata : public TNamed {
     void SetError(TString message = "") {
         fError = true;
         fErrorMessage = message;
+        if (message != "" && GetVerboseLevel() >= REST_Warning) ferr << fErrorMessage << endl;
         fNErrors++;
     }
 
@@ -210,6 +211,7 @@ class TRestMetadata : public TNamed {
     void SetWarning(TString message = "") {
         fWarning = true;
         fWarningMessage = message;
+        if (message != "") warning << fWarningMessage << endl;
         fNWarnings++;
     }
 

--- a/source/framework/core/inc/TRestMetadata.h
+++ b/source/framework/core/inc/TRestMetadata.h
@@ -174,8 +174,14 @@ class TRestMetadata : public TNamed {
     /// It can be used as a way to identify that something went wrong using SetError method.
     Bool_t fError = false;  //!
 
+    /// It can be used as a way to identify that something went wrong using SetWarning method.
+    Bool_t fWarning = false;  //!
+
     /// A string to store an optional error message through method SetError.
     TString fErrorMessage = "";  //!
+
+    /// It can be used as a way to identify that something went wrong using SetWarning method.
+    TString fWarningMessage = "";  //!
 
     /// It allows to modify the error message. Only if SetError was called previously.
     void SetErrorMessage(TString message) {
@@ -189,10 +195,19 @@ class TRestMetadata : public TNamed {
     /// It returns true if an error was identified by a derived metadata class
     Bool_t GetError() { return fError; }
 
+    /// It returns true if an error was identified by a derived metadata class
+    Bool_t GetWarning() { return fWarning; }
+
     /// A metadata class may use this method to signal that something went wrong
     void SetError(TString message = "") {
         fError = true;
         fErrorMessage = message;
+    }
+
+    /// A metadata class may use this method to signal that something went wrong
+    void SetWarning(TString message = "") {
+        fWarning = true;
+        fWarningMessage = message;
     }
 
     /// Returns a string containing the error message
@@ -201,6 +216,14 @@ class TRestMetadata : public TNamed {
             return fErrorMessage;
         else
             return "No error!";
+    }
+
+    /// Returns a string containing the warning message
+    TString GetWarningMessage() {
+        if (GetWarning())
+            return fWarningMessage;
+        else
+            return "No warning!";
     }
 
     Int_t LoadConfigFromElement(TiXmlElement* eSectional, TiXmlElement* eGlobal,

--- a/source/framework/core/inc/TRestMetadata.h
+++ b/source/framework/core/inc/TRestMetadata.h
@@ -199,37 +199,20 @@ class TRestMetadata : public TNamed {
     /// It returns true if an error was identified by a derived metadata class
     Bool_t GetWarning() { return fWarning; }
 
-    /// A metadata class may use this method to signal that something went wrong
-    void SetError(TString message = "") {
-        fError = true;
-        fErrorMessage = message;
-        if (message != "" && GetVerboseLevel() >= REST_Warning) ferr << fErrorMessage << endl;
-        fNErrors++;
-    }
+    /// Add logs to messageBuffer
+    void AddLog(string log = "", bool print = true);
 
     /// A metadata class may use this method to signal that something went wrong
-    void SetWarning(TString message = "") {
-        fWarning = true;
-        fWarningMessage = message;
-        if (message != "") warning << fWarningMessage << endl;
-        fNWarnings++;
-    }
+    void SetError(string message = "", bool print = true);
+
+    /// A metadata class may use this method to signal that something went wrong
+    void SetWarning(string message = "", bool print = true);
 
     /// Returns a string containing the error message
-    TString GetErrorMessage() {
-        if (GetError())
-            return fErrorMessage;
-        else
-            return "No error!";
-    }
+    TString GetErrorMessage();
 
     /// Returns a string containing the warning message
-    TString GetWarningMessage() {
-        if (GetWarning())
-            return fWarningMessage;
-        else
-            return "No warning!";
-    }
+    TString GetWarningMessage();
 
     Int_t GetNumberOfErrors() { return fNErrors; }
 

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -231,6 +231,8 @@ class TRestRun : public TRestMetadata {
     }
 
     void PrintEvent() { fInputEvent->PrintEvent(); }
+    void PrintErrors();
+    void PrintWarnings();
 
     Int_t Write(const char* name = 0, Int_t option = 0, Int_t bufsize = 0);
 

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -512,6 +512,14 @@ TRestMetadata::TRestMetadata(const char* cfgFileName) : endl(this) {
 }
 
 ///////////////////////////////////////////////
+/// \brief TRestMetadata default destructor
+///
+TRestMetadata::~TRestMetadata() {
+    if (fElementGlobal) delete fElementGlobal;
+    if (fElement) delete fElement;
+}
+
+///////////////////////////////////////////////
 /// \brief Give the file name, find out the corresponding section. Then call the
 /// main starter.
 ///
@@ -2465,12 +2473,4 @@ TString TRestMetadata::GetWarningMessage() {
         return fWarningMessage;
     else
         return "No warning!";
-}
-
-///////////////////////////////////////////////
-/// \brief TRestMetadata default destructor
-///
-TRestMetadata::~TRestMetadata() {
-    if (fElementGlobal) delete fElementGlobal;
-    if (fElement) delete fElement;
 }

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -2445,7 +2445,7 @@ void TRestMetadata::SetError(string message, bool print) {
     if (message != "") {
         fErrorMessage += message + "\n";
         if (print) {
-            ferr << message << noClass::endl;
+            cout << message << endl;
         }
     }
 }
@@ -2456,7 +2456,8 @@ void TRestMetadata::SetWarning(string message, bool print) {
     if (message != "") {
         fWarningMessage += message + "\n";
         if (print) {
-            warning << message << noClass::endl;
+            if (fVerboseLevel>=REST_Warning)
+            cout << message << endl;
         }
     }
 }

--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -883,17 +883,37 @@ void TRestProcessRunner::ConfigOutputFile() {
 
     std::vector<string> mdNames = fRunInfo->GetMetadataStructureNames();
     Int_t nErrors = 0;
-    for (int n = 0; n < mdNames.size(); n++)
+    Int_t nWarnings = 0;
+    for (int n = 0; n < mdNames.size(); n++) {
         if (fRunInfo->GetMetadata(mdNames[n])->GetError()) nErrors++;
+        if (fRunInfo->GetMetadata(mdNames[n])->GetWarning()) nWarnings++;
+    }
+
+    if (nWarnings) {
+        cout << endl;
+        warning << "Found a total of " << nWarnings << " metadata warnings on TRestRun" << endl;
+        for (int n = 0; n < mdNames.size(); n++)
+            if (fRunInfo->GetMetadata(mdNames[n])->GetWarning()) {
+                cout << endl;
+                warning << "Class: " << fRunInfo->GetMetadata(mdNames[n])->ClassName()
+                        << " Name: " << mdNames[n] << endl;
+                warning << "Number of warnings " << fRunInfo->GetMetadata(mdNames[n])->GetNumberOfWarnings()
+                        << endl;
+                warning << "Message: " << fRunInfo->GetMetadata(mdNames[n])->GetWarningMessage() << endl;
+            }
+        cout << endl;
+    }
 
     if (nErrors) {
         cout << endl;
-        ferr << "Found a total of " << nErrors << " errors on TRestRun metadata classes" << endl;
+        ferr << "Found a total of " << nErrors << " metadata errors on TRestRun" << endl;
         for (int n = 0; n < mdNames.size(); n++)
             if (fRunInfo->GetMetadata(mdNames[n])->GetError()) {
                 cout << endl;
                 ferr << "Class: " << fRunInfo->GetMetadata(mdNames[n])->ClassName() << " Name: " << mdNames[n]
                      << endl;
+                warning << "Number of errors " << fRunInfo->GetMetadata(mdNames[n])->GetNumberOfErrors()
+                        << endl;
                 ferr << "Message: " << fRunInfo->GetMetadata(mdNames[n])->GetErrorMessage() << endl;
             }
         cout << endl;

--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -888,8 +888,7 @@ void TRestProcessRunner::ConfigOutputFile() {
 
     if (nErrors) {
         cout << endl;
-        ferr << "Something went wrong ... " << endl;
-        ferr << "Found a total of " << nErrors << " errors" << endl;
+        ferr << "Found a total of " << nErrors << " errors on TRestRun metadata classes" << endl;
         for (int n = 0; n < mdNames.size(); n++)
             if (fRunInfo->GetMetadata(mdNames[n])->GetError()) {
                 cout << endl;

--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -417,7 +417,7 @@ void TRestProcessRunner::RunProcess() {
             if (a == 'p') {
                 fProcStatus = kPause;
                 usleep(100000);  // wait 0.1s for the processes to finish;
-                TRestStringOutput cout(REST_Silent, COLOR_BOLDWHITE, "|", kBorderedMiddle);
+                TRestStringOutput cout(REST_Silent, COLOR_BOLDWHITE, "| |", kMiddle);
                 Console::ClearLinesAfterCursor();
                 cout << endl;
                 cout << "-" << endl;
@@ -512,7 +512,7 @@ void TRestProcessRunner::RunProcess() {
 /// 4. Print the latest processed event
 /// 5. Quit the process directly with file saved
 void TRestProcessRunner::PauseMenu() {
-    TRestStringOutput cout(REST_Silent, COLOR_BOLDWHITE, "|", kBorderedMiddle);
+    TRestStringOutput cout(REST_Silent, COLOR_BOLDWHITE, "| |", kMiddle);
     Console::ClearLinesAfterCursor();
 
     cout << "--------------MENU--------------" << endl;

--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -912,8 +912,7 @@ void TRestProcessRunner::ConfigOutputFile() {
                 cout << endl;
                 ferr << "Class: " << fRunInfo->GetMetadata(mdNames[n])->ClassName() << " Name: " << mdNames[n]
                      << endl;
-                warning << "Number of errors " << fRunInfo->GetMetadata(mdNames[n])->GetNumberOfErrors()
-                        << endl;
+                ferr << "Number of errors " << fRunInfo->GetMetadata(mdNames[n])->GetNumberOfErrors() << endl;
                 ferr << "Message: " << fRunInfo->GetMetadata(mdNames[n])->GetErrorMessage() << endl;
             }
         cout << endl;

--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -889,34 +889,12 @@ void TRestProcessRunner::ConfigOutputFile() {
         if (fRunInfo->GetMetadata(mdNames[n])->GetWarning()) nWarnings++;
     }
 
-    if (nWarnings) {
-        cout << endl;
-        warning << "Found a total of " << nWarnings << " metadata warnings on TRestRun" << endl;
-        for (int n = 0; n < mdNames.size(); n++)
-            if (fRunInfo->GetMetadata(mdNames[n])->GetWarning()) {
-                cout << endl;
-                warning << "Class: " << fRunInfo->GetMetadata(mdNames[n])->ClassName()
-                        << " Name: " << mdNames[n] << endl;
-                warning << "Number of warnings " << fRunInfo->GetMetadata(mdNames[n])->GetNumberOfWarnings()
-                        << endl;
-                warning << "Message: " << fRunInfo->GetMetadata(mdNames[n])->GetWarningMessage() << endl;
-            }
-        cout << endl;
-    }
-
-    if (nErrors) {
-        cout << endl;
-        ferr << "Found a total of " << nErrors << " metadata errors on TRestRun" << endl;
-        for (int n = 0; n < mdNames.size(); n++)
-            if (fRunInfo->GetMetadata(mdNames[n])->GetError()) {
-                cout << endl;
-                ferr << "Class: " << fRunInfo->GetMetadata(mdNames[n])->ClassName() << " Name: " << mdNames[n]
-                     << endl;
-                ferr << "Number of errors " << fRunInfo->GetMetadata(mdNames[n])->GetNumberOfErrors() << endl;
-                ferr << "Message: " << fRunInfo->GetMetadata(mdNames[n])->GetErrorMessage() << endl;
-            }
-        cout << endl;
-    }
+    if (nWarnings)
+        warning << nWarnings
+                << " process warnings were found! Use run0->PrintWarnings(); to get additional info." << endl;
+    if (nErrors)
+        ferr << nErrors << " process errors were found! Use run0->PrintErrors(); to get additional info."
+             << endl;
 }
 
 // tools

--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -253,7 +253,8 @@ void TRestProcessRunner::EndOfInit() {
     if (fRunInfo->GetFileProcess() != nullptr) {
         fInputEvent = fRunInfo->GetFileProcess()->GetOutputEvent();
     } else {
-        if (fThreads[0]->GetProcessnum() > 0 && fThreads[0]->GetProcess(0)->GetInputEvent().address != nullptr) {
+        if (fThreads[0]->GetProcessnum() > 0 &&
+            fThreads[0]->GetProcess(0)->GetInputEvent().address != nullptr) {
             string name = fThreads[0]->GetProcess(0)->GetInputEvent().type;
             TRestEvent* a = REST_Reflection::Assembly(name);
             a->Initialize();
@@ -879,6 +880,25 @@ void TRestProcessRunner::ConfigOutputFile() {
     }
 
     fRunInfo->MergeToOutputFile(files_to_merge, fTempOutputDataFile->GetName());
+
+    std::vector<string> mdNames = fRunInfo->GetMetadataStructureNames();
+    Int_t nErrors = 0;
+    for (int n = 0; n < mdNames.size(); n++)
+        if (fRunInfo->GetMetadata(mdNames[n])->GetError()) nErrors++;
+
+    if (nErrors) {
+        cout << endl;
+        ferr << "Something went wrong ... " << endl;
+        ferr << "Found a total of " << nErrors << " errors" << endl;
+        for (int n = 0; n < mdNames.size(); n++)
+            if (fRunInfo->GetMetadata(mdNames[n])->GetError()) {
+                cout << endl;
+                ferr << "Class: " << fRunInfo->GetMetadata(mdNames[n])->ClassName() << " Name: " << mdNames[n]
+                     << endl;
+                ferr << "Message: " << fRunInfo->GetMetadata(mdNames[n])->GetErrorMessage() << endl;
+            }
+        cout << endl;
+    }
 }
 
 // tools

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -1693,7 +1693,9 @@ Bool_t TRestRun::EvaluateMetadataMember(const string instr) {
     return false;
 }
 
-// Printers
+///////////////////////////////////////////////
+/// \brief Prints the basic run information
+///
 void TRestRun::PrintMetadata() {
     // cout.precision(10);
     TRestMetadata::PrintMetadata();
@@ -1721,6 +1723,9 @@ void TRestRun::PrintMetadata() {
     metadata << endl;
 }
 
+///////////////////////////////////////////////
+/// \brief Prints the run start date and time in human format
+///
 void TRestRun::PrintStartDate() {
     cout.precision(10);
 
@@ -1741,6 +1746,9 @@ void TRestRun::PrintStartDate() {
     cout << "++++++++++++++++++++++++" << endl;
 }
 
+///////////////////////////////////////////////
+/// \brief Prints the run end date and time in human format
+///
 void TRestRun::PrintEndDate() {
     cout << "----------------------" << endl;
     cout << "---- Run end date ----" << endl;
@@ -1759,6 +1767,10 @@ void TRestRun::PrintEndDate() {
     cout << "++++++++++++++++++++++++" << endl;
 }
 
+///////////////////////////////////////////////
+/// \brief Prints out all the warnings registered by metadata classes accessible to
+/// TRestRun, thats metadata and processes previously used in a data chain.
+///
 void TRestRun::PrintErrors() {
     Int_t nErrors = 0;
     for (int n = 0; n < fMetadata.size(); n++)
@@ -1772,13 +1784,19 @@ void TRestRun::PrintErrors() {
                 cout << endl;
                 ferr << "Class: " << fMetadata[n]->ClassName() << " Name: " << fMetadata[n]->GetName()
                      << endl;
-                ferr << "Number of errors " << fMetadata[n]->GetNumberOfErrors() << endl;
+                ferr << "Number of errors: " << fMetadata[n]->GetNumberOfErrors() << endl;
                 ferr << "Message: " << fMetadata[n]->GetErrorMessage() << endl;
             }
         cout << endl;
+    } else {
+        cout << "No errors found!" << endl;
     }
 }
 
+///////////////////////////////////////////////
+/// \brief Prints out all the warnings registered by metadata classes accessible to
+/// TRestRun, thats metadata and processes previously used in a data chain.
+///
 void TRestRun::PrintWarnings() {
     Int_t nWarnings = 0;
     for (int n = 0; n < fMetadata.size(); n++)
@@ -1792,10 +1810,12 @@ void TRestRun::PrintWarnings() {
                 cout << endl;
                 warning << "Class: " << fMetadata[n]->ClassName() << " Name: " << fMetadata[n]->GetName()
                         << endl;
-                warning << "Number of warnings " << fMetadata[n]->GetNumberOfWarnings() << endl;
+                warning << "Number of warnings: " << fMetadata[n]->GetNumberOfWarnings() << endl;
                 warning << "Message: " << fMetadata[n]->GetWarningMessage() << endl;
             }
         cout << endl;
+    } else {
+        cout << "No warnings found!" << endl;
     }
 }
 

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -710,8 +710,8 @@ void TRestRun::ReadFileInfo(string filename) {
         }
 
         // if (!inforead) {
-            // 3. store file format fields to REST_ARGS as global parameter: aaa, bbb
-            // REST_ARGS[formatsectionlist[i]] = infoFromFileName;
+        // 3. store file format fields to REST_ARGS as global parameter: aaa, bbb
+        // REST_ARGS[formatsectionlist[i]] = infoFromFileName;
         // }
 
         pos = pos2 - 1;
@@ -1758,3 +1758,44 @@ void TRestRun::PrintEndDate() {
     cout << "Time : " << time << endl;
     cout << "++++++++++++++++++++++++" << endl;
 }
+
+void TRestRun::PrintErrors() {
+    Int_t nErrors = 0;
+    for (int n = 0; n < fMetadata.size(); n++)
+        if (fMetadata[n]->GetError()) nErrors++;
+
+    if (nErrors) {
+        cout << endl;
+        ferr << "Found a total of " << nErrors << " metadata errors" << endl;
+        for (int n = 0; n < fMetadata.size(); n++)
+            if (fMetadata[n]->GetError()) {
+                cout << endl;
+                ferr << "Class: " << fMetadata[n]->ClassName() << " Name: " << fMetadata[n]->GetName()
+                     << endl;
+                ferr << "Number of errors " << fMetadata[n]->GetNumberOfErrors() << endl;
+                ferr << "Message: " << fMetadata[n]->GetErrorMessage() << endl;
+            }
+        cout << endl;
+    }
+}
+
+void TRestRun::PrintWarnings() {
+    Int_t nWarnings = 0;
+    for (int n = 0; n < fMetadata.size(); n++)
+        if (fMetadata[n]->GetWarning()) nWarnings++;
+
+    if (nWarnings) {
+        cout << endl;
+        warning << "Found a total of " << nWarnings << " metadata warnings" << endl;
+        for (int n = 0; n < fMetadata.size(); n++)
+            if (fMetadata[n]->GetWarning()) {
+                cout << endl;
+                warning << "Class: " << fMetadata[n]->ClassName() << " Name: " << fMetadata[n]->GetName()
+                        << endl;
+                warning << "Number of warnings " << fMetadata[n]->GetNumberOfWarnings() << endl;
+                warning << "Message: " << fMetadata[n]->GetWarningMessage() << endl;
+            }
+        cout << endl;
+    }
+}
+

--- a/source/framework/core/src/TRestThread.cxx
+++ b/source/framework/core/src/TRestThread.cxx
@@ -560,20 +560,38 @@ void TRestThread::EndProcess() {
 
     fOutputFile->cd();
     Int_t nErrors = 0;
+    Int_t nWarnings = 0;
     for (unsigned int i = 0; i < fProcessChain.size(); i++) {
         // The processes must call object->Write in this method
         fProcessChain[i]->EndProcess();
         if (fProcessChain[i]->GetError()) nErrors++;
+        if (fProcessChain[i]->GetWarning()) nWarnings++;
+    }
+
+    if (nWarnings) {
+        cout << endl;
+        warning << "Found a total of " << nWarnings << " process warnings at thread " << fThreadId << endl;
+        cout << endl;
+        for (unsigned int i = 0; i < fProcessChain.size(); i++) {
+            if (fProcessChain[i]->GetWarning()) {
+                warning << "Class: " << fProcessChain[i]->ClassName()
+                        << " Name: " << fProcessChain[i]->GetName() << endl;
+                warning << "Number of warnings " << fProcessChain[i]->GetNumberOfWarnings() << endl;
+                warning << "Message: " << fProcessChain[i]->GetWarningMessage() << endl;
+                cout << endl;
+            }
+        }
     }
 
     if (nErrors) {
         cout << endl;
-        ferr << "Found a total of " << nErrors << " errors in processes at thread " << fThreadId << endl;
+        ferr << "Found a total of " << nErrors << " process errors at thread " << fThreadId << endl;
         cout << endl;
         for (unsigned int i = 0; i < fProcessChain.size(); i++) {
             if (fProcessChain[i]->GetError()) {
                 ferr << "Class: " << fProcessChain[i]->ClassName() << " Name: " << fProcessChain[i]->GetName()
                      << endl;
+                ferr << "Number of errors " << fProcessChain[i]->GetNumberOfErrors() << endl;
                 ferr << "Message: " << fProcessChain[i]->GetErrorMessage() << endl;
                 cout << endl;
             }

--- a/source/framework/core/src/TRestThread.cxx
+++ b/source/framework/core/src/TRestThread.cxx
@@ -568,35 +568,12 @@ void TRestThread::EndProcess() {
         if (fProcessChain[i]->GetWarning()) nWarnings++;
     }
 
-    if (nWarnings) {
-        cout << endl;
-        warning << "Found a total of " << nWarnings << " process warnings at thread " << fThreadId << endl;
-        cout << endl;
-        for (unsigned int i = 0; i < fProcessChain.size(); i++) {
-            if (fProcessChain[i]->GetWarning()) {
-                warning << "Class: " << fProcessChain[i]->ClassName()
-                        << " Name: " << fProcessChain[i]->GetName() << endl;
-                warning << "Number of warnings " << fProcessChain[i]->GetNumberOfWarnings() << endl;
-                warning << "Message: " << fProcessChain[i]->GetWarningMessage() << endl;
-                cout << endl;
-            }
-        }
-    }
-
-    if (nErrors) {
-        cout << endl;
-        ferr << "Found a total of " << nErrors << " process errors at thread " << fThreadId << endl;
-        cout << endl;
-        for (unsigned int i = 0; i < fProcessChain.size(); i++) {
-            if (fProcessChain[i]->GetError()) {
-                ferr << "Class: " << fProcessChain[i]->ClassName() << " Name: " << fProcessChain[i]->GetName()
-                     << endl;
-                ferr << "Number of errors " << fProcessChain[i]->GetNumberOfErrors() << endl;
-                ferr << "Message: " << fProcessChain[i]->GetErrorMessage() << endl;
-                cout << endl;
-            }
-        }
-    }
+    if (nWarnings)
+        warning << nWarnings
+                << " process warnings were found! Use run0->PrintWarnings(); to get additional info." << endl;
+    if (nErrors)
+        ferr << nErrors << " process errors were found! Use run0->PrintErrors(); to get additional info."
+             << endl;
 
     delete fAnalysisTree;
 }

--- a/source/framework/core/src/startup.cpp
+++ b/source/framework/core/src/startup.cpp
@@ -87,15 +87,15 @@ TRestDataBase* gDataBase = nullptr;
 MakeGlobal(TRestDataBase, gDataBase, 1);
 
 // initialize formatted message output tool
-TRestStringOutput fout(REST_Silent, COLOR_BOLDBLUE, "[==", kBorderedMiddle);
-TRestStringOutput ferr(REST_Silent, COLOR_BOLDRED, "-- Error : ", kHeaderedLeft);
-TRestStringOutput warning(REST_Warning, COLOR_BOLDYELLOW, "-- Warning : ", kHeaderedLeft);
-TRestStringOutput essential(REST_Essential, COLOR_BOLDGREEN, "", kHeaderedMiddle);
-TRestStringOutput metadata(REST_Essential, COLOR_BOLDGREEN, "||", kBorderedMiddle);
-TRestStringOutput info(REST_Info, COLOR_BLUE, "-- Info : ", kHeaderedLeft);
-TRestStringOutput success(REST_Info, COLOR_GREEN, "-- Success : ", kHeaderedLeft);
-TRestStringOutput debug(REST_Debug, COLOR_RESET, "-- Debug : ", kHeaderedLeft);
-TRestStringOutput extreme(REST_Extreme, COLOR_RESET, "-- Extreme : ", kHeaderedLeft);
+TRestStringOutput fout(REST_Silent, COLOR_BOLDBLUE, "[== ==]", kMiddle);
+TRestStringOutput ferr(REST_Silent, COLOR_BOLDRED, "-- Error : ", kLeft, true);
+TRestStringOutput warning(REST_Warning, COLOR_BOLDYELLOW, "-- Warning : ", kLeft, true);
+TRestStringOutput essential(REST_Essential, COLOR_BOLDGREEN, "", kMiddle);
+TRestStringOutput metadata(REST_Essential, COLOR_BOLDGREEN, "|| ||", kMiddle);
+TRestStringOutput info(REST_Info, COLOR_BLUE, "-- Info : ", kLeft);
+TRestStringOutput success(REST_Info, COLOR_GREEN, "-- Success : ", kLeft);
+TRestStringOutput debug(REST_Debug, COLOR_RESET, "-- Debug : ", kLeft);
+TRestStringOutput extreme(REST_Extreme, COLOR_RESET, "-- Extreme : ", kLeft);
 
 REST_Verbose_Level gVerbose = REST_Warning;
 

--- a/source/framework/tools/src/TRestStringOutput.cxx
+++ b/source/framework/tools/src/TRestStringOutput.cxx
@@ -1,4 +1,5 @@
 #include "TRestStringOutput.h"
+#include "TRestStringHelper.h"
 
 bool Console::CompatibilityMode = false;
 
@@ -140,40 +141,6 @@ void Console::ClearLinesAfterCursor() {
     fflush(stdout);
 }
 
-#define TRestStringOutput_BestLength 100
-TRestStringOutput::TRestStringOutput(string _color, string BorderOrHeader, REST_Display_Format style) {
-    color = _color;
-    formatstring = BorderOrHeader;
-
-    if (style == kBorderedLeft) {
-        orientation = 1;
-        useborder = true;
-    } else if (style == kBorderedMiddle) {
-        orientation = 0;
-        useborder = true;
-    } else if (style == kHeaderedLeft) {
-        orientation = 1;
-        useborder = false;
-    } else if (style == kHeaderedMiddle) {
-        orientation = 0;
-        useborder = false;
-    }
-
-    setlength(TRestStringOutput_BestLength);
-    resetstring();
-    if (length > 500 || length < 20)  // unsupported console, we will fall back to compatibility modes
-    {
-        length = -1;
-        Console::CompatibilityMode = true;
-    }
-
-    verbose = REST_Essential;
-}
-
-void TRestStringOutput::resetstring() {
-    buf.clear();  //清空流
-    buf.str("");  //清空流缓存
-}
 char mirrorchar(char c) {
     switch (c) {
         default:
@@ -209,6 +176,50 @@ char mirrorchar(char c) {
     }
 }
 
+
+#define TRestStringOutput_BestLength 100
+TRestStringOutput::TRestStringOutput(string _color, string formatter, REST_Display_Orientation _orientation) {
+    iserror = false;
+    color = _color;
+    orientation = _orientation;
+    // check if is border expression
+    useborder = true;
+    if (formatter.size() < 2) {
+        useborder = false;
+    }
+    for (unsigned int i = 0; i < formatter.size() / 2; i++) {
+        if (mirrorchar(formatter[i]) != formatter[formatter.size() - i - 1]) {
+            useborder = false;
+            break;
+        }
+    }
+    if (formatter[formatter.size() / 2] != ' ') {
+        useborder = false;
+    }
+    
+    if (useborder) {
+        formatstring = formatter.substr(0, formatter.size() / 2);
+        formatstring = Replace(formatstring, " ", "");
+    } else {
+        formatstring = formatter;
+    }
+
+    setlength(TRestStringOutput_BestLength);
+    resetstring();
+    if (length > 500 || length < 20)  // unsupported console, we will fall back to compatibility modes
+    {
+        length = -1;
+        Console::CompatibilityMode = true;
+    }
+
+    verbose = REST_Essential;
+}
+
+void TRestStringOutput::resetstring() {
+    buf.clear(); 
+    buf.str(""); 
+}
+
 string TRestStringOutput::FormattingPrintString(string input) {
     if (input == "") return "";
 
@@ -225,7 +236,7 @@ string TRestStringOutput::FormattingPrintString(string input) {
         int Lfmt = formatstring.size();
 
         int startblank;
-        if (useborder || orientation == 0) {
+        if (useborder || orientation == kMiddle) {
             startblank = (length - Lstr) / 2;
         } else {
             startblank = Lfmt;
@@ -276,7 +287,7 @@ void TRestStringOutput::flushstring() {
         std::cout << buf.str() << std::endl;
     } else {
         printf("\033[K");
-        if (orientation == 0) {
+        if (orientation == kMiddle) {
             // we always reset the length of TRestStringOutput in case the console is resized
             setlength(TRestStringOutput_BestLength);
             int blankwidth = (Console::GetWidth() - 2 - length) / 2;
@@ -294,22 +305,5 @@ TRestStringOutput& TRestStringOutput::operator<<(void (*pfunc)(TRestStringOutput
     if (gVerbose >= verbose) {
         ((*pfunc)(*this));
     }
-    return *this;
-}
-
-TRestStringOutput& TRestStringOutput::operator<<(endl_t et) {
-    if (et.vref <= REST_Info) {
-        et.sref += buf.str() + "\n";
-        if (et.sref.size() > 1000) {
-            et.sref.erase(0, et.sref.size() - 1000);
-        }
-    }
-
-    if (et.vref >= verbose) {
-        flushstring();
-    } else {
-        resetstring();
-    }
-
     return *this;
 }


### PR DESCRIPTION
![Large](https://badgen.net/badge/PR%20Size/Large/red) ![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![282](https://badgen.net/badge/Size/282/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/error_notifications/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/error_notifications) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I am trying to create error notifications at the end of `restManager` execution. The idea behind is that we get a list of errors of processes or metadata structures that invoked `TRestMetadata::SetError`.

I thought implementing it at the end of `TRestProcessRunner::ConfigOutputFile()` would do the job. But it seems that only metadata classes directly added to `TRestRun` are available. But no processes.



For example, I added at the detector lib some notifications, 

https://github.com/rest-for-physics/detectorlib/pull/14

I added it for both the process and gas metadata, but only gas metadata error comes out. 

This is an example when I compile REST without Garfield, but I try to use `TRestDetectorGas`.

<img width="872" alt="Screenshot 2021-07-20 at 23 18 40" src="https://user-images.githubusercontent.com/12447509/126397180-2f41598d-5f55-4d63-96e0-bf91c704d13c.png">