### PR TITLE
Using proper types after `std::string.find`

### DIFF
--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -632,8 +632,8 @@ string TRestTools::GetFileNameExtension(string fullname) {
 /// Input: "/home/jgalan/abc.txt" Output: "abc"
 ///
 string TRestTools::GetFileNameRoot(string fullname) {
-    int pos1 = fullname.find_last_of('/', -1);
-    int pos2 = fullname.find_last_of('.', -1);
+    size_t pos1 = fullname.find_last_of('/', -1);
+    size_t pos2 = fullname.find_last_of('.', -1);
 
     if (pos1 != string::npos && pos2 != string::npos) return fullname.substr(pos1 + 1, pos2 - pos1 - 1);
 


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/juanangp-patch-1/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/juanangp-patch-1)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Minor code update suggestion for https://github.com/rest-for-physics/framework/pull/184
