### PR TITLE
TRestEveEventViewer. GEOM_SCALE is set to 1 for any ROOT version

### DIFF
--- a/source/framework/core/inc/TRestEveEventViewer.h
+++ b/source/framework/core/inc/TRestEveEventViewer.h
@@ -38,11 +38,7 @@
 
 #include "TRestEventViewer.h"
 
-#if ROOT_VERSION_CODE >= ROOT_VERSION(6, 24, 0)
 #define GEOM_SCALE 1
-#else
-#define GEOM_SCALE 0.1
-#endif
 
 class TRestEveEventViewer : public TRestEventViewer {
    protected:


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![0](https://badgen.net/badge/Size/0/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/eve_viewer_geo_scale/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/eve_viewer_geo_scale) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- At #44 it was updated the GEOM_SCALE from 0.1 to 1 for ROOT versions above 6.24. However, I am using ROOT 6.20 and the hits did not appear at the right position inside the geometrical volumes. Applying this PR update fixes the problem for me.

Not sure if the problem could be connected with the fact that I generated the data in sultan using ROOT 6.24, and then visualised on my local PC with ROOT 6.20.

@rest-for-physics/core_dev