### PR TITLE
Adding requirement for C++17

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -84,16 +84,19 @@ execute_process(COMMAND root-config --has-cxx17 OUTPUT_VARIABLE HASCXX17)
 execute_process(COMMAND root-config --has-cxx14 OUTPUT_VARIABLE HASCXX14)
 execute_process(COMMAND root-config --has-cxx11 OUTPUT_VARIABLE HASCXX11)
 
+execute_process(COMMAND root-config --cflags OUTPUT_VARIABLE ROOT_CFLAGS)
+
 set(CMAKE_CXX_STANDARD_REQUIRED YES)
 
 if (${HASCXX20} MATCHES "yes")
     set(CMAKE_CXX_STANDARD 20)
 elseif (${HASCXX17} MATCHES "yes")
     set(CMAKE_CXX_STANDARD 17)
-elseif (${HASCXX14} MATCHES "yes")
-    set(CMAKE_CXX_STANDARD 14)
-elseif (${HASCXX11} MATCHES "yes")
-    set(CMAKE_CXX_STANDARD 11)
+else ()
+    message(FATAL_ERROR "Minimum C++ standard version is 17,
+            while the root version is compiled with an older
+            C++ standard, check root-config --cflags ${ROOT_CFLAGS}"
+           )
 endif ()
 
 set(external_include_dirs ${external_include_dirs} ${ROOT_INCLUDE_DIRS})


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 7](https://badgen.net/badge/PR%20Size/Ok%3A%207/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/c++17-required/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/c++17-required)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adding requirement for `C++17` in the `CMakeLists`:
- After checking `ROOT` compilation `C++` standard, a requirement for `C++17` has been added. Note that new structure bindings have been implemented in the code, which requires `C++17` standard.