### PR TITLE
TRestRun::GetRunInformation. Protecting method

### DIFF
--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -1430,7 +1430,7 @@ string TRestRun::GetRunInformation(string infoname) {
         return result;
     }
 
-    result = GetDataMemberValue("f" + infoname);
+    result = GetDataMemberValue(ParameterNameToDataMemberName(infoname));
     if (result != "") {
         return result;
     }

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -1435,7 +1435,7 @@ string TRestRun::GetRunInformation(string infoname) {
         return result;
     }
 
-    if (fHostmgr->GetProcessRunner() != nullptr) {
+    if (fHostmgr && fHostmgr->GetProcessRunner() != nullptr) {
         result = fHostmgr->GetProcessRunner()->GetProcInfo(infoname);
         if (result != "") {
             return result;


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![2](https://badgen.net/badge/Size/2/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/run_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/run_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- Added protection against segmentation fault.