### PR TITLE
TRestEventProcess::Begin/EndOfEventProcess are now virtual

### DIFF
--- a/source/framework/core/inc/TRestEventProcess.h
+++ b/source/framework/core/inc/TRestEventProcess.h
@@ -189,11 +189,11 @@ class TRestEventProcess : public TRestMetadata {
     /// To be executed at the beginning of the run (outside event loop)
     virtual void InitProcess() {}
     /// Begin of event process, preparation work. Called right before ProcessEvent()
-    void BeginOfEventProcess(TRestEvent* evInput = nullptr);
+    virtual void BeginOfEventProcess(TRestEvent* evInput = nullptr);
     /// Process one event
     virtual TRestEvent* ProcessEvent(TRestEvent* evInput) = 0;
     /// End of event process. Nothing to do. Called directly after ProcessEvent()
-    void EndOfEventProcess(TRestEvent* evInput = nullptr);
+    virtual void EndOfEventProcess(TRestEvent* evInput = nullptr);
     /// To be executed at the end of the run (outside event loop)
     virtual void EndProcess() {}
 


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![2](https://badgen.net/badge/Size/2/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_event_process/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_event_process)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

A simple PR to make `TRestEventProcess::Begin/EndOfEventProcess` virtual so that they can be re-implemented at the inherited classes.

This is required by rest-for-physics/axionlib#12