### PR TITLE
Updated CMake for inclusion of REST via find_package

### DIFF
--- a/cmake/scripts/RESTConfig.cmake
+++ b/cmake/scripts/RESTConfig.cmake
@@ -2,9 +2,17 @@
 # This cmake file will enable to find REST from another CMake project via "find_package(REST)"
 # It will define useful variables such as "REST_PATH" or "REST_LIBRARIES" which makes linking easier
 
-set(REST_PATH $ENV{REST_PATH})
+execute_process(COMMAND rest-config --prefix OUTPUT_VARIABLE REST_PATH)
 
-# TODO: I think there is a better way to do this, we shouldn't call 'rest-config' for this
+set(REST_PATH_ENV $ENV{REST_PATH})
+string(STRIP "${REST_PATH_ENV}" REST_PATH_ENV)
+string(STRIP "${REST_PATH}" REST_PATH)
+
+if (NOT "${REST_PATH_ENV}" STREQUAL "${REST_PATH}")
+    message(SEND_ERROR "REST installation found at ${REST_PATH} but 'REST_PATH' env variable points to $ENV{REST_PATH}")
+    set(REST_FOUND False)
+endif()
+
 execute_process(COMMAND rest-config --libs OUTPUT_VARIABLE REST_LIBRARIES)
 string(STRIP ${REST_LIBRARIES} REST_LIBRARIES) # It is necessary to strip the whitespaces, or it will give error
 
@@ -13,3 +21,5 @@ string(STRIP ${REST_INCLUDE_DIRS} REST_INCLUDE_DIRS) # It is necessary to strip 
 
 execute_process(COMMAND rest-config --version OUTPUT_VARIABLE REST_VERSION)
 string(STRIP ${REST_VERSION} REST_VERSION) # It is necessary to strip the whitespaces, or it will give error
+
+message(STATUS "REST installation found at: ${REST_PATH}")

--- a/cmake/scripts/RESTConfig.cmake
+++ b/cmake/scripts/RESTConfig.cmake
@@ -11,7 +11,7 @@ string(STRIP "${REST_PATH}" REST_PATH)
 if (NOT "${REST_PATH_ENV}" STREQUAL "${REST_PATH}")
     message(SEND_ERROR "REST installation found at ${REST_PATH} but 'REST_PATH' env variable points to $ENV{REST_PATH}")
     set(REST_FOUND False)
-endif()
+endif ()
 
 execute_process(COMMAND rest-config --libs OUTPUT_VARIABLE REST_LIBRARIES)
 string(STRIP ${REST_LIBRARIES} REST_LIBRARIES) # It is necessary to strip the whitespaces, or it will give error

--- a/cmake/thisREST.cmake
+++ b/cmake/thisREST.cmake
@@ -205,7 +205,7 @@ echo ${rest_macros_str}
 fi
 
 if [ $option = \\\"--version\\\" ] ; then
-echo ${GIT_TAG}
+echo \${GIT_TAG}
 
 fi
 

--- a/cmake/thisREST.cmake
+++ b/cmake/thisREST.cmake
@@ -40,7 +40,6 @@ endif (${REST_GARFIELD} MATCHES "ON")
 # install thisREST script, sh VERSION
 install(CODE
         "
-
 file( WRITE \${CMAKE_INSTALL_PREFIX}/thisREST.sh
 
 \"\#!/bin/bash
@@ -162,14 +161,12 @@ alias ${mac} \\\"restManager ${m}\\\"
 
 endforeach (mac ${rest_macros})
 
-
-#install rest-config
+# install rest-config
 install(CODE
         "
 include(${CMAKE_CURRENT_SOURCE_DIR}/cmake/CollectGitInfo.cmake)
 
 message(STATUS \"Installing: \${CMAKE_INSTALL_PREFIX}/bin/rest-config\")
-
 
 file( WRITE \${CMAKE_INSTALL_PREFIX}/bin/rest-config
 
@@ -208,7 +205,12 @@ echo ${rest_macros_str}
 fi
 
 if [ $option = \\\"--version\\\" ] ; then
-echo \${GIT_TAG}
+echo ${GIT_TAG}
+
+fi
+
+if [ $option = \\\"--prefix\\\" ] ; then
+echo ${CMAKE_INSTALL_PREFIX}
 
 fi
 
@@ -250,7 +252,7 @@ echo \\\"  Compilation date : ${date}  \\\"
 echo \\\"  Official release : \${REST_OFFICIAL_RELEASE} \\\"
 echo \\\"  Clean state : \${GIT_CLEANSTATE} \\\"
 echo \\\"  \\\"
-echo \\\"  Installed at : $REST_PATH  \\\"
+echo \\\"  Installed at : \${CMAKE_INSTALL_PREFIX}  \\\"
 echo \\\"  \\\"
 echo \\\"  REST-for-Physics site : rest-for-physics.github.io  \\\"
 echo \\\"  \\\"
@@ -264,24 +266,20 @@ fi
 fi
 
 if [ $option = \\\"--help\\\" ] ; then
-echo \\\"  Usage :                                                                      \\\"
-echo \\\"  rest-config [--incdir]  : Shows the directory of headers                      \\\"
-echo \\\"  rest-config [--libdir]  : Shows the directory of library                      \\\"
-echo \\\"  rest-config [--libs]    : Prints regular REST libraries                       \\\"
-echo \\\"  rest-config [--exes]    : Prints a list of REST executables with alias        \\\"
-echo \\\"  rest-config [--version] : Prints the version of REST                          \\\"
-echo \\\"  rest-config [--welcome] : Prints the welcome message                          \\\"
-echo \\\"  rest-config [--flags]   : Prints cmake flags defined when installing          \\\"
+echo \\\"  Usage :                                                                                              \\\"
+echo \\\"  rest-config [--version] : Prints the version of REST                                                 \\\"
+echo \\\"  rest-config [--prefix]  : Prints REST installation directory                                         \\\"
+echo \\\"  rest-config [--incdir]  : Shows the directory of headers                                             \\\"
+echo \\\"  rest-config [--libdir]  : Shows the directory of library                                             \\\"
+echo \\\"  rest-config [--libs]    : Prints regular REST libraries                                              \\\"
+echo \\\"  rest-config [--exes]    : Prints a list of REST executables with alias                               \\\"
+echo \\\"  rest-config [--welcome] : Prints the welcome message                                                 \\\"
+echo \\\"  rest-config [--flags]   : Prints cmake flags defined when installing                                 \\\"
 echo \\\"  rest-config [--release] : Prints 'Yes' if the compilation corresponds with an official git tag.      \\\"
-echo \\\"  rest-config [--clean] : Prints 'Yes' if no local modifications were found during compilation   \\\"
-
+echo \\\"  rest-config [--clean]   : Prints 'Yes' if no local modifications were found during compilation       \\\"
 fi
 
-
 fi
-
-
-
 
 
 \"


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![29](https://badgen.net/badge/Size/29/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-patch-cmake_find_package/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-patch-cmake_find_package)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Changes to the CMake files to support inclusion of REST via `find_package(REST)`.

Added new command: `rest-config --prefix` which returns the installation path of REST (doesn't have to be the same as the current REST_PATH).

When doing `find_package(REST)` it will check that the current REST_PATH and the installation path of REST match. It will throw an error if they don't.