### PR TITLE
TRestTools. Adding forgotten USE_Curl encapsulation

### DIFF
--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -43,7 +43,9 @@
 ///
 #include "TRestTools.h"
 
+#ifdef USE_Curl
 #include <curl/curl.h>
+#endif
 #include <dirent.h>
 
 #include <chrono>


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_curl_encapsulation/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_curl_encapsulation)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixing a problem when no CURL libraries are present.