### PR TITLE
Update TRestEventRateAnalysisProcess.cxx

### DIFF
--- a/source/framework/analysis/src/TRestEventRateAnalysisProcess.cxx
+++ b/source/framework/analysis/src/TRestEventRateAnalysisProcess.cxx
@@ -29,7 +29,7 @@
 ///  as follows:
 ///
 /// \code
-/// <addProcess type="TRestEventRateAnalysisProcess" name="rate" observables="all" />
+/// <addProcess type="TRestEventRateAnalysisProcess" name="rate" observable="all" />
 /// \endcode
 ///
 /// or


### PR DESCRIPTION
![DavidDiezIb](https://badgen.net/badge/PR%20submitted%20by%3A/DavidDiezIb/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/DavidDiezIb-documentation-bug/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/DavidDiezIb-documentation-bug)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Member inside process should be `observable` instead of observables. Changed in documentation.