### PR TITLE
restRoot.cxx adding TRestPhysics.h and TRestStringHelper.h

### DIFF
--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -63,6 +63,9 @@ int main(int argc, char* argv[]) {
 
     // load rest library and macros
     TRestTools::LoadRESTLibrary(silent);
+
+    gROOT->ProcessLine("#include <TRestStringHelper.h>");
+    gROOT->ProcessLine("#include <TRestPhysics.h>");
     if (loadMacros) {
         if (!silent) printf("= Loading macros ...\n");
         auto a = TRestTools::Execute(


### PR DESCRIPTION
A minor PR to include automatically `REST_Physics` and `REST_StringHelper` namespace into the `restRoot` interactive shell.