### PR TITLE
Minor updates for TRestGDMLParser

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -87,7 +87,7 @@ Build and Test:
     - cmake ${CI_PROJECT_DIR}
       -DTEST=ON -DREST_GARFIELD=OFF -DREST_G4=ON -DRESTLIB_DETECTOR=ON -DRESTLIB_RAW=ON -DRESTLIB_TRACK=ON
     - make -j2
-    - ctest --verbose -O ${CI_PROJECT_DIR}/build/Testing/summary.txt
+    - ctest --output-on-failure -O ${CI_PROJECT_DIR}/build/Testing/summary.txt
 
   artifacts:
     name: "Testing"

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -9,13 +9,6 @@ if (TEST)
     add_compile_definitions(REST_TESTING_ENABLED)
 endif ()
 
-macro(ADD_TEST)
-    if (TEST)
-        message(STATUS "Adding tests at ${CMAKE_CURRENT_SOURCE_DIR}")
-        add_subdirectory(test)
-    endif ()
-endmacro()
-
 macro(ADD_LIBRARY_TEST)
     if (TEST)
         message(STATUS "Adding tests at ${CMAKE_CURRENT_SOURCE_DIR}")
@@ -31,13 +24,9 @@ macro(ADD_LIBRARY_TEST)
 
         enable_testing()
 
-        add_executable(${TESTING_EXECUTABLE})
-
         FILE(GLOB SOURCES ${CMAKE_CURRENT_SOURCE_DIR}/test/src/*.cxx)
-        target_sources(
-                ${TESTING_EXECUTABLE} PUBLIC
-                ${SOURCES}
-        )
+
+        add_executable(${TESTING_EXECUTABLE} ${SOURCES})
 
         target_link_libraries(
                 ${TESTING_EXECUTABLE} PUBLIC

--- a/cmake/Testing.cmake
+++ b/cmake/Testing.cmake
@@ -38,7 +38,9 @@ macro(ADD_LIBRARY_TEST)
 
         include(GoogleTest)
 
-        gtest_discover_tests(${TESTING_EXECUTABLE})
-
+        gtest_add_tests(
+                TARGET ${TESTING_EXECUTABLE}
+                SOURCES ${SOURCES}
+        )
     endif ()
 endmacro()

--- a/cmake/thisREST.cmake
+++ b/cmake/thisREST.cmake
@@ -15,7 +15,7 @@ string(REGEX REPLACE "\n$" "" GEANT4_PATH "${GEANT4_PATH}")
 set(thisGeant4 "${GEANT4_PATH}/bin/geant4.sh")
 
 if (${REST_G4} MATCHES "ON")
-    set(loadG4 "\# if geant4.sh script is found we load the same Geant4 version as used in compilation\n if [[ -f \"${thisGeant4}\" && ${thisGeant4} != /usr/* ]]; then
+    set(loadG4 "\# if geant4.sh script is found we load the same Geant4 version as used in compilation\n if [[ -f \\\"${thisGeant4}\\\" && ${thisGeant4} != /usr/* ]]; then
 		source ${thisGeant4}\n fi\n")
 else ()
     set(loadG4 "")

--- a/pipeline/pandaxiii_MC/Xe136bb0n.rml
+++ b/pipeline/pandaxiii_MC/Xe136bb0n.rml
@@ -22,8 +22,8 @@
   </TRestRun>
 
   <TRestGeant4Metadata name="restG4 Simulation run" title="Simulation of Xe136bb0n decay from gas.">
-    <!-- <parameter name="Nevents" value="1000000"/>-->
-    <parameter name="Nevents" value="500"/>
+    <!-- <parameter name="nEvents" value="1000000"/>-->
+    <parameter name="nEvents" value="500"/>
     <parameter name="gdml_file" value="geometry/main.gdml"/>
     <parameter name="subEventTimeDelay" value="100us" />
     <parameter name="seed" value="1" />

--- a/pipeline/pandaxiii_MC/Xe136bb0n.rml
+++ b/pipeline/pandaxiii_MC/Xe136bb0n.rml
@@ -24,7 +24,7 @@
   <TRestGeant4Metadata name="restG4 Simulation run" title="Simulation of Xe136bb0n decay from gas.">
     <!-- <parameter name="nEvents" value="1000000"/>-->
     <parameter name="nEvents" value="500"/>
-    <parameter name="gdml_file" value="geometry/main.gdml"/>
+    <parameter name="gdmlFile" value="geometry/main.gdml"/>
     <parameter name="subEventTimeDelay" value="100us" />
     <parameter name="seed" value="1" />
 

--- a/pipeline/pandaxiii_MC/geometry/Th232_SS_01.rml
+++ b/pipeline/pandaxiii_MC/geometry/Th232_SS_01.rml
@@ -26,7 +26,7 @@
 
   <TRestGeant4Metadata name="restG4 Simulation run" title="Simulation of Th232 decay from vessel.">
 
-    <parameter name="Nevents" value="4000000"/>
+    <parameter name="nEvents" value="4000000"/>
     <parameter name="gdml_file" value="/home/zhoubugao/REST/geometry_bgzou/main.gdml"/>
     <parameter name="maxTargetStepSize" value="500" units="um" />
     <parameter name="subEventTimeDelay" value="100" units="us" />

--- a/pipeline/pandaxiii_MC/geometry/Th232_SS_01.rml
+++ b/pipeline/pandaxiii_MC/geometry/Th232_SS_01.rml
@@ -27,7 +27,7 @@
   <TRestGeant4Metadata name="restG4 Simulation run" title="Simulation of Th232 decay from vessel.">
 
     <parameter name="nEvents" value="4000000"/>
-    <parameter name="gdml_file" value="/home/zhoubugao/REST/geometry_bgzou/main.gdml"/>
+    <parameter name="gdmlFile" value="/home/zhoubugao/REST/geometry_bgzou/main.gdml"/>
     <parameter name="maxTargetStepSize" value="500" units="um" />
     <parameter name="subEventTimeDelay" value="100" units="us" />
 

--- a/source/framework/core/inc/TRestGDMLParser.h
+++ b/source/framework/core/inc/TRestGDMLParser.h
@@ -39,6 +39,9 @@ class TRestGDMLParser : public TRestMetadata {
     }
 
     TGeoManager* CreateGeoManager();
+    [[deprecated("Use CreateGeoManager() instead.")]] inline TGeoManager* CreateGeoM() {
+        return CreateGeoManager();
+    }
 
     void InitFromConfigFile() override {}
 

--- a/source/framework/core/inc/TRestGDMLParser.h
+++ b/source/framework/core/inc/TRestGDMLParser.h
@@ -13,30 +13,30 @@
 
 class TRestGDMLParser : public TRestMetadata {
    private:
-    TGeoManager* fGeo;
+    TGeoManager* fGeoManager;
 
    public:
     TRestGDMLParser() {}
     ~TRestGDMLParser() {}
-    std::string filestr = "";
-    std::string path = "";
-    std::string outPath = REST_USER_PATH + "/gdml/";
-    std::string outfilename = "";
-    std::string gdmlVersion = "0.0";
-    std::map<std::string, std::string> entityVersion;
+    std::string fFileString;
+    std::string fPath;
+    std::string fOutputGdmlDirectory = REST_USER_PATH + "/gdml/";
+    std::string fOutputGdmlFilename;
+    std::string fGdmlVersion = "0.0";
+    std::map<std::string, std::string> fEntityVersionMap;
 
-    std::string GetEntityVersion(std::string name);
+    std::string GetEntityVersion(const std::string& name) const;
 
-    std::string GetGDMLVersion();
+    inline std::string GetGDMLVersion() const { return fGdmlVersion; }
 
-    std::string GetOutputGDMLFile();
+    inline std::string GetOutputGDMLFile() const { return fOutputGdmlFilename; }
 
-    void Load(std::string file);
+    void Load(const std::string& filename);
 
-    TGeoManager* GetGeoManager(std::string gdmlFile) {
-        Load(gdmlFile);
-        fGeo = TGeoManager::Import(GetOutputGDMLFile().c_str());
-        return fGeo;
+    inline TGeoManager* GetGeoManager(const std::string& gdmlFilename) {
+        Load(gdmlFilename);
+        fGeoManager = TGeoManager::Import(GetOutputGDMLFile().c_str());
+        return fGeoManager;
     }
 
     TGeoManager* CreateGeoM();
@@ -49,7 +49,7 @@ class TRestGDMLParser : public TRestMetadata {
 
     void ReplaceAttributeWithKeyWord(std::string keyword);
 
-    ClassDef(TRestGDMLParser, 1);
+    ClassDef(TRestGDMLParser, 2);
 };
 
 #endif

--- a/source/framework/core/inc/TRestGDMLParser.h
+++ b/source/framework/core/inc/TRestGDMLParser.h
@@ -7,23 +7,22 @@
 
 #include "TRestMetadata.h"
 
-///////////////////////////////////////////
 // we must preprocess gdml file because of a bug in TGDMLParse::Value() in ROOT6
-//
 
 class TRestGDMLParser : public TRestMetadata {
    private:
-    TGeoManager* fGeoManager;
+    TGeoManager* fGeoManager{};
 
    public:
-    TRestGDMLParser() {}
-    ~TRestGDMLParser() {}
-    std::string fFileString;
-    std::string fPath;
-    std::string fOutputGdmlDirectory = REST_USER_PATH + "/gdml/";
-    std::string fOutputGdmlFilename;
+    TRestGDMLParser() = default;
+    ~TRestGDMLParser() = default;
+
+    std::string fFileString = "";
+    std::string fPath = "";
+    std::string fOutputGdmlDirectory = REST_USER_PATH.empty() ? "/tmp/gdml/" : REST_USER_PATH + "/gdml/";
+    std::string fOutputGdmlFilename = "";
     std::string fGdmlVersion = "0.0";
-    std::map<std::string, std::string> fEntityVersionMap;
+    std::map<std::string, std::string> fEntityVersionMap{};
 
     std::string GetEntityVersion(const std::string& name) const;
 
@@ -41,7 +40,7 @@ class TRestGDMLParser : public TRestMetadata {
 
     TGeoManager* CreateGeoM();
 
-    void InitFromConfigFile() {}
+    void InitFromConfigFile() override {}
 
     void PrintContent();
 

--- a/source/framework/core/inc/TRestGDMLParser.h
+++ b/source/framework/core/inc/TRestGDMLParser.h
@@ -38,7 +38,7 @@ class TRestGDMLParser : public TRestMetadata {
         return fGeoManager;
     }
 
-    TGeoManager* CreateGeoM();
+    TGeoManager* CreateGeoManager();
 
     void InitFromConfigFile() override {}
 
@@ -46,9 +46,9 @@ class TRestGDMLParser : public TRestMetadata {
 
     void ReplaceEntity();
 
-    void ReplaceAttributeWithKeyWord(std::string keyword);
+    void ReplaceAttributeWithKeyWord(const std::string& keyword);
 
-    ClassDef(TRestGDMLParser, 2);
+    ClassDefOverride(TRestGDMLParser, 2);
 };
 
 #endif

--- a/source/framework/core/src/TRestGDMLParser.cxx
+++ b/source/framework/core/src/TRestGDMLParser.cxx
@@ -31,7 +31,7 @@ void TRestGDMLParser::Load(const string& filename) {
 
         fFileString = ReplaceConstants(ReplaceVariables(fFileString));
 
-        cout << "GDML: initializating variables" << endl;
+        cout << "TRestGDMLParser: initializing variables" << endl;
         int pos = fFileString.find("<gdml", 0);
         if (pos != -1) {
             string elementstr = fFileString.substr(pos, -1);
@@ -42,7 +42,7 @@ void TRestGDMLParser::Load(const string& filename) {
             LoadSectionMetadata();
         }
 
-        cout << "GDML: replacing expressions in GDML" << endl;
+        cout << "TRestGDMLParser: replacing expressions in GDML" << endl;
         ReplaceEntity();
         fFileString = Replace(fFileString, "= \"", "=\"");
         fFileString = Replace(fFileString, " =\"", "=\"");
@@ -59,7 +59,7 @@ void TRestGDMLParser::Load(const string& filename) {
         string fname = TRestTools::SeparatePathAndName(filenameAbsolute).second;
         // we have to use a unique identifier on the file to prevent collision when launching multiple jobs
         fOutputGdmlFilename = fOutputGdmlDirectory + "PID" + std::to_string(getpid()) + "_" + fname;
-        cout << "GDML: creating temporary file at: \"" << fOutputGdmlFilename << "\"" << endl;
+        cout << "TRestGDMLParser: creating temporary file at: \"" << fOutputGdmlFilename << "\"" << endl;
 
         outf.open(fOutputGdmlFilename, ios::trunc);
         outf << fFileString << endl;
@@ -100,14 +100,14 @@ void TRestGDMLParser::ReplaceEntity() {
         int pos4 = fFileString.find("\"", pos3);
         string entityfile = RemoveWhiteSpaces(fFileString.substr(pos3, pos4 - pos3));
 
-        cout << "GDML: replacing entitiy: " << entityName << ", file: " << entityfile << endl;
+        cout << "TRestGDMLParser: replacing entitiy: " << entityName << ", file: " << entityfile << endl;
 
         if ((int)entityfile.find("http") != -1) {
             string entityfiledl =
                 fOutputGdmlDirectory + "PID" + std::to_string(getpid()) + "_" + entityName + ".xml";
             int a = TRestTools::DownloadRemoteFile(entityfile, entityfiledl);
             if (a != 0) {
-                cout << "GDML: Download failed!" << endl;
+                cout << "TRestGDMLParser: Download failed!" << endl;
                 exit(1);
             }
             entityfile = entityfiledl;
@@ -141,7 +141,7 @@ void TRestGDMLParser::ReplaceEntity() {
                 exit(0);
             }
         } else {
-            cout << "GDML: Warning! redundant entity: \"" << entityName << "\"" << endl;
+            cout << "TRestGDMLParser: Warning! redundant entity: \"" << entityName << "\"" << endl;
         }
         pos++;
     }

--- a/source/framework/core/src/TRestGDMLParser.cxx
+++ b/source/framework/core/src/TRestGDMLParser.cxx
@@ -60,15 +60,15 @@ void TRestGDMLParser::Load(string file) {
         ReplaceAttributeWithKeyWord("log(");
         ReplaceAttributeWithKeyWord("exp(");
 
-        cout << "GDML: creating temporary file" << endl;
         ofstream outf;
         string fname = TRestTools::SeparatePathAndName(file).second;
         // we have to use a unique identifier on the file to prevent collision when launching multiple jobs
         outfilename = outPath + "PID" + std::to_string(getpid()) + "_" + fname;
+        cout << "GDML: creating temporary file at: \"" << outfilename << "\"" << endl;
+
         outf.open(outfilename, ios::trunc);
         outf << filestr << endl;
         outf.close();
-        // getchar();
 
     } else {
         ferr << "Filename : " << file << endl;

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -113,18 +113,18 @@
 /// If no arguments are provided, LoadConfigFromFile() will only call the Initialize()
 /// method. If given the rml file name, it will find out the needed rml sections. We
 /// can also directly give the xml sections to the method. Two xml sections are used
-/// to startup the class: the section for the class and a global section. Additionaly
+/// to startup the class: the section for the class and a global section. Additionally
 /// we can give a map object to the method to import additional variables.
 ///
 /// The "section for the class" is an xml section with the value of class name.
-/// It is the main information souce for the class's startup. The "global"
+/// It is the main information source for the class's startup. The "global"
 /// section is a special xml section in the rml file, containing global information
 /// which could be seen by all the class sections.
 ///
 /// With the xml sections given, LoadConfigFromFile() first merge them together. Then it
 /// calls LoadSectionMetadata(), which loads some universal parameters like
 /// name, title and verbose level. This method also preprocesses the config
-/// sections, expanding the include/for decinition and replacing the variables.
+/// sections, expanding the include/for definition and replacing the variables.
 /// After this, LoadConfigFromFile() calls the method InitFromConfigFile().
 ///
 /// **InitFromConfigFile()** is a pure virtual method and every child classes have
@@ -1269,7 +1269,7 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
 /// If still not found, it returns the default value.
 ///
 /// \param parName The name of the parameter from which we want to obtain the
-/// value. \param defaultValue The default value if the paremeter is not found
+/// value. \param defaultValue The default value if the parameter is not found
 ///
 /// \return A string of result
 string TRestMetadata::GetParameter(std::string parName, TString defaultValue) {
@@ -1307,7 +1307,7 @@ string TRestMetadata::GetParameter(std::string parName, TString defaultValue) {
 ///
 /// \param parName The name of the parameter from which we want to obtain the
 /// value. \param e The target eml element where the program is to search the
-/// parameter \param defaultValue The default value if the paremeter is not
+/// parameter \param defaultValue The default value if the parameter is not
 /// found
 ///
 /// \return A string of result, with env and expressions replaced

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -515,8 +515,8 @@ TRestMetadata::TRestMetadata(const char* cfgFileName) : endl(this) {
 /// \brief TRestMetadata default destructor
 ///
 TRestMetadata::~TRestMetadata() {
-    if (fElementGlobal) delete fElementGlobal;
-    if (fElement) delete fElement;
+    delete fElementGlobal;
+    delete fElement;
 }
 
 ///////////////////////////////////////////////
@@ -564,7 +564,7 @@ Int_t TRestMetadata::LoadConfigFromFile(string cfgFileName, string sectionName) 
         delete rootEle;
         return result;
     } else {
-        ferr << "Filename : " << fConfigFileName << endl;
+        ferr << "Filename: " << fConfigFileName << endl;
         ferr << "Config File does not exist. Right path/filename?" << endl;
         GetChar();
         return -1;
@@ -628,7 +628,7 @@ Int_t TRestMetadata::LoadConfigFromBuffer() {
 ///////////////////////////////////////////////
 /// \brief This method does some preparation of xml section.
 ///
-/// Preparation includes: seting the name, title and verbose level of the
+/// Preparation includes: setting the name, title and verbose level of the
 /// current class. Finding out and saving the env sections.
 ///
 /// By calling TRestMetadata::ReadElement(), is also expands for loops and

--- a/source/framework/test/src/FrameworkCore.cxx
+++ b/source/framework/test/src/FrameworkCore.cxx
@@ -9,26 +9,26 @@ namespace fs = std::filesystem;
 
 using namespace std;
 
-#define FILES_PATH fs::path(__FILE__).parent_path().parent_path() / "files"
-#define BASIC_TRESTRUN_RML FILES_PATH / "TRestRunBasic.rml"
-#define BASIC_TRESTMETADATA_RML FILES_PATH / "TRestMetadataTest.rml"
+const auto filesPath = fs::path(__FILE__).parent_path().parent_path() / "files";
+const auto basicRunRml = filesPath / "TRestRunBasic.rml";
+const auto basicMetadataRml = filesPath / "TRestMetadataTest.rml";
 
 TEST(FrameworkCore, TestFiles) {
-    cout << "FrameworkCore test files path: " << FILES_PATH << endl;
+    cout << "FrameworkCore test files path: " << filesPath << endl;
 
     // Check dir exists and is a directory
-    EXPECT_TRUE(fs::is_directory(FILES_PATH));
+    EXPECT_TRUE(fs::is_directory(filesPath));
     // Check it's not empty
-    EXPECT_TRUE(!fs::is_empty(FILES_PATH));
+    EXPECT_TRUE(!fs::is_empty(filesPath));
     // Check required files exist
-    EXPECT_TRUE(fs::exists(BASIC_TRESTRUN_RML));
-    EXPECT_TRUE(fs::exists(BASIC_TRESTMETADATA_RML));
+    EXPECT_TRUE(fs::exists(basicRunRml));
+    EXPECT_TRUE(fs::exists(basicMetadataRml));
 }
 
 TEST(FrameworkCore, TRestRun) {
     TRestRun run;
 
-    run.LoadConfigFromFile(BASIC_TRESTRUN_RML);
+    run.LoadConfigFromFile(basicRunRml);
 
     run.PrintAllMetadata();
 
@@ -50,7 +50,7 @@ TEST(FrameworkCore, TRestMetadata) {
     };
 
     TRestMetadataTest restMetadataTest;
-    restMetadataTest.LoadConfigFromFile(BASIC_TRESTMETADATA_RML, "TRestMetadataTest");
+    restMetadataTest.LoadConfigFromFile(basicMetadataRml, "TRestMetadataTest");
 
     restMetadataTest.PrintMetadata();
 

--- a/source/framework/tools/src/TRestStringHelper.cxx
+++ b/source/framework/tools/src/TRestStringHelper.cxx
@@ -486,7 +486,7 @@ Float_t REST_StringHelper::StringToFloat(string in) {
 /// \brief Gets an integer from a string.
 ///
 Int_t REST_StringHelper::StringToInteger(string in) {
-    // If we find an hexadecimal number
+    // If we find a hexadecimal number
     if (in.find("0x") != std::string::npos) return (Int_t)std::stoul(in, nullptr, 16);
 
     return (Int_t)StringToDouble(in);


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Medium: 147](https://badgen.net/badge/PR%20Size/Medium%3A%20147/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-activeVolume-43/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-activeVolume-43)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

* Related to https://github.com/rest-for-physics/restG4/issues/43
* Replaces Nevents by nEvents in RML files (Nevents still works) for consistency
* Replaces gdml_file by gdmlFile in RML files (gdml_file still works) for consistency

TRestGDMLParser:
* Renamed members for consistency (starting with `f`...)
* Made some methods parameters by const ref.
* When USER is not defined, will save temporary gdml file to `/tmp` directory instead of failing
* Includes <filesystem> header to create directory recursively if not exists
* Other minor changes