### PR TITLE
New class: TRestCut

### DIFF
--- a/source/framework/core/inc/TRestCut.h
+++ b/source/framework/core/inc/TRestCut.h
@@ -23,31 +23,33 @@
 #ifndef RestCore_TRestCut
 #define RestCore_TRestCut
 
+#include "TCut.h"
 #include "TRestMetadata.h"
 #include "TRestRun.h"
-#include "TCut.h"
 
+//! A class to help on cuts definitions. To be used with TRestAnalysisTree
 class TRestCut : public TRestMetadata {
-private:
-	vector<TCut> fCuts;
+   private:
+    vector<TCut> fCuts;
 
-protected:
-	void Initialize() override;
-	void InitFromConfigFile() override;
-public:
-	void AddCut(TCut cut);
-	TCut GetCut(string name);
+   protected:
+    void Initialize() override;
+    void InitFromConfigFile() override;
 
-	void PrintMetadata() override;
+   public:
+    void AddCut(TCut cut);
+    TCut GetCut(string name);
 
-	Int_t Write(const char* name, Int_t option, Int_t bufsize) override;
+    void PrintMetadata() override;
 
-	// Constructor
-	TRestCut();
-	// Destructor
-	~TRestCut() {}
+    Int_t Write(const char* name, Int_t option, Int_t bufsize) override;
 
-	ClassDefOverride(TRestCut, 1);  // Template for a REST "event process" class inherited from
-										 // TRestEventProcess
+    // Constructor
+    TRestCut();
+    // Destructor
+    ~TRestCut() {}
+
+    ClassDefOverride(TRestCut, 1);  // Template for a REST "event process" class inherited from
+                                    // TRestEventProcess
 };
 #endif

--- a/source/framework/core/inc/TRestCut.h
+++ b/source/framework/core/inc/TRestCut.h
@@ -1,0 +1,66 @@
+/*************************************************************************
+ * This file is part of the REST software framework.                     *
+ *                                                                       *
+ * Copyright (C) 2016 GIFNA/TREX (University of Zaragoza)                *
+ * For more information see http://gifna.unizar.es/trex                  *
+ *                                                                       *
+ * REST is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * REST is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ * GNU General Public License for more details.                          *
+ *                                                                       *
+ * You should have a copy of the GNU General Public License along with   *
+ * REST in $REST_PATH/LICENSE.                                           *
+ * If not, see http://www.gnu.org/licenses/.                             *
+ * For the list of contributors see $REST_PATH/CREDITS.                  *
+ *************************************************************************/
+
+#ifndef RestCore_TRestCut
+#define RestCore_TRestCut
+
+#include "TRestMetadata.h"
+#include "TRestRun.h"
+#include "TCut.h"
+
+/// A Collection of TCut objects initialized from rml, e.g:
+/// 
+/// <TRestCut/>
+///   <cut name="cc1" value="XX>10 AND XX<90"/>
+///   <cut name="cc2" value="sAna_ThresholdIntegral<100e3"/>
+/// </TRestCut>
+/// 
+/// Note that the notations " AND " and " OR " will be replaced by " && " and " || " 
+/// When saved to ROOT file, this class will save together all its TCut objects 
+/// Then we can easily draw the tree with these cuts:
+/// 
+/// AnalysisTree->Draw("xxx",*cc1)
+/// AnalysisTree->Draw("xxx",*cc1 && *cc2 )
+class TRestCut : public TRestMetadata {
+private:
+	vector<TCut> fCuts;
+
+protected:
+	void Initialize() override;
+	void InitFromConfigFile() override;
+public:
+	void AddCut(TCut cut);
+	TCut GetCut(string name);
+
+	void PrintMetadata() override;
+
+	Int_t Write(const char* name, Int_t option, Int_t bufsize) override;
+
+	// Constructor
+	TRestCut();
+	// Destructor
+	~TRestCut() {}
+
+	ClassDefOverride(TRestCut, 1);  // Template for a REST "event process" class inherited from
+										 // TRestEventProcess
+};
+#endif

--- a/source/framework/core/inc/TRestCut.h
+++ b/source/framework/core/inc/TRestCut.h
@@ -27,19 +27,6 @@
 #include "TRestRun.h"
 #include "TCut.h"
 
-/// A Collection of TCut objects initialized from rml, e.g:
-/// 
-/// <TRestCut/>
-///   <cut name="cc1" value="XX>10 AND XX<90"/>
-///   <cut name="cc2" value="sAna_ThresholdIntegral<100e3"/>
-/// </TRestCut>
-/// 
-/// Note that the notations " AND " and " OR " will be replaced by " && " and " || " 
-/// When saved to ROOT file, this class will save together all its TCut objects 
-/// Then we can easily draw the tree with these cuts:
-/// 
-/// AnalysisTree->Draw("xxx",*cc1)
-/// AnalysisTree->Draw("xxx",*cc1 && *cc2 )
 class TRestCut : public TRestMetadata {
 private:
 	vector<TCut> fCuts;

--- a/source/framework/core/src/TRestCut.cxx
+++ b/source/framework/core/src/TRestCut.cxx
@@ -1,3 +1,55 @@
+/*************************************************************************
+ * This file is part of the REST software framework.                     *
+ *                                                                       *
+ * Copyright (C) 2016 GIFNA/TREX (University of Zaragoza)                *
+ * For more information see http://gifna.unizar.es/trex                  *
+ *                                                                       *
+ * REST is free software: you can redistribute it and/or modify          *
+ * it under the terms of the GNU General Public License as published by  *
+ * the Free Software Foundation, either version 3 of the License, or     *
+ * (at your option) any later version.                                   *
+ *                                                                       *
+ * REST is distributed in the hope that it will be useful,               *
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of        *
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the          *
+ * GNU General Public License for more details.                          *
+ *                                                                       *
+ * You should have a copy of the GNU General Public License along with   *
+ * REST in $REST_PATH/LICENSE.                                           *
+ * If not, see http://www.gnu.org/licenses/.                             *
+ * For the list of contributors see $REST_PATH/CREDITS.                  *
+ *************************************************************************/
+
+//////////////////////////////////////////////////////////////////////////
+/// TRestCut is a Collection of TCut objects initialized from rml and stored with the output file, e.g:
+/// 
+/// <TRestCut/>
+///   <cut name="cc1" value="XX>10 AND XX<90"/>
+///   <cut name="cc2" value="sAna_ThresholdIntegral<100e3"/>
+/// </TRestCut>
+/// 
+/// Note that the notations " AND " and " OR " will be replaced by " && " and " || " 
+/// When saved to ROOT file, this class will save together all its TCut objects 
+/// Then we can easily draw from analysis tree with these cuts:
+/// 
+/// AnalysisTree->Draw("xxx",*cc1)
+/// AnalysisTree->Draw("xxx",*cc1 && *cc2 )
+///
+///--------------------------------------------------------------------------
+///
+/// RESTsoft - Software for Rare Event Searches with TPCs
+///
+/// History of developments:
+///
+/// 2021-dec: First concept.
+///           Ni Kaixiang
+///
+/// \class TRestCut
+///
+/// <hr>
+///
+//////////////////////////////////////////////////////////////////////////
+
 #include "TRestDataBase.h"
 #include "TRestManager.h"
 #include "TRestProcessRunner.h"

--- a/source/framework/core/src/TRestCut.cxx
+++ b/source/framework/core/src/TRestCut.cxx
@@ -1,0 +1,73 @@
+#include "TRestDataBase.h"
+#include "TRestManager.h"
+#include "TRestProcessRunner.h"
+#include "TRestStringOutput.h"
+
+#include "TRestCut.h"
+
+ClassImp(TRestCut);
+
+//______________________________________________________________________________
+TRestCut::TRestCut() { 
+    Initialize();
+}
+
+void TRestCut::Initialize() {
+    fCuts.clear();
+}
+
+void TRestCut::InitFromConfigFile() {
+    auto ele = GetElement("cut");
+    while (ele != NULL) {
+        string name = GetParameter("name", ele, "");
+        string cutStr = GetParameter("value", ele, "");
+        cutStr = Replace(cutStr, " AND ", " && ");
+        cutStr = Replace(cutStr, " OR ", " || ");
+        AddCut(TCut(name.c_str(), cutStr.c_str()));
+        ele = GetNextElement(ele);
+    }
+}
+
+void TRestCut::AddCut(TCut cut) {
+    if ((string)cut.GetName() == "") {
+        warning << "TRestCut::AddCut: cannot add cut without name!" << endl;
+    }
+    if ((string)cut.GetTitle() == "") {
+        warning << "TRestCut::AddCut: cannot add empty cut!" << endl;
+    }
+    for (auto c : fCuts) {
+        if ((string)c.GetName() == (string)cut.GetName()) {
+            warning << "TRestCut::AddCut: cut with name \"" << c.GetName() << "\" already added!" << endl;
+            return;
+        }
+    }
+    fCuts.push_back(cut);
+}
+
+TCut TRestCut::GetCut(string name) {
+    for (auto c : fCuts) {
+        if ((string)c.GetName() == name) {
+            return c;
+        }
+    }
+    return TCut();
+}
+
+void TRestCut::PrintMetadata() {
+	TRestMetadata::PrintMetadata();
+	metadata << " " << endl;
+	metadata << "Number of TCut objects added: " << fCuts.size() << endl;
+	metadata << " " << endl;
+	metadata << "+++" << endl;
+}
+
+Int_t TRestCut::Write(const char* name, Int_t option, Int_t bufsize) {
+    // write cuts to file.
+
+    for (auto c : fCuts) {
+        c.Write();
+    }
+
+    return TRestMetadata::Write(name, option, bufsize);
+
+}


### PR DESCRIPTION
![Large](https://badgen.net/badge/PR%20Size/Large/red) ![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![180](https://badgen.net/badge/Size/180/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/nkx111-TRestCut/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/nkx111-TRestCut)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Added new class: TRestCut. A metadata class which collects TCut objects initialized from rml, e.g:

```xml
<TRestCut/>
   <cut name="cc1" value="XX>10 AND XX<90"/>
   <cut name="cc2" value="sAna_ThresholdIntegral<100e3"/>
 </TRestCut>
```
The notations " AND " and " OR " will be replaced by " && " and " || " .

When saved to ROOT file, this class will save together all its TCut objects 
When we open the output file, we can easily draw histogram with different cuts, to investugate their impacts.

```
AnalysisTree->Draw("xxx",*cc1)
AnalysisTree->Draw("xxx",*cc1 && *cc2 )
```

By properly defing TCuts it also tells other people how to select events.

```
KEY: TCut     fiducial;1        pHitsAna_MeanX>120 && pHitsAna_MeanX<280 && pHitsAna_MeanY>-180 && pHitsAna_MeanY<-20
KEY: TCut     cs137;1 sAna_ThresholdIntegral>65e3 && sAna_ThresholdIntegral<80e3
KEY: TCut     kr85;1  sAna_ThresholdIntegral>85e3 && sAna_ThresholdIntegral<103e3
```