### PR TITLE
Change directory

### DIFF
--- a/source/framework/core/src/TRestHits.cxx
+++ b/source/framework/core/src/TRestHits.cxx
@@ -551,9 +551,9 @@ void TRestHits::WriteHitsToTextFile(TString filename) {
     FILE* fff = fopen(filename.Data(), "w");
     for (int i = 0; i < GetNumberOfHits(); i++) {
         if ((fType.size() == 0 ? !IsNaN(fX[i]) : fType[i] % X == 0))
-            fprintf(fff, "%d\t%e\t%e\t%e\t%e\n", i, fX[i], "NaN", fZ[i], fEnergy[i]);
+            fprintf(fff, "%d\t%e\t%s\t%e\t%e\n", i, fX[i], "NaN", fZ[i], fEnergy[i]);
         if ((fType.size() == 0 ? !IsNaN(fY[i]) : fType[i] % Y == 0))		
-            fprintf(fff, "%d\t%e\t%e\t%e\t%e\n", i, "NaN", fY[i], fZ[i], fEnergy[i]);
+            fprintf(fff, "%d\t%s\t%e\t%e\t%e\n", i, "NaN", fY[i], fZ[i], fEnergy[i]);
     }
     fclose(fff);
 }

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -91,6 +91,9 @@ class TRestTools {
     static int DownloadRemoteFile(string remoteFile, string localFile);
     static int UploadToServer(string localfile, string remotefile, string methodurl = "");
 
+	static void ChangeDirectory( string toDirectory );
+	static void ReturnToPreviousDirectory( );
+
     /// Rest tools class
     ClassDef(TRestTools, 1);
 };

--- a/source/framework/tools/src/TRestSystemOfUnits.cxx
+++ b/source/framework/tools/src/TRestSystemOfUnits.cxx
@@ -1,5 +1,3 @@
-#include <bits/stdc++.h>
-
 #include <iostream>
 #include <limits>
 

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -814,3 +814,33 @@ int TRestTools::UploadToServer(string filelocal, string remotefile, string metho
     }
     return 0;
 }
+
+void TRestTools::ChangeDirectory( string toDirectory ) {
+
+        char originDirectory[256];
+        sprintf(originDirectory, "%s", getenv("PWD"));
+        chdir(toDirectory.c_str());
+
+		string fullPath = "";
+		if( toDirectory[0] == '/' )
+			fullPath = toDirectory;
+		else
+			fullPath = (string) originDirectory + "/" + toDirectory;
+
+		setenv ( "PWD", fullPath.c_str(), 1 );
+		setenv ( "OLDPWD", originDirectory, 1 );
+}
+
+void TRestTools::ReturnToPreviousDirectory( ) {
+
+        char originDirectory[256];
+        sprintf(originDirectory, "%s", getenv("PWD"));
+
+        char newDirectory[256];
+        sprintf(newDirectory, "%s", getenv("OLDPWD"));
+
+		setenv ( "PWD", newDirectory, 1 );
+		setenv ( "OLDPWD", originDirectory, 1 );
+
+		chdir( newDirectory );
+}


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![35](https://badgen.net/badge/Size/35/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/change_directory/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/change_directory)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adds two new methods at TRestTools, `ChangeDirectory` and `ReturnToPreviousDirectory`.

Those were implemented in order to be used at `restG4`. rest-for-physics/restG4#27

@rest-for-physics/core_dev