### PR TITLE
Encapsulating the use of CURL libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -75,7 +75,14 @@ find_package(ROOT REQUIRED COMPONENTS ${ROOT_REQUIRED_LIBRARIES})
 
 message(STATUS "ROOT LIBRARIES: ${ROOT_LIBRARIES}")
 
-set(external_libs "${external_libs};${ROOT_LIBRARIES};-lcurl")
+set(external_libs "${external_libs};${ROOT_LIBRARIES}")
+
+find_library ( CURL_LIB curl )
+if( NOT "${CURL_LIB}" MATCHES "NOTFOUND")
+	add_definitions(-DUSE_Curl)
+	message ( STATUS "Found CURL: ${CURL_LIB}" )
+	set(external_libs "${external_libs};-lcurl")
+endif( NOT "${CURL_LIB}" MATCHES "NOTFOUND")
 
 set(ROOTCINT_EXECUTABLE ${ROOT_rootcint_CMD})
 

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -839,6 +839,8 @@ int TRestTools::DownloadRemoteFile(string remoteFile, string localFile) {
 /// by argument, and returns the result as a string.
 ///
 std::string TRestTools::POSTRequest(const std::string& url, const std::map<std::string, std::string>& keys) {
+    std::string file_content = "";
+#ifdef USE_Curl
     CURL* curl;
     CURLcode res;
 
@@ -878,8 +880,13 @@ std::string TRestTools::POSTRequest(const std::string& url, const std::map<std::
     fclose(f);
     curl_global_cleanup();
 
-    std::string file_content = "";
     std::getline(std::ifstream(filename), file_content, '\0');
+#else
+    ferr << "TRestTools::POSTRequest. REST framework was compiled without CURL support" << endl;
+    ferr << "Please recompile REST after installing curl development libraries." << endl;
+    ferr << "Depending on your system this might be: curl-dev, curl-devel or libcurl-openssl-dev. " << endl;
+    ferr << "No file will be downloaded" << endl;
+#endif
 
     return file_content;
 }


### PR DESCRIPTION
We recently included dependency with curl libraries.

Inside this PR I am encapsulating the methods using CURL so that if no curl libraries have been installed in the system the CURL functions used in the code are bypassed.

Perhaps cmake gurus prefer a different add-on. In that case, please do not hesitate to commit any changes here.

@rest-for-physics/core_dev
