### PR TITLE
Removing override, looks problematic with root

### DIFF
--- a/source/framework/core/inc/TRestVolumeHits.h
+++ b/source/framework/core/inc/TRestVolumeHits.h
@@ -46,10 +46,10 @@ class TRestVolumeHits : public TRestHits {
     void SortByEnergy();
     void SwapHits(Int_t i, Int_t j);
 
-    Bool_t areXY() const override;
-    Bool_t areXZ() const override;
-    Bool_t areYZ() const override;
-    Bool_t areXYZ() const override;
+    Bool_t areXY() const;
+    Bool_t areXZ() const;
+    Bool_t areYZ() const;
+    Bool_t areXYZ() const;
 
     // Setters
 


### PR DESCRIPTION
After new changes in the code, it seems that root doesn't like `override` method, see below:

![image](https://user-images.githubusercontent.com/80903717/161924135-e887b19e-5b1c-4695-bda3-c2c145ef7149.png)

Fix this error by removing `override` from `TRestVolumeHits`
