### PR TITLE
Nkx111 testrunfix

### DIFF
--- a/source/framework/core/inc/TRestThread.h
+++ b/source/framework/core/inc/TRestThread.h
@@ -35,7 +35,8 @@ class TRestThread : public TRestMetadata {
 
     std::thread t;      //!
     Bool_t isFinished;  //!
-
+    Bool_t fProcessNullReturned; //!
+   
    public:
     void Initialize();
     void InitFromConfigFile() {}
@@ -61,7 +62,7 @@ class TRestThread : public TRestMetadata {
     Int_t GetThreadId() { return fThreadId; }
     TRestEvent* GetInputEvent() { return fInputEvent; }
     TFile* GetOutputFile() { return fOutputFile; };
-    TRestEvent* GetOutputEvent() { return fOutputEvent; }
+    TRestEvent* GetOutputEvent() { return fProcessNullReturned ? 0 : fOutputEvent; }
     Int_t GetProcessnum() { return fProcessChain.size(); }
     TRestEventProcess* GetProcess(int i) { return fProcessChain[i]; }
     TRestAnalysisTree* GetAnalysisTree() { return fAnalysisTree; }

--- a/source/framework/core/src/TRestThread.cxx
+++ b/source/framework/core/src/TRestThread.cxx
@@ -477,6 +477,7 @@ void TRestThread::AddProcess(TRestEventProcess* process) {
 /// result and saves it in the local output event.
 void TRestThread::ProcessEvent() {
     TRestEvent* ProcessedEvent = fInputEvent;
+    fProcessNullReturned = false;
 
     if (fVerboseLevel >= REST_Debug) {
 #ifdef TIME_MEASUREMENT
@@ -503,6 +504,7 @@ void TRestThread::ProcessEvent() {
                 cout << "------- End of process " + (string)fProcessChain[j]->GetName() +
                             " (NULL returned) -------"
                      << endl;
+                fProcessNullReturned = true;
                 break;
             } else {
                 cout << "------- End of process " + (string)fProcessChain[j]->GetName() + " -------" << endl;
@@ -525,7 +527,9 @@ void TRestThread::ProcessEvent() {
             fOutputEvent = ProcessedEvent;
         } else {
             cout << "Transferring output event..." << endl;
-            ProcessedEvent->CloneTo(fOutputEvent);
+            if (ProcessedEvent != nullptr) {
+                ProcessedEvent->CloneTo(fOutputEvent);
+            }
         }
 
         GetChar("======= End of Event " +
@@ -536,13 +540,18 @@ void TRestThread::ProcessEvent() {
             fProcessChain[j]->BeginOfEventProcess(ProcessedEvent);
             ProcessedEvent = fProcessChain[j]->ProcessEvent(ProcessedEvent);
             fProcessChain[j]->EndOfEventProcess();
-            if (ProcessedEvent == nullptr) break;
+            if (ProcessedEvent == nullptr) {
+                fProcessNullReturned = true;
+                break;
+            }
         }
 
         if (fHostRunner->UseTestRun()) {
             fOutputEvent = ProcessedEvent;
         } else {
-            ProcessedEvent->CloneTo(fOutputEvent);
+            if (ProcessedEvent != nullptr) {
+                ProcessedEvent->CloneTo(fOutputEvent);
+            }
         }
     }
 }


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![16](https://badgen.net/badge/Size/16/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/nkx111-testrunfix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/nkx111-testrunfix) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fix a bug when test run if off, and the returned event is NULL from the process. The NULL returned event will not be cloned to the output event.