### PR TITLE
Using `cpr` as http library

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,7 @@ find_package(ROOT REQUIRED COMPONENTS ${ROOT_REQUIRED_LIBRARIES})
 
 message(STATUS "ROOT LIBRARIES: ${ROOT_LIBRARIES}")
 
-set(external_libs "${external_libs};${ROOT_LIBRARIES};-lcurl")
+set(external_libs "${external_libs};${ROOT_LIBRARIES}")
 
 set(ROOTCINT_EXECUTABLE ${ROOT_rootcint_CMD})
 

--- a/source/framework/CMakeLists.txt
+++ b/source/framework/CMakeLists.txt
@@ -10,6 +10,8 @@ if (NOT ${REST_EVE} MATCHES "ON")
     set(excludes TRestEveEventViewer)
 endif (NOT ${REST_EVE} MATCHES "ON")
 
+set(external_libs "${external_libs};PRIVATE cpr::cpr")
+
 COMPILEDIR(RestFramework)
 
 ADD_LIBRARY_TEST()

--- a/source/framework/external/CMakeLists.txt
+++ b/source/framework/external/CMakeLists.txt
@@ -15,3 +15,9 @@ if (TEST)
     set(gtest_force_shared_crt ON CACHE BOOL "" FORCE) # Windows only
     FetchContent_MakeAvailable(googletest)
 endif ()
+
+include(FetchContent)
+FetchContent_Declare(cpr GIT_REPOSITORY https://github.com/libcpr/cpr.git
+        GIT_TAG 21f42cf882d0b7e5ae9e3434574fc47e187728de)
+# The commit hash for 1.8.0. Replace with the latest from: https://github.com/libcpr/cpr/releases
+FetchContent_MakeAvailable(cpr)

--- a/source/framework/external/CMakeLists.txt
+++ b/source/framework/external/CMakeLists.txt
@@ -16,7 +16,7 @@ if (TEST)
     FetchContent_MakeAvailable(googletest)
 endif ()
 
-include(FetchContent)
+message(STATUS "- https://github.com/libcpr/cpr.git")
 FetchContent_Declare(cpr GIT_REPOSITORY https://github.com/libcpr/cpr.git
         GIT_TAG 21f42cf882d0b7e5ae9e3434574fc47e187728de)
 # The commit hash for 1.8.0. Replace with the latest from: https://github.com/libcpr/cpr/releases

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -90,8 +90,8 @@ class TRestTools {
     static std::string DownloadRemoteFile(std::string remoteFile);
     static int DownloadRemoteFile(std::string remoteFile, std::string localFile);
     static int UploadToServer(std::string localfile, std::string remotefile, std::string methodurl = "");
-    static int POSTRequest(std::string& file_content, std::vector<std::string> keys,
-                           std::vector<std::string> values);
+    static std::string POSTRequest(const std::string& url,
+                                   const std::map<std::string, std::string>& parameters);
 
     static void ChangeDirectory(string toDirectory);
     static void ReturnToPreviousDirectory();

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -777,54 +777,10 @@ int TRestTools::DownloadRemoteFile(string remoteFile, string localFile) {
 /// \brief It performs a POST web protocol request using a set of keys and values given
 /// by argument, and places the result inside `content`.
 ///
-int TRestTools::POSTRequest(std::string& file_content, std::vector<std::string> keys,
-                            std::vector<std::string> values) {
-    if (keys.size() != values.size()) {
-        ferr << "The number of keys and values does not match!" << endl;
-        return 1;
-    }
-
-    CURL* curl;
-    CURLcode res;
-
-    string filename = REST_USER_PATH + "/download/curl.out";
-
-    /* In windows, this will init the winsock stuff */
-    curl_global_init(CURL_GLOBAL_ALL);
-
-    FILE* f = fopen(filename.c_str(), "wt");
-
-    std::string request = "";
-    for (unsigned int n = 0; n < keys.size(); n++) {
-        if (n > 0) request += "&";
-        request += keys[n] + "=" + values[n];
-    }
-    cout << request << endl;
-    /* get a curl handle */
-    curl = curl_easy_init();
-    if (curl) {
-        /* First set the URL that is about to receive our POST. This URL can
-           just as well be a https:// URL if that is what should receive the
-           data. */
-        curl_easy_setopt(curl, CURLOPT_URL, "https://henke.lbl.gov/cgi-bin/laymir.pl");
-        curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void*)f);
-        /* Now specify the POST data */
-        curl_easy_setopt(curl, CURLOPT_POSTFIELDS, request.c_str());
-
-        /* Perform the request, res will get the return code */
-        res = curl_easy_perform(curl);
-        /* Check for errors */
-        if (res != CURLE_OK) ferr << "curl_easy_perform() failed: " << curl_easy_strerror(res) << endl;
-
-        /* always cleanup */
-        curl_easy_cleanup(curl);
-    }
-    fclose(f);
-    curl_global_cleanup();
-
-    std::getline(std::ifstream(filename), file_content, '\0');
-
-    return 0;
+int TRestTools::POSTRequest(const std::string& url, const std::map<std::string, std::string>& parameters) {
+    cpr::Response r = cpr::Post(cpr::Url{url}, parameters);
+    r.status_code;  // if it's not 200 something probably went wrong
+    return r.text;  // JSON text string
 }
 
 ///////////////////////////////////////////////

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -43,6 +43,7 @@
 ///
 #include "TRestTools.h"
 
+#include <cpr/cpr.h>
 #include <dirent.h>
 
 #include <iostream>
@@ -54,8 +55,6 @@
 #include "TRestStringOutput.h"
 #include "TSystem.h"
 #include "TUrl.h"
-
-#include <curl/curl.h>
 
 ClassImp(TRestTools);
 
@@ -830,7 +829,7 @@ int TRestTools::POSTRequest(std::string& file_content, std::vector<std::string> 
 
 ///////////////////////////////////////////////
 /// Upload the local file to remote file, method url will overwrite the login information
-/// inside remotefile.
+/// inside remote file.
 ///
 /// Example: UploadToServer("/home/nkx/abc.txt", "https://sultan.unizar.es/gasFiles/gases.rml",
 /// "ssh://nkx:M123456@:8322") Then, the local file abc.txt will be uploaded to the server, renamed to


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![11](https://badgen.net/badge/Size/11/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-jgalan_tools_post/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-jgalan_tools_post)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I added this library via cmake to handle `http` requests so we don't need to force the user to install external dependencies.

It looks like there is some problem on the cmake however, I think due to the `COMPILELIB()` macro...