### PR TITLE
It adds a method at TRestTools to do http POST requests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,4 @@
-image: ghcr.io/lobis/root-geant4-garfield:cpp17_ROOT-v6-26-00_Geant4-v10.4.3_Garfield-af4a1451
-#image: nkx1231/root6-geant4-garfield:0.6
+image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
 
 variables:
 #    GIT_SUBMODULE_STRATEGY: recursive

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ find_package(ROOT REQUIRED COMPONENTS ${ROOT_REQUIRED_LIBRARIES})
 
 message(STATUS "ROOT LIBRARIES: ${ROOT_LIBRARIES}")
 
-set(external_libs "${external_libs};${ROOT_LIBRARIES}")
+set(external_libs "${external_libs};${ROOT_LIBRARIES};-lcurl")
 
 set(ROOTCINT_EXECUTABLE ${ROOT_rootcint_CMD})
 

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -2216,6 +2216,8 @@ TString TRestMetadata::GetSearchPath() {
 
     if (getenv("configPath")) result += getenv("configPath") + (string) ":";
     result += REST_PATH + "/data/:";
+    // We give priority to the official /data/ path.
+    result += REST_USER_PATH + ":";
     if (result.back() == ':') result.erase(result.size() - 1);
 
     return ReplaceConstants(ReplaceVariables(result));

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -50,8 +50,8 @@ class TRestTools {
 
     static void LoadRESTLibrary(bool silent = false);
 
-    static int ReadASCIITable(string fName, std::vector<std::vector<Double_t>>& data);
-    static int ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& data);
+    static int ReadASCIITable(string fName, std::vector<std::vector<Double_t>>& data, Int_t skipLines = 0);
+    static int ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& data, Int_t skipLines = 0);
 
     template <typename T>
     static int ReadBinaryTable(string fName, std::vector<std::vector<T>>& data, Int_t columns);

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -90,8 +90,7 @@ class TRestTools {
     static std::string DownloadRemoteFile(std::string remoteFile);
     static int DownloadRemoteFile(std::string remoteFile, std::string localFile);
     static int UploadToServer(std::string localfile, std::string remotefile, std::string methodurl = "");
-    static int POSTRequest(std::string& file_content, std::vector<std::string> keys,
-                           std::vector<std::string> values);
+    static std::string POSTRequest(const std::map<std::string, std::string>& keys);
 
     static void ChangeDirectory(string toDirectory);
     static void ReturnToPreviousDirectory();

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -87,12 +87,14 @@ class TRestTools {
 
     static std::string Execute(string cmd);
 
-    static std::string DownloadRemoteFile(string remoteFile);
-    static int DownloadRemoteFile(string remoteFile, string localFile);
-    static int UploadToServer(string localfile, string remotefile, string methodurl = "");
+    static std::string DownloadRemoteFile(std::string remoteFile);
+    static int DownloadRemoteFile(std::string remoteFile, std::string localFile);
+    static int UploadToServer(std::string localfile, std::string remotefile, std::string methodurl = "");
+    static int POSTRequest(std::string& file_content, std::vector<std::string> keys,
+                           std::vector<std::string> values);
 
-	static void ChangeDirectory( string toDirectory );
-	static void ReturnToPreviousDirectory( );
+    static void ChangeDirectory(string toDirectory);
+    static void ReturnToPreviousDirectory();
 
     /// Rest tools class
     ClassDef(TRestTools, 1);
@@ -124,7 +126,7 @@ inline void SetInitLevel(T* name, int level) {
     struct __##classname##_Init {                                   \
         __##classname##_Init() {                                    \
             REST_ARGS[#objname] = #classname;                       \
-            if (objname != nullptr) {                                  \
+            if (objname != nullptr) {                               \
                 if (REST_InitTools::CanOverwrite(objname, level)) { \
                     delete objname;                                 \
                     objname = new classname();                      \

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -68,6 +68,9 @@ class TRestTools {
     template <typename T>
     static int PrintTable(std::vector<std::vector<T>> data, Int_t start = 0, Int_t end = 0);
 
+    template <typename T>
+    static int ExportASCIITable(std::string fname, std::vector<std::vector<T>> data);
+
     static Int_t isValidFile(const string& path);
     static bool fileExists(const std::string& filename);
     static bool isRootFile(const std::string& filename);

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -69,7 +69,7 @@ class TRestTools {
     static int PrintTable(std::vector<std::vector<T>> data, Int_t start = 0, Int_t end = 0);
 
     template <typename T>
-    static int ExportASCIITable(std::string fname, std::vector<std::vector<T>> data);
+    static int ExportASCIITable(std::string fname, std::vector<std::vector<T>>& data);
 
     static Int_t isValidFile(const string& path);
     static bool fileExists(const std::string& filename);

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -90,7 +90,7 @@ class TRestTools {
     static std::string DownloadRemoteFile(std::string remoteFile);
     static int DownloadRemoteFile(std::string remoteFile, std::string localFile);
     static int UploadToServer(std::string localfile, std::string remotefile, std::string methodurl = "");
-    static std::string POSTRequest(const std::map<std::string, std::string>& keys);
+    static std::string POSTRequest(const std::string& url, const std::map<std::string, std::string>& keys);
 
     static void ChangeDirectory(string toDirectory);
     static void ReturnToPreviousDirectory();

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -263,7 +263,7 @@ template Double_t TRestTools::GetLowestIncreaseFromTable<Double_t>(std::vector<s
 ///
 /// Only works with Double_t vector since we use StringToDouble method.
 ///
-int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>& data) {
+int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>& data, Int_t skipLines) {
     if (!TRestTools::isValidFile((string)fName)) {
         cout << "TRestTools::ReadASCIITable. Error" << endl;
         cout << "Cannot open file : " << fName << endl;
@@ -278,6 +278,11 @@ int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>&
     std::vector<std::vector<string>> values;
 
     for (string line; std::getline(fin, line);) {
+        if (skipLines > 0) {
+            skipLines--;
+            continue
+        }
+
         if (line.find("#") == string::npos) {
             std::istringstream in(line);
             values.push_back(
@@ -309,7 +314,7 @@ int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>&
 ///
 /// This version works with Float_t vector since we use StringToFloat method.
 ///
-int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& data) {
+int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& data, Int_t skipLines) {
     if (!TRestTools::isValidFile((string)fName)) {
         cout << "TRestTools::ReadASCIITable. Error" << endl;
         cout << "Cannot open file : " << fName << endl;
@@ -324,6 +329,11 @@ int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& 
     std::vector<std::vector<string>> values;
 
     for (string line; std::getline(fin, line);) {
+        if (skipLines > 0) {
+            skipLines--;
+            continue
+        }
+
         if (line.find("#") == string::npos) {
             std::istringstream in(line);
             values.push_back(

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -132,7 +132,7 @@ template int TRestTools::PrintTable<Double_t>(std::vector<std::vector<Double_t>>
 /// Allowed types are Int_t, Float_t and Double_t.
 ///
 template <typename T>
-int TRestTools::ExportASCIITable(std::string fname, std::vector<std::vector<T>> data) {
+int TRestTools::ExportASCIITable(std::string fname, std::vector<std::vector<T>>& data) {
     ofstream file(fname);
     if (!file.is_open()) {
         ferr << "Unable to open file for writting : " << fname << endl;
@@ -150,10 +150,11 @@ int TRestTools::ExportASCIITable(std::string fname, std::vector<std::vector<T>> 
     return 0;
 }
 
-template int TRestTools::ExportASCIITable<Int_t>(std::string fname, std::vector<std::vector<Int_t>> data);
-template int TRestTools::ExportASCIITable<Float_t>(std::string fname, std::vector<std::vector<Float_t>> data);
+template int TRestTools::ExportASCIITable<Int_t>(std::string fname, std::vector<std::vector<Int_t>>& data);
+template int TRestTools::ExportASCIITable<Float_t>(std::string fname,
+                                                   std::vector<std::vector<Float_t>>& data);
 template int TRestTools::ExportASCIITable<Double_t>(std::string fname,
-                                                    std::vector<std::vector<Double_t>> data);
+                                                    std::vector<std::vector<Double_t>>& data);
 
 ///////////////////////////////////////////////
 /// \brief Reads a binary file containning a fixed-columns table with values

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -280,7 +280,7 @@ int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>&
     for (string line; std::getline(fin, line);) {
         if (skipLines > 0) {
             skipLines--;
-            continue
+            continue;
         }
 
         if (line.find("#") == string::npos) {
@@ -331,7 +331,7 @@ int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& 
     for (string line; std::getline(fin, line);) {
         if (skipLines > 0) {
             skipLines--;
-            continue
+            continue;
         }
 
         if (line.find("#") == string::npos) {

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -778,7 +778,7 @@ int TRestTools::DownloadRemoteFile(string remoteFile, string localFile) {
 /// \brief It performs a POST web protocol request using a set of keys and values given
 /// by argument, and returns the result as a string.
 ///
-std::string TRestTools::POSTRequest(const std::map<std::string, std::string>& keys) {
+std::string TRestTools::POSTRequest(const std::string& url, const std::map<std::string, std::string>& keys) {
     CURL* curl;
     CURLcode res;
 
@@ -791,9 +791,9 @@ std::string TRestTools::POSTRequest(const std::map<std::string, std::string>& ke
 
     std::string request = "";
     int n = 0;
-    for (auto const& [key, val] : symbolTable) {
+    for (auto const& x : keys) {
         if (n > 0) request += "&";
-        request += key + "=" + val;
+        request += x.first + "=" + x.second;
         n++;
     }
     /* get a curl handle */
@@ -802,7 +802,7 @@ std::string TRestTools::POSTRequest(const std::map<std::string, std::string>& ke
         /* First set the URL that is about to receive our POST. This URL can
            just as well be a https:// URL if that is what should receive the
            data. */
-        curl_easy_setopt(curl, CURLOPT_URL, "https://henke.lbl.gov/cgi-bin/laymir.pl");
+        curl_easy_setopt(curl, CURLOPT_URL, url.c_str());
         curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*)f);
         /* Now specify the POST data */
         curl_easy_setopt(curl, CURLOPT_POSTFIELDS, request.c_str());

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -128,6 +128,34 @@ template int TRestTools::PrintTable<Double_t>(std::vector<std::vector<Double_t>>
                                               Int_t end);
 
 ///////////////////////////////////////////////
+/// \brief Writes the contents of the vector table given as argument to `fname`.
+/// Allowed types are Int_t, Float_t and Double_t.
+///
+template <typename T>
+int TRestTools::ExportASCIITable(std::string fname, std::vector<std::vector<T>> data) {
+    ofstream file(fname);
+    if (!file.is_open()) {
+        ferr << "Unable to open file for writting : " << fname << endl;
+        return 1;
+    }
+
+    for (int n = 0; n < data.size(); n++)
+        for (int m = 0; m < data[n].size(); m++) {
+            file << data[n][m];
+            if (m + 1 < data[n].size()) file << "\t";
+            if (m + 1 == data[n].size()) file << "\n";
+        }
+    file.close();
+
+    return 0;
+}
+
+template int TRestTools::ExportASCIITable<Int_t>(std::string fname, std::vector<std::vector<Int_t>> data);
+template int TRestTools::ExportASCIITable<Float_t>(std::string fname, std::vector<std::vector<Float_t>> data);
+template int TRestTools::ExportASCIITable<Double_t>(std::string fname,
+                                                    std::vector<std::vector<Double_t>> data);
+
+///////////////////////////////////////////////
 /// \brief Reads a binary file containning a fixed-columns table with values
 ///
 /// This method will open the file fName. This file should contain a
@@ -180,7 +208,8 @@ template int TRestTools::ReadBinaryTable<Double_t>(string fName, std::vector<std
                                                    Int_t columns);
 
 ///////////////////////////////////////////////
-/// \brief It returns the maximum value for a particular `column` from the table given by argument.
+/// \brief It returns the maximum value for a particular `column` from the table given by
+/// argument.
 ///
 /// This method is available for tables of type Float_t, Double_t and Int_t.
 ///
@@ -202,7 +231,8 @@ template Double_t TRestTools::GetMaxValueFromTable<Double_t>(std::vector<std::ve
                                                              Int_t column);
 
 ///////////////////////////////////////////////
-/// \brief It returns the minimum value for a particular `column` from the table given by argument.
+/// \brief It returns the minimum value for a particular `column` from the table given by
+/// argument.
 ///
 /// This method is available for tables of type Float_t, Double_t and Int_t.
 ///
@@ -224,13 +254,13 @@ template Double_t TRestTools::GetMinValueFromTable<Double_t>(std::vector<std::ve
                                                              Int_t column);
 
 ///////////////////////////////////////////////
-/// \brief It returns the lowest increase, different from zero, between the elements of a particular `column`
-/// from the table given by argument.
+/// \brief It returns the lowest increase, different from zero, between the elements of a
+/// particular `column` from the table given by argument.
 ///
 /// This method is available for tables of type Float_t, Double_t and Int_t.
 ///
-/// \warning This method will not check every possible column element difference. It will only look for
-/// consecutive elements steps.
+/// \warning This method will not check every possible column element difference. It will only
+/// look for consecutive elements steps.
 ///
 template <typename T>
 T TRestTools::GetLowestIncreaseFromTable(std::vector<std::vector<T>> data, Int_t column) {
@@ -839,8 +869,8 @@ std::string TRestTools::POSTRequest(const std::string& url, const std::map<std::
 /// inside remotefile.
 ///
 /// Example: UploadToServer("/home/nkx/abc.txt", "https://sultan.unizar.es/gasFiles/gases.rml",
-/// "ssh://nkx:M123456@:8322") Then, the local file abc.txt will be uploaded to the server, renamed to
-/// gases.rml and overwrite it
+/// "ssh://nkx:M123456@:8322") Then, the local file abc.txt will be uploaded to the server,
+/// renamed to gases.rml and overwrite it
 int TRestTools::UploadToServer(string filelocal, string remotefile, string methodurl) {
     if (!TRestTools::fileExists(filelocal)) {
         cout << "error! local file not exist!" << endl;

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -776,15 +776,9 @@ int TRestTools::DownloadRemoteFile(string remoteFile, string localFile) {
 
 ///////////////////////////////////////////////
 /// \brief It performs a POST web protocol request using a set of keys and values given
-/// by argument, and places the result inside `content`.
+/// by argument, and returns the result as a string.
 ///
-int TRestTools::POSTRequest(std::string& file_content, std::vector<std::string> keys,
-                            std::vector<std::string> values) {
-    if (keys.size() != values.size()) {
-        ferr << "The number of keys and values does not match!" << endl;
-        return 1;
-    }
-
+std::string TRestTools::POSTRequest(const std::map<std::string, std::string>& keys) {
     CURL* curl;
     CURLcode res;
 
@@ -796,11 +790,12 @@ int TRestTools::POSTRequest(std::string& file_content, std::vector<std::string> 
     FILE* f = fopen(filename.c_str(), "wt");
 
     std::string request = "";
-    for (unsigned int n = 0; n < keys.size(); n++) {
+    int n = 0;
+    for (auto const& [key, val] : symbolTable) {
         if (n > 0) request += "&";
-        request += keys[n] + "=" + values[n];
+        request += key + "=" + val;
+        n++;
     }
-    cout << request << endl;
     /* get a curl handle */
     curl = curl_easy_init();
     if (curl) {
@@ -823,9 +818,10 @@ int TRestTools::POSTRequest(std::string& file_content, std::vector<std::string> 
     fclose(f);
     curl_global_cleanup();
 
+    std::string file_content = "";
     std::getline(std::ifstream(filename), file_content, '\0');
 
-    return 0;
+    return file_content;
 }
 
 ///////////////////////////////////////////////

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -45,9 +45,11 @@
 
 #include <dirent.h>
 
+#include <chrono>
 #include <iostream>
 #include <limits>
 #include <memory>
+#include <thread>
 
 #include "TClass.h"
 #include "TRestStringHelper.h"
@@ -762,7 +764,7 @@ std::string TRestTools::DownloadRemoteFile(string url) {
             out = TRestTools::DownloadRemoteFile(url, fullpath);
             if (out == 1024) {
                 warning << "Retrying download in 5 seconds" << endl;
-                sleep(5);
+                std::this_thread::sleep_for(std::chrono::seconds(5));
             }
             attempts--;
         } while (out == 1024 && attempts > 0);


### PR DESCRIPTION
![Large](https://badgen.net/badge/PR%20Size/Large/red) ![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![162](https://badgen.net/badge/Size/162/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_tools_post/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_tools_post)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- It adds dependency with libcurl libraries
- It adds a static method `TRestTools::POSTRequest` to do POST requests to a website.
- `TRestTools::ReadASCIITable` added an optional argument to skip header lines.
- `TRestMetadata::GetSearchPath` now adds also `REST_USER_PATH` as a default.
- `TRestTools::ExportASCIITable` method added to write a file with the contents of `std::vector<std::vector>>`.

@rest-for-physics/core_dev