### PR TITLE
TRestMetadata: undefine = operator method overload

### DIFF
--- a/pipeline/metadata/readout/PrintReadout.C
+++ b/pipeline/metadata/readout/PrintReadout.C
@@ -33,7 +33,7 @@ void PrintReadout(TString fName) {
     while ((key = (TKey*)nextkey())) {
         if (((string)(key->GetClassName())).find("TRestDetectorReadout") != -1) {
             TObject* obj = f->Get(key->GetName());
-            TRestDetectorReadout readout = *(TRestDetectorReadout*)obj;
+            TRestDetectorReadout& readout = *(TRestDetectorReadout*)obj;
             readout[0].Print(1);
         }
         n++;

--- a/source/framework/core/inc/TRestMetadata.h
+++ b/source/framework/core/inc/TRestMetadata.h
@@ -306,6 +306,9 @@ class TRestMetadata : public TNamed {
     /// overwriting the write() method with fStore considered
     virtual Int_t Write(const char* name = 0, Int_t option = 0, Int_t bufsize = 0);
 
+    TRestMetadata& operator=(const TRestMetadata&) = delete;
+    TRestMetadata(const TRestMetadata&) = delete;
+   
     TRestMetadata();
     ~TRestMetadata();
     TRestMetadata(const char* cfgFileNamecfgFileName);


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![4](https://badgen.net/badge/Size/4/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/nkx111-patch-2/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/nkx111-patch-2)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

It will cause double free problems if we use `=` or copy constructor for metadata classes. The reason is that the data member `fElement` as a pointer will also be copied. And when we delete the two metadata classes, the same pointer will be deleted twice. For example:

```cpp
TRestDetectorGas *g=new TRestDetectorGas("server","Xenon-TMA 0.1Pct 10-10E3Vcm") // initialize a metadata
{TRestDetectorGas gg = *g;} // make a new copy and delete.
delete g;  // this delete operation will cause seg.fault
```

In this PR I undefined the `=` operator. Now the second line doesn't work, and avoids this problem.

Now to copy metadata or to use the object(instead of pointer), one can use `Clone()`, or reference:

```cpp
TRestDetectorGas* g=new TRestDetectorGas("server","Xenon-TMA 0.1Pct 10-10E3Vcm") 
TRestDetectorGas* gg = (TRestDetectorGas*)g->Clone();
delete g; 
delete gg;
```

```cpp
TRestDetectorGas *g=new TRestDetectorGas("server","Xenon-TMA 0.1Pct 10-10E3Vcm")
{TRestDetectorGas& gg = *g;}
delete g;
```