### PR TITLE
restRoot upgrades

### DIFF
--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -61,6 +61,7 @@ int main(int argc, char* argv[]) {
     bool debug = false;
     if (gVerbose >= REST_Debug) debug = true;
 
+    gROOT->ProcessLine("#include <TRestStringHelper.h>");
     // load rest library and macros
     TRestTools::LoadRESTLibrary(silent);
     if (loadMacros) {


### PR DESCRIPTION
= Added `TRestStringHelper` header so that `REST_StringHelper` methods can be invoked inside `restRoot`.

= This PR will track the implementation of RML automatic loading, so that when we call `restRoot file.rml` the main `TRest` class definitions found inside the RML will be automatically loaded as `md_name`.

