### PR TITLE
Minor but urgent fixes

### DIFF
--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -138,6 +138,8 @@ int main(int argc, char* argv[]) {
 
             argv[i] = (char*)"";
             Nfile++;
+        } else if (TRestTools::isRootFile(opt)) {
+            printf("\nFile %s not found ... !!\n", opt.c_str());
         }
     }
 

--- a/source/framework/CMakeLists.txt
+++ b/source/framework/CMakeLists.txt
@@ -14,7 +14,7 @@ find_library(CURL_LIB curl)
 if (NOT ${CURL_LIB} STREQUAL "CURL_LIB-NOTFOUND")
     add_compile_definitions(USE_Curl)
     message(STATUS "Found curl library: ${CURL_LIB}")
-    set(external_libs "${external_libs};-lcurl;stdc++fs")
+    set(external_libs "${external_libs};-lcurl;-lstdc++fs")
 endif ()
 
 COMPILEDIR(RestFramework)

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -2218,7 +2218,8 @@ TString TRestMetadata::GetSearchPath() {
 
     if (getenv("configPath")) result += getenv("configPath") + (string) ":";
     result += REST_PATH + "/data/:";
-    // We give priority to the official /data/ path.
+    result += REST_PATH + "/examples/:";
+    // We give priority to the official /data/ and /examples/ path.
     result += REST_USER_PATH + ":";
     if (result.back() == ':') result.erase(result.size() - 1);
 

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -667,6 +667,7 @@ void TRestRun::ReadFileInfo(const string& filename) {
         int pos1 = name.find(formatprefixlist[i], pos + 1) + formatprefixlist[i].size();
         if (formatprefixlist[i] == "") pos1 = 0;
         int pos2 = name.find(formatprefixlist[i + 1], pos1);
+        if (formatprefixlist[i + 1] == "") pos2 = name.length();
         if (pos1 == -1 || pos2 == -1) {
             warning << "File pattern matching: file format mismatch!" << endl;
             return;


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 6](https://badgen.net/badge/PR%20Size/Ok%3A%206/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_minor_fixes/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_minor_fixes)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR adds the following minor changes:

- `restRoot` now will warn the user if we use `restRoot file.root` and `file.root` does not exist.
- `TRestRun::ReadFileInfo` bug fixed.
- `TRestMetadata::GetSearchPath`. Added `REST_PATH/examples` directory to the default search paths.
- `framework/CMakeList` fixed a compilation issue related to `std::filesystem`