### PR TITLE
TRestMesh::GetPosition. Fixed an issue on spherical coordinates not r…

### DIFF
--- a/source/framework/core/src/TRestMesh.cxx
+++ b/source/framework/core/src/TRestMesh.cxx
@@ -137,6 +137,8 @@ TVector3 TRestMesh::GetPosition(Int_t nX, Int_t nY, Int_t nZ) {
         v.SetTheta(theta);
         v.SetPhi(phi);
 
+        return v;
+
     } else {
         Double_t x = fNetOrigin.X() + (fNetSizeX / (fNodesX - 1)) * nX;
         Double_t y = fNetOrigin.Y() + (fNetSizeY / (fNodesY - 1)) * nY;


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![2](https://badgen.net/badge/Size/2/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/mesh_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/mesh_fix) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

…eturnig the proper values

Fix clear bug when retrieving position in spherical coordinates.