### PR TITLE
TRestMetadata. if datamember does not support units, the value is ret…

### DIFF
--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -471,7 +471,7 @@ using namespace REST_Physics;
 map<string, string> TRestMetadata_UpdatedConfigFile;
 
 ClassImp(TRestMetadata);
-    ///////////////////////////////////////////////
+///////////////////////////////////////////////
 /// \brief TRestMetadata default constructor
 ///
 TRestMetadata::TRestMetadata() : endl(this) {
@@ -1121,8 +1121,9 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
         if ((string)e->Value() == "include") {
             localele = (TiXmlElement*)e->Parent();
             if (localele == nullptr) return;
-            if (localele->Attribute("expanded") == nullptr ? false : ((string)localele->Attribute("expanded") ==
-                                                                   "true")) {
+            if (localele->Attribute("expanded") == nullptr
+                    ? false
+                    : ((string)localele->Attribute("expanded") == "true")) {
                 debug << "----already expanded----" << endl;
                 return;
             }
@@ -1157,8 +1158,9 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
         // overwrites "type"
         else {
             localele = e;
-            if (localele->Attribute("expanded") == nullptr ? false : ((string)localele->Attribute("expanded") ==
-                                                                   "true")) {
+            if (localele->Attribute("expanded") == nullptr
+                    ? false
+                    : ((string)localele->Attribute("expanded") == "true")) {
                 debug << "----already expanded----" << endl;
                 return;
             }
@@ -2361,7 +2363,7 @@ void TRestMetadata::ReadOneParameter(string name, string value) {
                             << this->ClassName() << " find unit definition in parameter: " << name
                             << ", but the corresponding data member doesn't support it. Data member type: "
                             << datamember.type << endl;
-                        datamember.ParseString(val);
+                        datamember.ParseString(value);
                     }
                 } else {
                     datamember.ParseString(value);
@@ -2456,8 +2458,7 @@ void TRestMetadata::SetWarning(string message, bool print) {
     if (message != "") {
         fWarningMessage += message + "\n";
         if (print) {
-            if (fVerboseLevel>=REST_Warning)
-            cout << message << endl;
+            if (fVerboseLevel >= REST_Warning) cout << message << endl;
         }
     }
 }


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![10](https://badgen.net/badge/Size/10/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/no_units_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/no_units_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes a problem that removes the identified unit string at data members where units are not allowed.

For example, if I try to define a runTag using "5MeV". It was becoming "5", but I really want the units are specified at the runTag.