### PR TITLE
Improving clang formatting

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -126,6 +126,9 @@ string(TIMESTAMP date "%Y-%m-%d %H:%M")
 # Enable testing (-DTEST=ON flag, it is OFF by default)
 include(Testing)
 
+# Includes githooks, now using clang-format
+include(GitHooks)
+
 # Start compile
 include(MacroRootDict)
 add_subdirectory(source)

--- a/cmake/GitHooks.cmake
+++ b/cmake/GitHooks.cmake
@@ -9,7 +9,7 @@ endif ()
 # Installing clang-format pre-commit hook if prerequisites are met and it doesn't exist yet.
 
 if (NOT EXISTS ${PROJECT_SOURCE_DIR}/.git)
-    message(WARNING ".git directory not found at the root of the repository (${PROJECT_SOURCE_DIR}), skipping formatting in pre-commit hook")
+    message(WARNING ".git directory not found at the root of the repository (${PROJECT_SOURCE_DIR}), skipping formatting in pre-commit hook. Perhaps you are compiling in a remote host?")
     return()
 endif ()
 

--- a/cmake/GitHooks.cmake
+++ b/cmake/GitHooks.cmake
@@ -1,0 +1,18 @@
+
+if(NOT GIT_FOUND)
+  find_package(Git QUIET)
+endif()
+
+if(NOT CLANG_FORMAT)
+  find_program(CLANG_FORMAT clang-format)
+endif()
+
+# Installing clang-format precommit hook if prerequisites are met and it doesn't
+# exist yet.
+if(GIT_FOUND AND CLANG_FORMAT AND EXISTS ${PROJECT_SOURCE_DIR}/.git AND
+   NOT EXISTS ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
+
+   # We cannot write the file from here because we need exec permissions
+   configure_file(${CMAKE_SOURCE_DIR}/cmake/utils/git_pre-commit.in
+                  ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
+endif()

--- a/cmake/GitHooks.cmake
+++ b/cmake/GitHooks.cmake
@@ -1,18 +1,23 @@
 
-if(NOT GIT_FOUND)
-  find_package(Git QUIET)
-endif()
+find_program(clang-format QUIET)
 
-if(NOT CLANG_FORMAT)
-  find_program(CLANG_FORMAT clang-format)
-endif()
+if (clang-format_NOTFOUND)
+    message(WARNING "clang-format not found, skipping formatting in pre-commit hook")
+    return()
+endif ()
 
-# Installing clang-format precommit hook if prerequisites are met and it doesn't
-# exist yet.
-if(GIT_FOUND AND CLANG_FORMAT AND EXISTS ${PROJECT_SOURCE_DIR}/.git AND
-   NOT EXISTS ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
+# Installing clang-format pre-commit hook if prerequisites are met and it doesn't exist yet.
 
-   # We cannot write the file from here because we need exec permissions
-   configure_file(${CMAKE_SOURCE_DIR}/cmake/utils/git_pre-commit.in
-                  ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
-endif()
+if (NOT EXISTS ${PROJECT_SOURCE_DIR}/.git)
+    message(WARNING ".git directory not found at the root of the repository (${PROJECT_SOURCE_DIR}), skipping formatting in pre-commit hook")
+    return()
+endif ()
+
+if (EXISTS ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
+    message(DEBUG "git hook found at ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit")
+    return()
+endif ()
+
+# We cannot write the file from here because we need exec permissions
+configure_file(${CMAKE_SOURCE_DIR}/cmake/utils/git_pre-commit.in ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
+

--- a/cmake/utils/git_pre-commit.in
+++ b/cmake/utils/git_pre-commit.in
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+STYLE=$PWD/.clang-format
+echo "$STYLE"
+if [ -n "$STYLE" ] ; then
+  STYLEARG="-style=file"
+else
+  STYLEARG=""
+fi
+
+format_file() {
+  file="$1"
+  if [ -f $file ]; then
+    clang-format -i $STYLEARG $1
+    git add $1
+  fi
+}
+
+case "${1}" in
+  --about )
+    echo "Runs clang-format on source files"
+    ;;
+  * )
+    for file in `git diff-index --cached --name-only HEAD | grep -iE '\.(cxx|cc|h|C)$' ` ; do
+      format_file "$file"
+    done
+    ;;
+esac

--- a/cmake/utils/git_pre-commit.in
+++ b/cmake/utils/git_pre-commit.in
@@ -2,7 +2,7 @@
 
 STYLE=$PWD/.clang-format
 echo "$STYLE"
-if [ -n "$STYLE" ] ; then
+if [ -n "$STYLE" ]; then
   STYLEARG="-style=file"
 else
   STYLEARG=""
@@ -17,12 +17,12 @@ format_file() {
 }
 
 case "${1}" in
-  --about )
-    echo "Runs clang-format on source files"
-    ;;
-  * )
-    for file in `git diff-index --cached --name-only HEAD | grep -iE '\.(cxx|cc|h|C)$' ` ; do
-      format_file "$file"
-    done
-    ;;
+--about)
+  echo "Runs clang-format on source files"
+  ;;
+*)
+  for file in $(git diff-index --cached --name-only HEAD | grep -iE '\.(cxx|cc|h|C)$'); do
+    format_file "$file"
+  done
+  ;;
 esac

--- a/scripts/reformat-clang.sh
+++ b/scripts/reformat-clang.sh
@@ -41,13 +41,27 @@ if [ $# -eq 0 ]; then
 fi
 
 pathNow=$PWD
+pathToFormat=$(readlink -f $1)
 
-for DIRECTORY in $1
-do
-    echo "Formatting code under $DIRECTORY/"
-    cd $DIRECTORY
-    echo "$DIRECTORY" \( -name '*.h' -or -name '*.cxx' -or -name '*.cc' -or -name '*.C' \) -print0 | xargs -0 "$CLANG_FORMAT" -i
-    find "$DIRECTORY" \( -name '*.h' -or -name '*.cxx' -or -name '*.cc' -or -name '*.C' \) -print0 | xargs -0 "$CLANG_FORMAT" -i
-    cd $pathNow
-    echo "DONE!"
-done
+if [ -d "$pathToFormat" ] ; then
+    echo "$pathToFormat is a directory"
+    for DIRECTORY in $pathToFormat
+    do
+      echo "Formatting code under $DIRECTORY/"
+      #find "$DIRECTORY" \( -name '*.h' -or -name '*.cxx' -or -name '*.cc' -or -name '*.C' \) -print0 | xargs -0 "$CLANG_FORMAT"
+      find "$DIRECTORY" \( -name '*.h' -or -name '*.cxx' -or -name '*.cc' -or -name '*.C' \) -print0 | xargs -0 "$CLANG_FORMAT" -i
+      echo "DONE!"
+    done
+elif [ -f "$pathToFormat" ] ; then
+   echo "$pathToFormat is a file";
+   ext="${pathToFormat##*.}"
+   #echo "$ext"
+      if [[ "$ext" == "h" || "$ext" == "cxx" || "$ext" == "cc" || "$ext" == "C" ]]; then
+         echo "$CLANG_FORMAT -i $pathToFormat"
+            eval "$CLANG_FORMAT -i $pathToFormat"
+         else
+            echo "Not valid extension $ext, valid extensions are *.h, *.cxx, *.cc and *.C"
+       fi
+else
+   echo "$pathToFormat is not valid file or directory";
+fi

--- a/source/framework/CMakeLists.txt
+++ b/source/framework/CMakeLists.txt
@@ -14,7 +14,7 @@ find_library(CURL_LIB curl)
 if (NOT ${CURL_LIB} STREQUAL "CURL_LIB-NOTFOUND")
     add_compile_definitions(USE_Curl)
     message(STATUS "Found curl library: ${CURL_LIB}")
-    set(external_libs "${external_libs};-lcurl")
+    set(external_libs "${external_libs};-lcurl;stdc++fs")
 endif ()
 
 COMPILEDIR(RestFramework)


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 87](https://badgen.net/badge/PR%20Size/Ok%3A%2087/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/clang-script/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/clang-script)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Script `reformat-clang` has been improved:
- Added `readlink` to make the script independent from the path where is launched
- Adding support for single files including file extensions `*.h`, `*.cxx`, `*.cc` and `*.C`
- Now the script check if the file or directory exists
- Removing un-necessary commands

**Added  `githook` in the `cmake`, so the `clang-format` is performed when `git commit` is issued**
- `githook` is created when `cmake` is issued and if there is no `pre-commit` present.
- Check if `clang-format` is present in the system, otherwise is skipped.
- Can be used as template to add different `githook` features.