### PR TITLE
fixed calling of external process's endprocess() method

### DIFF
--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -466,11 +466,12 @@ void TRestProcessRunner::RunProcess() {
         if (finish) break;
     }
 
+    // make analysis tree filled with observables, which may used in EndProcess()
     fAnalysisTree->GetEntry(fAnalysisTree->GetEntries() - 1);
     for (int i = 0; i < fThreadNumber; i++) {
         fThreads[i]->EndProcess();
     }
-
+    if (fRunInfo->GetFileProcess() != NULL) fRunInfo->GetFileProcess()->EndProcess();
     fProcStatus = kFinished;
 
 #ifdef TIME_MEASUREMENT

--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -471,7 +471,9 @@ void TRestProcessRunner::RunProcess() {
     for (int i = 0; i < fThreadNumber; i++) {
         fThreads[i]->EndProcess();
     }
-    if (fRunInfo->GetFileProcess() != NULL) fRunInfo->GetFileProcess()->EndProcess();
+    if (fRunInfo->GetFileProcess()) {
+        fRunInfo->GetFileProcess()->EndProcess();
+    }
     fProcStatus = kFinished;
 
 #ifdef TIME_MEASUREMENT

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -804,7 +804,7 @@ Int_t TRestRun::GetNextEvent(TRestEvent* targetevt, TRestAnalysisTree* targettre
             goto GetEventExt;
         }
         fInputEvent = eve;
-        if (fFileProcess != nullptr) fFileProcess->EndProcess();
+        // if (fFileProcess != nullptr) fFileProcess->EndProcess();
         return -1;
     }
 


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![5](https://badgen.net/badge/Size/5/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/nkx-patch-endprocess/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/nkx-patch-endprocess)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

fix a bug that when manually quit the file process from pause menu, the `EndProcess()` method of external process is not called.