### PR TITLE
TRestAnalysisPlot supports color/line/fill style def with strings

### DIFF
--- a/source/framework/core/inc/TRestAnalysisPlot.h
+++ b/source/framework/core/inc/TRestAnalysisPlot.h
@@ -23,67 +23,24 @@ const int REST_MAX_TAGS = 15;
 
 // as enum "EColor" defined in Rtypes.h
 // as enum "ELineStyle" defined in TAttLine.h
-// as enum "EMarkerStyle" defined in TAttMarker.h
-const map<string, int> StyleIdMap{{"white", kWhite},
-                            {"black", kBlack},
-                            {"gray", kGray},
-                            {"red", kRed},
-                            {"green", kGreen},
-                            {"blue", kBlue},
-                            {"yellow", kYellow},
-                            {"magenta", kMagenta},
-                            {"cyan", kCyan},
-                            {"orange", kOrange},
-                            {"spring", kSpring},
-                            {"teal", kTeal},
-                            {"azure", kAzure},
-                            {"violet", kViolet},
-                            {"pink", kPink},
-
-                            {"solid", kSolid},
-                            {"dashed", kDashed},
-                            {"dotted", kDotted},
-                            {"dashDotted", kDashDotted},
-
-                            {"dot", kDot},
-                            {"plus", kPlus},
-                            {"star", kStar},
-                            {"circle", kCircle},
-                            {"multiply", kMultiply},
-                            {"fullDotSmall", kFullDotSmall},
-                            {"fullDotMedium", kFullDotMedium},
-                            {"fullDotLarge", kFullDotLarge},
-                            {"fullCircle", kFullCircle},
-                            {"fullSquare", kFullSquare},
-                            {"fullTriangleUp", kFullTriangleUp},
-                            {"fullTriangleDown", kFullTriangleDown},
-                            {"openCircle", kOpenCircle},
-                            {"openSquare", kOpenSquare},
-                            {"openTriangleUp", kOpenTriangleUp},
-                            {"openDiamond", kOpenDiamond},
-                            {"openCross", kOpenCross},
-                            {"fullStar", kFullStar},
-                            {"openStar", kOpenStar},
-                            {"openTriangleDown", kOpenTriangleDown},
-                            {"fullDiamond", kFullDiamond},
-                            {"fullCross", kFullCross},
-                            {"openDiamondCross", kOpenDiamondCross},
-                            {"openSquareDiagonal", kOpenSquareDiagonal},
-                            {"openThreeTriangles", kOpenThreeTriangles},
-                            {"octagonCross", kOctagonCross},
-                            {"fullThreeTriangles", kFullThreeTriangles},
-                            {"openFourTrianglesX", kOpenFourTrianglesX},
-                            {"fullFourTrianglesX", kFullFourTrianglesX},
-                            {"openDoubleDiamond", kOpenDoubleDiamond},
-                            {"fullDoubleDiamond", kFullDoubleDiamond},
-                            {"openFourTrianglesPlus", kOpenFourTrianglesPlus},
-                            {"fullFourTrianglesPlus", kFullFourTrianglesPlus},
-                            {"openCrossX", kOpenCrossX},
-                            {"fullCrossX", kFullCrossX},
-                            {"fourSquaresX", kFourSquaresX},
-                            {"fourSquaresPlus", kFourSquaresPlus}
-
-};
+// as enum "EFillStyle" defined in TAttFill.h
+const map<string, int> ColorIdMap{
+    {"white", kWhite},   {"black", kBlack},   {"gray", kGray},       {"red", kRed},       {"green", kGreen},
+    {"blue", kBlue},     {"yellow", kYellow}, {"magenta", kMagenta}, {"cyan", kCyan},     {"orange", kOrange},
+    {"spring", kSpring}, {"teal", kTeal},     {"azure", kAzure},     {"violet", kViolet}, {"pink", kPink}};
+const map<string, int> LineStyleMap{
+    {"solid", kSolid}, {"dashed", kDashed}, {"dotted", kDotted}, {"dashDotted", kDashDotted}};
+const map<string, int> FillStyleMap{
+    {"dotted", kFDotted1},        {"dashed", kFDashed1},    {"dotted1", kFDotted1},
+    {"dotted2", kFDotted2},       {"dotted3", kFDotted3},   {"hatched1", kFHatched1},
+    {"hatched2", kHatched2},      {"hatched3", kFHatched3}, {"hatched4", kFHatched4},
+    {"wicker", kFWicker},         {"scales", kFScales},     {"bricks", kFBricks},
+    {"snowflakes", kFSnowflakes}, {"circles", kFCircles},   {"tiles", kFTiles},
+    {"mondrian", kFMondrian},     {"diamonds", kFDiamonds}, {"waves1", kFWaves1},
+    {"dashed1", kFDashed1},       {"dashed2", kFDashed2},   {"alhambra", kFAlhambra},
+    {"waves2", kFWaves2},         {"stars1", kFStars1},     {"stars2", kFStars2},
+    {"pyramids", kFPyramids},     {"frieze", kFFrieze},     {"metopes", kFMetopes},
+    {"empty", kFEmpty},           {"solid", kFSolid}};
 
 class TRestAnalysisPlot : public TRestMetadata {
    public:
@@ -200,7 +157,9 @@ class TRestAnalysisPlot : public TRestMetadata {
     TRestAnalysisTree* GetTree(TString fileName);
     TRestRun* GetRunInfo(TString fileName);
     bool IsDynamicRange(TString rangeString);
-    Int_t GetStyleIDFromString(string in);
+    Int_t GetColorIDFromString(string in);
+    Int_t GetFillStyleIDFromString(string in);
+    Int_t GetLineStyleIDFromString(string in);
 
    protected:
    public:

--- a/source/framework/core/inc/TRestAnalysisPlot.h
+++ b/source/framework/core/inc/TRestAnalysisPlot.h
@@ -13,13 +13,77 @@
 #define RestCore_TRestAnalysisPlot
 
 #include <TLatex.h>
+#include <TRestRun.h>
+
 #include "TCanvas.h"
 #include "TH3D.h"
-
-#include <TRestRun.h>
 #include "TRestAnalysisTree.h"
 
 const int REST_MAX_TAGS = 15;
+
+// as enum "EColor" defined in Rtypes.h
+// as enum "ELineStyle" defined in TAttLine.h
+// as enum "EMarkerStyle" defined in TAttMarker.h
+const map<string, int> StyleIdMap{{"white", kWhite},
+                            {"black", kBlack},
+                            {"gray", kGray},
+                            {"red", kRed},
+                            {"green", kGreen},
+                            {"blue", kBlue},
+                            {"yellow", kYellow},
+                            {"magenta", kMagenta},
+                            {"cyan", kCyan},
+                            {"orange", kOrange},
+                            {"spring", kSpring},
+                            {"teal", kTeal},
+                            {"azure", kAzure},
+                            {"violet", kViolet},
+                            {"pink", kPink},
+
+                            {"solid", kSolid},
+                            {"dashed", kDashed},
+                            {"dotted", kDotted},
+                            {"dashDotted", kDashDotted},
+
+                            {"dot", kDot},
+                            {"plus", kPlus},
+                            {"star", kStar},
+                            {"circle", kCircle},
+                            {"multiply", kMultiply},
+                            {"fullDotSmall", kFullDotSmall},
+                            {"fullDotMedium", kFullDotMedium},
+                            {"fullDotLarge", kFullDotLarge},
+                            {"fullCircle", kFullCircle},
+                            {"fullSquare", kFullSquare},
+                            {"fullTriangleUp", kFullTriangleUp},
+                            {"fullTriangleDown", kFullTriangleDown},
+                            {"openCircle", kOpenCircle},
+                            {"openSquare", kOpenSquare},
+                            {"openTriangleUp", kOpenTriangleUp},
+                            {"openDiamond", kOpenDiamond},
+                            {"openCross", kOpenCross},
+                            {"fullStar", kFullStar},
+                            {"openStar", kOpenStar},
+                            {"openTriangleDown", kOpenTriangleDown},
+                            {"fullDiamond", kFullDiamond},
+                            {"fullCross", kFullCross},
+                            {"openDiamondCross", kOpenDiamondCross},
+                            {"openSquareDiagonal", kOpenSquareDiagonal},
+                            {"openThreeTriangles", kOpenThreeTriangles},
+                            {"octagonCross", kOctagonCross},
+                            {"fullThreeTriangles", kFullThreeTriangles},
+                            {"openFourTrianglesX", kOpenFourTrianglesX},
+                            {"fullFourTrianglesX", kFullFourTrianglesX},
+                            {"openDoubleDiamond", kOpenDoubleDiamond},
+                            {"fullDoubleDiamond", kFullDoubleDiamond},
+                            {"openFourTrianglesPlus", kOpenFourTrianglesPlus},
+                            {"fullFourTrianglesPlus", kFullFourTrianglesPlus},
+                            {"openCrossX", kOpenCrossX},
+                            {"fullCrossX", kFullCrossX},
+                            {"fourSquaresX", kFourSquaresX},
+                            {"fourSquaresPlus", kFourSquaresPlus}
+
+};
 
 class TRestAnalysisPlot : public TRestMetadata {
    public:
@@ -136,6 +200,7 @@ class TRestAnalysisPlot : public TRestMetadata {
     TRestAnalysisTree* GetTree(TString fileName);
     TRestRun* GetRunInfo(TString fileName);
     bool IsDynamicRange(TString rangeString);
+    Int_t GetStyleIDFromString(string in);
 
    protected:
    public:

--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -495,11 +495,11 @@ TRestAnalysisPlot::Histo_Info_Set TRestAnalysisPlot::SetupHistogramFromConfigFil
     }
 
     // 5. read draw style(line color, width, fill style, etc.)
-    hist.lineColor = GetStyleIDFromString(GetParameter("lineColor", histele, "602"));
-    hist.lineWidth = GetStyleIDFromString(GetParameter("lineWidth", histele, "1"));
-    hist.lineStyle = GetStyleIDFromString(GetParameter("lineStyle", histele, "1"));
-    hist.fillStyle = GetStyleIDFromString(GetParameter("fillStyle", histele, "1001"));
-    hist.fillColor = GetStyleIDFromString(GetParameter("fillColor", histele, "0"));
+    hist.lineColor = GetColorIDFromString(GetParameter("lineColor", histele, "602"));
+    hist.lineWidth = StringToInteger(GetParameter("lineWidth", histele, "1"));
+    hist.lineStyle = GetLineStyleIDFromString(GetParameter("lineStyle", histele, "1"));
+    hist.fillStyle = GetFillStyleIDFromString(GetParameter("fillStyle", histele, "1001"));
+    hist.fillColor = GetColorIDFromString(GetParameter("fillColor", histele, "0"));
 
     return hist;
 }
@@ -587,13 +587,35 @@ bool TRestAnalysisPlot::IsDynamicRange(TString rangeString) {
     return (string(rangeString)).find(",  ") != -1;
 }
 
-Int_t TRestAnalysisPlot::GetStyleIDFromString(string in) {
+Int_t TRestAnalysisPlot::GetColorIDFromString(string in) {
     if (in.find_first_not_of("0123456789") == string::npos) {
         return StringToInteger(in);
-    } else if (StyleIdMap.count(in) != 0) {
-        return StyleIdMap.at(in);
+    } else if (ColorIdMap.count(in) != 0) {
+        return ColorIdMap.at(in);
     } else {
-        warning << "cannot find style id for \"" << in << "\"" << endl;
+        warning << "cannot find color with name \"" << in << "\"" << endl;
+    }
+    return -1;
+}
+
+Int_t TRestAnalysisPlot::GetFillStyleIDFromString(string in) {
+    if (in.find_first_not_of("0123456789") == string::npos) {
+        return StringToInteger(in);
+    } else if (FillStyleMap.count(in) != 0) {
+        return FillStyleMap.at(in);
+    } else {
+        warning << "cannot find fill style with name \"" << in << "\"" << endl;
+    }
+    return -1;
+}
+
+Int_t TRestAnalysisPlot::GetLineStyleIDFromString(string in) {
+    if (in.find_first_not_of("0123456789") == string::npos) {
+        return StringToInteger(in);
+    } else if (LineStyleMap.count(in) != 0) {
+        return LineStyleMap.at(in);
+    } else {
+        warning << "cannot find line style with name \"" << in << "\"" << endl;
     }
     return -1;
 }

--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -495,11 +495,11 @@ TRestAnalysisPlot::Histo_Info_Set TRestAnalysisPlot::SetupHistogramFromConfigFil
     }
 
     // 5. read draw style(line color, width, fill style, etc.)
-    hist.lineColor = StringToInteger(GetParameter("lineColor", histele, "602"));
-    hist.lineWidth = StringToInteger(GetParameter("lineWidth", histele, "1"));
-    hist.lineStyle = StringToInteger(GetParameter("lineStyle", histele, "1"));
-    hist.fillStyle = StringToInteger(GetParameter("fillStyle", histele, "1001"));
-    hist.fillColor = StringToInteger(GetParameter("fillColor", histele, "0"));
+    hist.lineColor = GetStyleIDFromString(GetParameter("lineColor", histele, "602"));
+    hist.lineWidth = GetStyleIDFromString(GetParameter("lineWidth", histele, "1"));
+    hist.lineStyle = GetStyleIDFromString(GetParameter("lineStyle", histele, "1"));
+    hist.fillStyle = GetStyleIDFromString(GetParameter("fillStyle", histele, "1001"));
+    hist.fillColor = GetStyleIDFromString(GetParameter("fillColor", histele, "0"));
 
     return hist;
 }
@@ -585,6 +585,17 @@ TRestRun* TRestAnalysisPlot::GetRunInfo(TString fileName) {
 
 bool TRestAnalysisPlot::IsDynamicRange(TString rangeString) {
     return (string(rangeString)).find(",  ") != -1;
+}
+
+Int_t TRestAnalysisPlot::GetStyleIDFromString(string in) {
+    if (in.find_first_not_of("0123456789") == string::npos) {
+        return StringToInteger(in);
+    } else if (StyleIdMap.count(in) != 0) {
+        return StyleIdMap.at(in);
+    } else {
+        warning << "cannot find style id for \"" << in << "\"" << endl;
+    }
+    return -1;
 }
 
 void TRestAnalysisPlot::PlotCombinedCanvas() {


### PR DESCRIPTION
![Large](https://badgen.net/badge/PR%20Size/Large/red) ![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![63](https://badgen.net/badge/Size/63/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/style-def-with-string/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/style-def-with-string)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now we can define histo color/line/file styles with directly string in TRestAnalysisPlot. Previously we must input enum values of each item. The supported styles were defined in Rtypes.h, TAttLine.h and TAttFill.h respectivelly. (In rml these names shall be converted according to our standard parameter-datamember logic. e.g., kYellow --> yellow, kFullDotLarge --> fullDotLarge)

Now we can use 

```
    <plot name="Energy" title="Energy spectrum" xlabel="Energy [keV]" ylabel="Counts" value="ON" stats="ON" >

      <histo name="1MeV_5um" fillColor="red" lineColor="red">
        <variable name="sAna_ThresholdIntegral" range="(0,200e3)" nbins="100"/>
        <classify runTag="1MeV_5um"/>
      </histo>

      <histo name="5MeV_5um" fillColor="gray" lineColor="blue">
        <variable name="sAna_ThresholdIntegral" range="(0,200e3)" nbins="100"/>
        <classify runTag="5MeV_5um"/>
      </histo>

      <histo name="5MeV_1um" fillColor="gray" lineColor="black">
        <variable name="sAna_ThresholdIntegral" range="(0,200e3)" nbins="100"/>
        <classify runTag="5MeV_1um"/>
      </histo>

    </plot>
```

to produce compared spectrums