### PR TITLE
Jgalan run members

### DIFF
--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -17,24 +17,44 @@ class TRestEventProcess;
 /// Data provider and manager in REST
 class TRestRun : public TRestMetadata {
    protected:
-    // run info
-    Int_t fRunNumber;  //< first identification number
-    Int_t fParentRunNumber;
-    TString fRunClassName;
-    TString fRunType;  //< Stores bit by bit the type of run. e.g. calibration, background, pedestal,
-                       // simulation, data taking
-    TString fRunUser;  //< To identify the author it has created the run. It might be also a word describing
-                       // the origin of the run (I.e. REST_Prototype, T-REX, etc)
-    TString fRunTag;   //< A tag to be written to the output file
-    TString fRunDescription;  //< A word or sentence describing the run (I.e. Fe55 calibration, cosmics, etc)
+    /// The primary run identification number
+    Int_t fRunNumber;  //<
+
+    /// Parent run number of subrun number
+    Int_t fParentRunNumber;  //<
+
+    /// A string to define the run type to the user convenience: restG4, data, calibration, background, etc
+    TString fRunType;
+
+    /// It identifies the user that produced the file
+    TString fRunUser;  //<
+
+    /// A run tag or keyword describing the data that contains this run: Co60_Neon_1bar, Pb210_Argon_10bar
+    TString fRunTag;  //<
+
+    /// A more detailed description of the contents of this run
+    TString fRunDescription;  //<
+
+    /// The name of the project or experiment this run belongs to: IAXO, TREX-DM, PandaX-III, R&D-micromegas
     TString fExperimentName;
 
-    // program data
-    TString fInputFileName;
+    /// The input filename in the case that the run contains already processed data
+    TString fInputFileName;  //<
+
+    /// The output filename. It should match the name of the file where this run is stored
     TString fOutputFileName;
-    Double_t fStartTime;  ///< Event absolute starting time/date (unix timestamp)
-    Double_t fEndTime;    ///< Event absolute ending time/date (unix timestamp)
-    Int_t fEntriesSaved;
+
+    /// Event absolute starting time/date (unix timestamp)
+    Double_t fStartTime;  //<
+
+    /// Event absolute ending time/date (unix timestamp)
+    Double_t fEndTime;  //<
+
+    /// Number of entries found inside the event and analysis tree
+    Int_t fEntriesSaved;  //<
+
+    /// The effective run duration in seconds
+    Double_t fRunDuration = 0;  //<
 
     // data-like metadata objects
     std::vector<TRestMetadata*> fMetadata;       //!
@@ -252,7 +272,7 @@ class TRestRun : public TRestMetadata {
     TRestRun(const std::string& filename);
     ~TRestRun();
 
-    ClassDef(TRestRun, 5);
+    ClassDef(TRestRun, 6);
 };
 
 #endif

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -164,6 +164,7 @@ void TRestRun::InitFromConfigFile() {
         fRunNumber = atoi(runNstr.c_str());
         fStartTime = gDataBase->query_run(fRunNumber).tstart;
         fEndTime = gDataBase->query_run(fRunNumber).tend;
+        fRunDuration = fEndTime - fStartTime;
     }
 
     if (ToUpper(inputname) == "AUTO") {
@@ -624,6 +625,7 @@ void TRestRun::ReadFileInfo(const string& filename) {
     fclose(fp);
     if (fEndTime == 0) {
         fEndTime = buf.st_mtime;
+        fRunDuration = fEndTime - fStartTime;
     }
 
     if (TRestTools::isRootFile((string)filename)) {
@@ -1006,6 +1008,7 @@ void TRestRun::WriteWithDataBase() {
         time_t timev;
         time(&timev);
         fEndTime = (Double_t)timev;
+        fRunDuration = fEndTime - fStartTime;
     }
 
     fRunUser = REST_USER;
@@ -1251,7 +1254,7 @@ Double_t TRestRun::GetRunLength() const {
     if (fEndTime - fStartTime == -1) {
         cout << "Run time is not set\n";
     }
-    return fEndTime - fStartTime;
+    return fRunDuration;
 }
 
 Long64_t TRestRun::GetTotalBytes() {

--- a/source/framework/tools/src/TRestSystemOfUnits.cxx
+++ b/source/framework/tools/src/TRestSystemOfUnits.cxx
@@ -251,6 +251,13 @@ double _AddUnit(string name, int type, double scale) {
 ///
 TRestSystemOfUnits::TRestSystemOfUnits(string unitsStr) {
     unitsStr = Trim(unitsStr);
+
+    // We skip for the moment parameters/fields that contain elements {,,,}.
+    if (unitsStr.find("{") != string::npos || unitsStr.find("}") != string::npos) {
+        fZombie = true;
+        return;
+    }
+
     if (unitsStr == "") {
         fZombie = true;
         return;


### PR DESCRIPTION
A major update adding a NEW metadata member inside TRestRun and REMOVING an unused data member,

This might cause issues. It would be a good moment to integrate a validation pipeline reading existing ROOT files generated with previous versions of the code.

@rest-for-physics/core_dev 