### PR TITLE
TRestRun::OpenInputFile. Fixing a problem on runTag extraction

### DIFF
--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -58,6 +58,7 @@ class TRestRun : public TRestMetadata {
     int fEventBranchLoc;               //!
     int fEventIndexCounter = 0;        //!
     bool fHangUpEndFile = false;       //!
+    bool fFromRML = false;             //!
    private:
     string ReplaceMetadataMember(const string instr);
 

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -114,6 +114,7 @@ void TRestRun::Initialize() {
 ///
 void TRestRun::InitFromConfigFile() {
     debug << "Initializing TRestRun from config file, version: " << REST_RELEASE << endl;
+    fFromRML = true;
     ReSetVersion();
 
     // 1. Read basic parameter
@@ -389,18 +390,20 @@ void TRestRun::OpenInputFile(TString filename, string mode) {
 
             // If the value was initialized from RML and is not preserve, we recover
             // back the value in RML
-            if (runTypeTmp != "Null" && runTypeTmp != "preserve") fRunType = runTypeTmp;
+            if (fFromRML) {
+                if (runTypeTmp != "Null" && runTypeTmp != "preserve") fRunType = runTypeTmp;
 
-            // We should not recover the user. Only when writting. If not when I open a file
-            // with restRoot just to read, and Print the run content from other user in my
-            // own account, it will say it was me!
-            // if (runUserTmp != "Null" && runTypeTmp != "preserve") fRunUser = runUserTmp;
+                // We should not recover the user. Only when writting. If not when I open a file
+                // with restRoot just to read, and Print the run content from other user in my
+                // own account, it will say it was me!
+                // if (runUserTmp != "Null" && runTypeTmp != "preserve") fRunUser = runUserTmp;
 
-            // if (runTagTmp != "Null" && runTagTmp != "preserve") fRunTag = runTagTmp;
-            // if (runDescriptionTmp != "Null" && runDescriptionTmp != "preserve")
-            //    fRunDescription = runDescriptionTmp;
-            // if (experimentNameTmp != "Null" && experimentNameTmp != "preserve")
-            //    fExperimentName = experimentNameTmp;
+                if (runTagTmp != "Null" && runTagTmp != "preserve") fRunTag = runTagTmp;
+                if (runDescriptionTmp != "Null" && runDescriptionTmp != "preserve")
+                    fRunDescription = runDescriptionTmp;
+                if (experimentNameTmp != "Null" && experimentNameTmp != "preserve")
+                    fExperimentName = experimentNameTmp;
+            }
 
             // If version is lower than 2.2.1 we do not read/transfer the metadata to
             // output file?

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -396,11 +396,11 @@ void TRestRun::OpenInputFile(TString filename, string mode) {
             // own account, it will say it was me!
             // if (runUserTmp != "Null" && runTypeTmp != "preserve") fRunUser = runUserTmp;
 
-            if (runTagTmp != "Null" && runTagTmp != "preserve") fRunTag = runTagTmp;
-            if (runDescriptionTmp != "Null" && runDescriptionTmp != "preserve")
-                fRunDescription = runDescriptionTmp;
-            if (experimentNameTmp != "Null" && experimentNameTmp != "preserve")
-                fExperimentName = experimentNameTmp;
+            // if (runTagTmp != "Null" && runTagTmp != "preserve") fRunTag = runTagTmp;
+            // if (runDescriptionTmp != "Null" && runDescriptionTmp != "preserve")
+            //    fRunDescription = runDescriptionTmp;
+            // if (experimentNameTmp != "Null" && experimentNameTmp != "preserve")
+            //    fExperimentName = experimentNameTmp;
 
             // If version is lower than 2.2.1 we do not read/transfer the metadata to
             // output file?
@@ -1712,8 +1712,8 @@ void TRestRun::PrintMetadata() {
              << ")" << endl;
     metadata << "End Date/Time : " << ToDateTimeString(GetEndTimestamp()) << " (" << GetEndTimestamp() << ")"
              << endl;
-    metadata << "Input file : " << GetInputFileNamepattern() << endl;
-    metadata << "Output file : " << GetOutputFileName() << endl;
+    metadata << "Input file : " << TRestTools::GetPureFileName((string)GetInputFileNamepattern()) << endl;
+    metadata << "Output file : " << TRestTools::GetPureFileName((string)GetOutputFileName()) << endl;
     metadata << "Number of events : " << fEntriesSaved << endl;
     // metadata << "Input filename : " << fInputFilename << endl;
     // metadata << "Output filename : " << fOutputFilename << endl;


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![7](https://badgen.net/badge/Size/7/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_fix_trestrun/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_fix_trestrun) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

@rest-for-physics/core_dev