### PR TITLE
Pipeline debugging

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -276,7 +276,7 @@ trexDM_data_latest:
     - sleep 30
     - ls -lrth
     - restManager --fork --c 02_signal.rml --f "RawData*.root"
-    - sleep 30
+    - sleep 60
     - ls -lrth
     - restManager --fork --c 03_hits.rml --f "Signals*.root"
     - sleep 30

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -274,10 +274,13 @@ trexDM_data_latest:
     - cp R01928_tagTest_Vm_250_Vd_160_Pr_6_Gain_0x0_Shape_0xF_Clock_0x4-068.aqs R01929_tagTest_Vm_250_Vd_160_Pr_6_Gain_0x0_Shape_0xF_Clock_0x4-068.aqs
     - restManager --fork --c 01_raw.rml --f "*.aqs"
     - sleep 30
+    - ls
     - restManager --fork --c 02_signal.rml --f "RawData*.root"
     - sleep 30
+    - ls
     - restManager --fork --c 03_hits.rml --f "Signals*.root"
     - sleep 30
+    - ls
     - restRoot -b -q ../MakeBasicTree.C'("Hits_01928.root")'
     - rm RawData_01928.root
     - rm Signals_01928.root

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -274,13 +274,13 @@ trexDM_data_latest:
     - cp R01928_tagTest_Vm_250_Vd_160_Pr_6_Gain_0x0_Shape_0xF_Clock_0x4-068.aqs R01929_tagTest_Vm_250_Vd_160_Pr_6_Gain_0x0_Shape_0xF_Clock_0x4-068.aqs
     - restManager --fork --c 01_raw.rml --f "*.aqs"
     - sleep 30
-    - ls
+    - ls -lrth
     - restManager --fork --c 02_signal.rml --f "RawData*.root"
     - sleep 30
-    - ls
+    - ls -lrth
     - restManager --fork --c 03_hits.rml --f "Signals*.root"
     - sleep 30
-    - ls
+    - ls -lrth
     - restRoot -b -q ../MakeBasicTree.C'("Hits_01928.root")'
     - rm RawData_01928.root
     - rm Signals_01928.root


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![4](https://badgen.net/badge/Size/4/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/pipeline_debugging/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/pipeline_debugging) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Just adds an increased time for data files to be produced at TREX-DM data validation.

@rest-for-physics/core_dev