### PR TITLE
Fix `FindROOT.cmake` in case `thisroot.sh` wasn't sourced

### DIFF
--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -1,15 +1,15 @@
 # - Finds ROOT instalation
-# This module sets up ROOT information 
+# This module sets up ROOT information
 # It defines:
 # ROOT_FOUND          If the ROOT is found
 # ROOT_INCLUDE_DIR    PATH to the include directory (deprecated)
 # ROOT_INCLUDE_DIRS   PATH to the include directory
 # ROOT_LIBRARIES      Most common libraries
-# ROOT_LIBRARY_DIR    PATH to the library directory 
+# ROOT_LIBRARY_DIR    PATH to the library directory
 # ROOT_BIN_DIR	      PATH to the excutables directory
 # ROOT_PYTHONVER      Compatible python version string
 
-# First search for ROOTConfig.cmake on the path defined via user setting 
+# First search for ROOTConfig.cmake on the path defined via user setting
 # ROOT_DIR
 
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
@@ -19,7 +19,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Windows")
   endif()
 
   if(NOT ROOTSYS)
-	set(ROOT_FOUND FALSE)
+    set(ROOT_FOUND FALSE)
   else()
     set(ROOT_FOUND TRUE)
 
@@ -27,17 +27,17 @@ if (CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(ROOT_INCLUDE_DIRS ${ROOTSYS}/include)
     set(ROOT_BIN_DIR ${ROOTSYS}/bin)
     set(ROOTCINT_EXECUTABLE ${ROOTSYS}/bin/rootcint.exe)
-	set(GENREFLEX_EXECUTABLE ${ROOTSYS}/bin/genreflex.exe)
+    set(GENREFLEX_EXECUTABLE ${ROOTSYS}/bin/genreflex.exe)
 
     set(CMAKE_FIND_LIBRARY_PREFIXES "lib")
     set(CMAKE_FIND_LIBRARY_SUFFIXES ".lib" ".dll")
     set(ROOT_LIBRARIES)
     foreach(_cpt Core Imt RIO Net Hist Gui Eve RGL Gdml Geom Graf Graf3d Gpad Tree TreePlayer Rint Postscript Matrix Physics MathCore Thread MultiProc Minuit)
       find_library(ROOT_${_cpt}_LIBRARY ${_cpt} HINTS ${ROOT_LIBRARY_DIR})
-        if(ROOT_${_cpt}_LIBRARY)
-          mark_as_advanced(ROOT_${_cpt}_LIBRARY)
-		    list(APPEND ROOT_LIBRARIES ${ROOT_${_cpt}_LIBRARY})
-		  endif()
+      if(ROOT_${_cpt}_LIBRARY)
+        mark_as_advanced(ROOT_${_cpt}_LIBRARY)
+	list(APPEND ROOT_LIBRARIES ${ROOT_${_cpt}_LIBRARY})
+      endif()
     endforeach()
     if(ROOT_LIBRARIES)
       list(REMOVE_DUPLICATES ROOT_LIBRARIES)
@@ -51,17 +51,16 @@ else()
 
   if(NOT ROOT_CONFIG_EXECUTABLE)
     set(ROOT_FOUND FALSE)
-  else()    
+  else()
     set(ROOT_FOUND TRUE)
 
-
-	execute_process(
-      COMMAND ${ROOT_CONFIG_EXECUTABLE} --incdir 
+    execute_process(
+      COMMAND ${ROOT_CONFIG_EXECUTABLE} --incdir
       OUTPUT_VARIABLE ROOT_INCLUDE_DIRS
       OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-	execute_process(
-      COMMAND ${ROOT_CONFIG_EXECUTABLE} --libdir 
+    execute_process(
+      COMMAND ${ROOT_CONFIG_EXECUTABLE} --libdir
       OUTPUT_VARIABLE ROOT_LIBRARY_DIR
       OUTPUT_STRIP_TRAILING_WHITESPACE)
 
@@ -70,7 +69,7 @@ else()
 	set(GENREFLEX_EXECUTABLE $ENV{ROOTSYS}/bin/genreflex)
 
     execute_process(
-      COMMAND ${ROOT_CONFIG_EXECUTABLE} --version 
+      COMMAND ${ROOT_CONFIG_EXECUTABLE} --version
       OUTPUT_VARIABLE ROOT_VERSION
       OUTPUT_STRIP_TRAILING_WHITESPACE)
 
@@ -84,15 +83,16 @@ else()
       OUTPUT_VARIABLE ROOT_BIN_DIR
       OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-	# Make variables changeble to the advanced user
+
+    # Make variables changeble to the advanced user
     mark_as_advanced(ROOT_CONFIG_EXECUTABLE)
   endif()
 endif()
 
 
 if (NOT ROOT_FOUND)
-    message(FATAL_ERROR "ROOT required, but not found")
+  message(FATAL_ERROR "ROOT required, but not found")
 else()
-	message(STATUS "Find ROOT ${ROOT_VERSION} in ${ROOT_BIN_DIR}")
+  message(STATUS "Find ROOT ${ROOT_VERSION} in ${ROOT_BIN_DIR}")
 endif()
 

--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -66,10 +66,6 @@ else()
       OUTPUT_VARIABLE ROOT_LIBRARY_DIR
       OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-
-    set(ROOTCINT_EXECUTABLE $ENV{ROOTSYS}/bin/rootcint)
-	set(GENREFLEX_EXECUTABLE $ENV{ROOTSYS}/bin/genreflex)
-
     execute_process(
       COMMAND ${ROOT_CONFIG_EXECUTABLE} --version
       OUTPUT_VARIABLE ROOT_VERSION
@@ -85,6 +81,8 @@ else()
       OUTPUT_VARIABLE ROOT_BIN_DIR
       OUTPUT_STRIP_TRAILING_WHITESPACE)
 
+    set(ROOTCINT_EXECUTABLE ${ROOT_BIN_DIR}/rootcint)
+    set(GENREFLEX_EXECUTABLE ${ROOT_BIN_DIR}/genreflex)
 
     # Make variables changeble to the advanced user
     mark_as_advanced(ROOT_CONFIG_EXECUTABLE)

--- a/cmake/FindROOT.cmake
+++ b/cmake/FindROOT.cmake
@@ -15,7 +15,9 @@
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
 
   if(DEFINED ENV{ROOTSYS})
-   set(ROOTSYS $ENV{ROOTSYS})
+    set(ROOTSYS $ENV{ROOTSYS})
+  else()
+    message(FATAL_ERROR "ROOTSYS environment variable is undefined. Did you forget to source the `thisroot.bat`?")
   endif()
 
   if(NOT ROOTSYS)


### PR DESCRIPTION
![Vindaar](https://badgen.net/badge/PR%20submitted%20by%3A/Vindaar/blue) ![24](https://badgen.net/badge/Size/24/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/fixFindRoot/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/fixFindRoot)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Related to #133.

While helping @jovoy, we stumbled over the `FindROOT.cmake` script which currently:
- neither checks whether `ROOTSYS` is defined (i.e. whether `thisroot.*` was sourced)
- nor just uses the `root-config` to get all information it needs.

So this PR:
- throws a fatal error on Windows in case `ROOTSYS` is undefined
- uses the result of `root-config --bindir` on unix, as that is all we need to determine the path to `rootcint`.

I'm neither a cmake expert, nor sure whether it's wise in the first place to continue if `ROOTSYS` is not defined. I can't foresee if later not having sourced the file leads to even harder to debug issues. Alternatively, we could also just check for the existence of the variable on unix and fatal error in the same way.

If `FindROOT.cmake` is buried soon, just make sure the behavior of the alternative is sane & checks for this as well.

@rest-for-physics/core_dev