### PR TITLE
Analysis plot fix

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -354,6 +354,14 @@ AnalysisPlot:
     - cd ${CI_PROJECT_DIR}/pipeline/analysisPlot/
     - restManager --c summary.rml --f ${CI_PROJECT_DIR}/pipeline/trex/Hits_01929.root
 
+AnalysisPlot2:
+  type: postProcessing
+  script:
+    - . ${CI_PROJECT_DIR}/install_latest/thisREST.sh
+    - cd ${CI_PROJECT_DIR}/pipeline/analysisPlot/
+    - restManager --batch --c classify.rml
+    - restRoot -b -q ValidateClassify.C
+
 deploy:
   type: deploy
   only:

--- a/pipeline/analysisPlot/ValidateClassify.C
+++ b/pipeline/analysisPlot/ValidateClassify.C
@@ -2,17 +2,29 @@ Int_t ValidateClassify() {
     TFile* f = new TFile("/tmp/canvas.root");
 
     TH1D* h1 = (TH1D*)f->Get("NumberSignals10852");
-    cout << h1->GetEntries() << endl;
-    if (h1->GetEntries() != 7584) {
-        cout << "The number of entries at Run 10852 is not 7584!" << endl;
+    if (!h1) {
+        cout << "Histogram NumberSignals10852 not found!" << endl;
         return 1;
     }
 
+    cout << h1->GetEntries() << endl;
+
+    if (h1->GetEntries() != 7584) {
+        cout << "The number of entries at Run 10852 is not 7584!" << endl;
+        return 2;
+    }
+
     TH1D* h2 = (TH1D*)f->Get("NumberSignals10964");
+    if (!h2) {
+        cout << "Histogram NumberSignals10964 not found!" << endl;
+        return 3;
+    }
+
     cout << h2->GetEntries() << endl;
+
     if (h2->GetEntries() != 3812) {
         cout << "The number of entries at Run 10964 is not 3812!" << endl;
-        return 2;
+        return 4;
     }
 
     return 0;

--- a/pipeline/analysisPlot/ValidateClassify.C
+++ b/pipeline/analysisPlot/ValidateClassify.C
@@ -1,0 +1,19 @@
+Int_t ValidateClassify() {
+    TFile* f = new TFile("/tmp/canvas.root");
+
+    TH1D* h1 = (TH1D*)f->Get("NumberSignals10852");
+    cout << h1->GetEntries() << endl;
+    if (h1->GetEntries() != 7584) {
+        cout << "The number of entries at Run 10852 is not 7584!" << endl;
+        return 1;
+    }
+
+    TH1D* h2 = (TH1D*)f->Get("NumberSignals10964");
+    cout << h2->GetEntries() << endl;
+    if (h2->GetEntries() != 3812) {
+        cout << "The number of entries at Run 10964 is not 3812!" << endl;
+        return 2;
+    }
+
+    return 0;
+}

--- a/pipeline/analysisPlot/classify.rml
+++ b/pipeline/analysisPlot/classify.rml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no" ?>
+
+<!-- This plot template shows an example of AnalysisPlot implementation.
+     The file where we have applied a signalAnalysisProcess name sgnl.Ana -->
+
+
+<TRestManager name="SpecPlot" title="Example" verboseLevel="info" >
+
+	<globals>
+		<variable name="RUN1" value="10852" overwrite="false" />
+		<variable name="RUN2" value="10964" overwrite="false" />
+		<variable name="E_MIN_RUN1" value="0" overwrite="false" />
+		<variable name="E_MAX_RUN1" value="1e6" overwrite="false" />
+		<variable name="E_MIN_RUN2" value="0" overwrite="false" />
+		<variable name="E_MAX_RUN2" value="1e6" overwrite="false" />
+	</globals>
+
+    <TRestAnalysisPlot name="CalToBackComp" title="Calibration and background comparison" previewPlot="false" verboseLevel="info">
+
+		<addFile name="https://sultan.unizar.es/rest_pipeline/v2.3.8_${RUN1}.root"/>
+		<addFile name="https://sultan.unizar.es/rest_pipeline/v2.3.8_${RUN2}.root"/>
+
+		<canvas size="(800,600)" divide="(1,1)" save="/tmp/canvas.root" />
+
+		<globalCut variable="hitsAna_nHitsX" condition=">0" value="ON" />
+		<globalCut variable="hitsAna_nHitsY" condition=">0" value="ON" />
+		<globalCut variable="tckAna_nTracks_X" condition="==1" value="OFF"/>
+		<globalCut variable="tckAna_nTracks_Y" condition="==1" value="OFF"/>
+
+		<globalCut variable="hitsAna_xMean*hitsAna_xMean+hitsAna_yMean*hitsAna_yMean" condition="<100" value="OFF"/>
+
+		<plot name="NumberOfGoodSignals" title="Number of good signals" xlabel="Number of good signals" ylabel="Counts" logscale="false" stats="on" save="/tmp/plot.root" value="ON" >
+			<histo name="NumberSignals${RUN1}" lineColor="1" save="">
+				<variable name="sAna_NumberOfGoodSignals" range="(0,50)" nbins="50" />
+				<classify fRunNumber="${RUN1}"/>
+				<cut variable="hitsAna_energy" condition=">${E_MIN_RUN1}" value="ON"/>
+				<cut variable="hitsAna_energy" condition="<=${E_MAX_RUN1}"  value="ON"/>
+			</histo>
+			<histo name="NumberSignals${RUN2}" lineColor="2">
+				<variable name="sAna_NumberOfGoodSignals" range="(0,50)" nbins="50" />
+				<classify fRunNumber="${RUN2}"/>
+				<cut variable="hitsAna_energy" condition=">${E_MIN_RUN2}" value="ON"/>
+				<cut variable="hitsAna_energy" condition="<=${E_MAX_RUN2}"  value="ON"/>
+			</histo>
+		</plot>
+
+  </TRestAnalysisPlot>
+
+  <addTask command="CalToBackComp->PlotCombinedCanvas()" value="ON"/>
+
+</TRestManager>

--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -550,7 +550,7 @@ Int_t TRestAnalysisPlot::GetPlotIndex(TString plotName) {
 }
 
 TRestAnalysisTree* TRestAnalysisPlot::GetTree(TString fileName) {
-    if (fileName == fRun->GetInputFileName(0)) {
+    if (fRun->GetInputFile() != NULL && fRun->GetInputFile()->GetName() == fileName){
         // this means the file is already opened by TRestRun
         return fRun->GetAnalysisTree();
     }
@@ -568,11 +568,8 @@ TRestAnalysisTree* TRestAnalysisPlot::GetTree(TString fileName) {
 }
 
 TRestRun* TRestAnalysisPlot::GetRunInfo(TString fileName) {
-    fRun->OpenInputFile(fileName);
-    return fRun;
-
     // in any case we directly return fRun. No need to reopen the given file
-    if (fileName == fRun->GetInputFileName(0)) {
+    if (fRun->GetInputFile() != NULL && fRun->GetInputFile()->GetName() == fileName){
         return fRun;
     }
     if (fileName == fRun->GetOutputFileName() && fRun->GetOutputFile() != nullptr) {

--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -164,7 +164,13 @@ void TRestAnalysisPlot::InitFromConfigFile() {
     fCanvasSize = StringTo2DVector(GetParameter("size", canvasdef, "(800,600)"));
     fCanvasDivisions = StringTo2DVector(GetParameter("divide", canvasdef, "(1,1)"));
     fCanvasDivisionMargins = StringTo2DVector(GetParameter("divideMargin", canvasdef, "(0.01, 0.01)"));
-    fCanvasSave = GetDataPath() + GetParameter("save", canvasdef, "rest_AnalysisPlot.pdf");
+
+    string save = (string)GetParameter("save", canvasdef, "rest_AnalysisPlot.pdf");
+    if (save.rfind("/", 0) == 0)
+        fCanvasSave = (TString)save;
+    else
+        fCanvasSave = GetDataPath() + save;
+
     fPaletteStyle = StringToInteger(GetParameter("paletteStyle", canvasdef, "57"));
 #pragma endregion
 

--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -562,6 +562,9 @@ TRestAnalysisTree* TRestAnalysisPlot::GetTree(TString fileName) {
 }
 
 TRestRun* TRestAnalysisPlot::GetRunInfo(TString fileName) {
+    fRun->OpenInputFile(fileName);
+    return fRun;
+
     // in any case we directly return fRun. No need to reopen the given file
     if (fileName == fRun->GetInputFileName(0)) {
         return fRun;


### PR DESCRIPTION
![Large](https://badgen.net/badge/PR%20Size/Large/red) ![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![100](https://badgen.net/badge/Size/100/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/analysis_plot_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/analysis_plot_fix) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Changes proposed in this pull-request:
- A fix when using a full-path filename at `save=""`.
- A fix when getting run info.
- A new validation for analysisPlot when using `classify fRunNumber=`.

I identified a problem on `TRestAnalysisPlot::GetRunInfo`. In some circumstances the run number for the corresponding file was not being properly retrieved. It seems that `GetRunInfo` optimises the opening/closing of files, in case the `fRun` is already open, however, there were some problems. The fix I introduced is bypassing that optimisation and opening the file each time this method is called.

Of course, this is not the best, but as it is right now it works, and I added a new validation test for analysisPlot to check this problem.

If these lines are removed,

```
571    fRun->OpenInputFile(fileName);
572    return fRun;
```

the validation `ValidateClassify.C` will fail.


Any quick fix to solve this? @nkx?