### PR TITLE
Adding detector-project template to projects as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -64,3 +64,6 @@
 [submodule "doc/userguide"]
 	path = doc/userguide
 	url = https://github.com/rest-for-physics/rest-docs.github.io.git
+[submodule "projects/detector-project"]
+	path = projects/detector-project
+	url = git@github.com:rest-for-physics/detector-project.git


### PR DESCRIPTION
We should take it as a good chance to review the base/template project for `detector-project`.

I use `detector-project` and not `template-project` because it might happen that in future we get other kind of project templates. This one is clearly intended for detectors.

@rest-for-physics/core_dev
