### PR TITLE
Renaming endl to RESTendl and other loggers functions

### DIFF
--- a/macros/REST_CheckRunFileList.C
+++ b/macros/REST_CheckRunFileList.C
@@ -20,7 +20,7 @@ Int_t REST_CheckRunFileList(TString namePattern, Int_t N = 100000) {
 
     vector<TString> filesNotWellClosed;
 
-    TRestStringOutput RESTcout;
+    TRestStringOutput RESTLog;
 
     string a = TRestTools::Execute((string)("ls -d -1 " + namePattern));
     vector<string> b = Split(a, "\n");
@@ -29,14 +29,14 @@ Int_t REST_CheckRunFileList(TString namePattern, Int_t N = 100000) {
     int cont = 0;
     for (int i = 0; i < b.size(); i++) {
         string filename = b[i];
-        RESTcout << filename << RESTendl;
+        RESTLog << filename << RESTendl;
         cont++;
         TRestRun* run = new TRestRun();
 
         TFile* f = new TFile(filename.c_str());
 
         if (!TRestTools::fileExists(filename)) {
-            RESTcout << "WARNING. Input file does not exist" << RESTendl;
+            RESTLog << "WARNING. Input file does not exist" << RESTendl;
             exit(1);
         }
 
@@ -48,12 +48,12 @@ Int_t REST_CheckRunFileList(TString namePattern, Int_t N = 100000) {
         while ((key = (TKey*)nextkey())) {
             string className = key->GetClassName();
             if (className == "TRestRun") {
-                RESTcout << key->GetName() << RESTendl;
+                RESTLog << key->GetName() << RESTendl;
                 run = (TRestRun*)f->Get(key->GetName());
             }
         }
 
-        RESTcout << "Run time (hours) : " << run->GetRunLength() / 3600. << RESTendl;
+        RESTLog << "Run time (hours) : " << run->GetRunLength() / 3600. << RESTendl;
         if (run->GetRunLength() > 0) totalTime += run->GetRunLength() / 3600.;
 
         if (run->GetEndTimestamp() == 0 || run->GetRunLength() < 0) {
@@ -66,15 +66,15 @@ Int_t REST_CheckRunFileList(TString namePattern, Int_t N = 100000) {
     }
 
     if (filesNotWellClosed.size() > 0) {
-        RESTcout << RESTendl;
-        RESTcout << "---------------------" << RESTendl;
-        RESTcout << "Files not well closed" << RESTendl;
-        RESTcout << "---------------------" << RESTendl;
-        for (int i = 0; i < filesNotWellClosed.size(); i++) RESTcout << filesNotWellClosed[i] << RESTendl;
+        RESTLog << RESTendl;
+        RESTLog << "---------------------" << RESTendl;
+        RESTLog << "Files not well closed" << RESTendl;
+        RESTLog << "---------------------" << RESTendl;
+        for (int i = 0; i < filesNotWellClosed.size(); i++) RESTLog << filesNotWellClosed[i] << RESTendl;
     }
 
-    RESTcout << "------------------------------" << RESTendl;
-    RESTcout << "Total runs time : " << totalTime << " hours" << RESTendl;
+    RESTLog << "------------------------------" << RESTendl;
+    RESTLog << "Total runs time : " << totalTime << " hours" << RESTendl;
 
     return 0;
 }

--- a/macros/REST_CheckRunFileList.C
+++ b/macros/REST_CheckRunFileList.C
@@ -20,7 +20,7 @@ Int_t REST_CheckRunFileList(TString namePattern, Int_t N = 100000) {
 
     vector<TString> filesNotWellClosed;
 
-    TRestStringOutput cout;
+    TRestStringOutput RESTcout;
 
     string a = TRestTools::Execute((string)("ls -d -1 " + namePattern));
     vector<string> b = Split(a, "\n");
@@ -29,14 +29,14 @@ Int_t REST_CheckRunFileList(TString namePattern, Int_t N = 100000) {
     int cont = 0;
     for (int i = 0; i < b.size(); i++) {
         string filename = b[i];
-        cout << filename << endl;
+        RESTcout << filename << RESTendl;
         cont++;
         TRestRun* run = new TRestRun();
 
         TFile* f = new TFile(filename.c_str());
 
         if (!TRestTools::fileExists(filename)) {
-            cout << "WARNING. Input file does not exist" << endl;
+            RESTcout << "WARNING. Input file does not exist" << RESTendl;
             exit(1);
         }
 
@@ -48,12 +48,12 @@ Int_t REST_CheckRunFileList(TString namePattern, Int_t N = 100000) {
         while ((key = (TKey*)nextkey())) {
             string className = key->GetClassName();
             if (className == "TRestRun") {
-                cout << key->GetName() << endl;
+                RESTcout << key->GetName() << RESTendl;
                 run = (TRestRun*)f->Get(key->GetName());
             }
         }
 
-        cout << "Run time (hours) : " << run->GetRunLength() / 3600. << endl;
+        RESTcout << "Run time (hours) : " << run->GetRunLength() / 3600. << RESTendl;
         if (run->GetRunLength() > 0) totalTime += run->GetRunLength() / 3600.;
 
         if (run->GetEndTimestamp() == 0 || run->GetRunLength() < 0) {
@@ -66,15 +66,15 @@ Int_t REST_CheckRunFileList(TString namePattern, Int_t N = 100000) {
     }
 
     if (filesNotWellClosed.size() > 0) {
-        cout << endl;
-        cout << "---------------------" << endl;
-        cout << "Files not well closed" << endl;
-        cout << "---------------------" << endl;
-        for (int i = 0; i < filesNotWellClosed.size(); i++) cout << filesNotWellClosed[i] << endl;
+        RESTcout << RESTendl;
+        RESTcout << "---------------------" << RESTendl;
+        RESTcout << "Files not well closed" << RESTendl;
+        RESTcout << "---------------------" << RESTendl;
+        for (int i = 0; i < filesNotWellClosed.size(); i++) RESTcout << filesNotWellClosed[i] << RESTendl;
     }
 
-    cout << "------------------------------" << endl;
-    cout << "Total runs time : " << totalTime << " hours" << endl;
+    RESTcout << "------------------------------" << RESTendl;
+    RESTcout << "Total runs time : " << totalTime << " hours" << RESTendl;
 
     return 0;
 }

--- a/macros/REST_CreateHisto.C
+++ b/macros/REST_CreateHisto.C
@@ -18,14 +18,14 @@
 //*******************************************************************************************************
 Int_t REST_CreateHisto(string varName, string rootFileName, TString histoName, int startVal = 0,
                        int endVal = 1000, int bins = 1000, Double_t normFactor = 1) {
-    TRestStringOutput cout;
+    TRestStringOutput RESTcout;
 
     std::vector<string> inputFilesNew = TRestTools::GetFilesMatchingPattern(rootFileName);
 
     TH1D* h = new TH1D(histoName, histoName, bins, startVal, endVal);
 
     if (inputFilesNew.size() == 0) {
-        cout << "Files not found!" << endl;
+        RESTcout << "Files not found!" << RESTendl;
         return -1;
     }
 
@@ -38,9 +38,9 @@ Int_t REST_CreateHisto(string varName, string rootFileName, TString histoName, i
 
         Int_t obsID = run->GetAnalysisTree()->GetObservableID(varName);
         if (obsID == -1) {
-            cout << endl;
-            cout.setcolor(COLOR_BOLDRED);
-            cout << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << endl;
+            RESTcout << RESTendl;
+            RESTcout.setcolor(COLOR_BOLDRED);
+            RESTcout << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << RESTendl;
             continue;
         }
         for (int i = 0; i < run->GetEntries(); i++) {
@@ -58,7 +58,7 @@ Int_t REST_CreateHisto(string varName, string rootFileName, TString histoName, i
     h->Write(histoName);
     f->Close();
 
-    cout << "Written histogram " << histoName << " into " << rootFileName << endl;
+    RESTcout << "Written histogram " << histoName << " into " << rootFileName << RESTendl;
 
     return 0;
 };

--- a/macros/REST_CreateHisto.C
+++ b/macros/REST_CreateHisto.C
@@ -18,14 +18,14 @@
 //*******************************************************************************************************
 Int_t REST_CreateHisto(string varName, string rootFileName, TString histoName, int startVal = 0,
                        int endVal = 1000, int bins = 1000, Double_t normFactor = 1) {
-    TRestStringOutput RESTcout;
+    TRestStringOutput RESTLog;
 
     std::vector<string> inputFilesNew = TRestTools::GetFilesMatchingPattern(rootFileName);
 
     TH1D* h = new TH1D(histoName, histoName, bins, startVal, endVal);
 
     if (inputFilesNew.size() == 0) {
-        RESTcout << "Files not found!" << RESTendl;
+        RESTLog << "Files not found!" << RESTendl;
         return -1;
     }
 
@@ -38,9 +38,9 @@ Int_t REST_CreateHisto(string varName, string rootFileName, TString histoName, i
 
         Int_t obsID = run->GetAnalysisTree()->GetObservableID(varName);
         if (obsID == -1) {
-            RESTcout << RESTendl;
-            RESTcout.setcolor(COLOR_BOLDRED);
-            RESTcout << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << RESTendl;
+            RESTLog << RESTendl;
+            RESTLog.setcolor(COLOR_BOLDRED);
+            RESTLog << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << RESTendl;
             continue;
         }
         for (int i = 0; i < run->GetEntries(); i++) {
@@ -58,7 +58,7 @@ Int_t REST_CreateHisto(string varName, string rootFileName, TString histoName, i
     h->Write(histoName);
     f->Close();
 
-    RESTcout << "Written histogram " << histoName << " into " << rootFileName << RESTendl;
+    RESTLog << "Written histogram " << histoName << " into " << rootFileName << RESTendl;
 
     return 0;
 };

--- a/macros/REST_DataSummary.C
+++ b/macros/REST_DataSummary.C
@@ -91,16 +91,16 @@ Int_t REST_DataSummary(TString pattern, TString startDate = "", TString endDate 
         }
 
         if (runEndTimeStamp - runStartTimeStamp <= 0) {
-            warning << "Problem with start/end timestamps" << endl;
-            warning << "Skipping file : " << TRestTools::GetPureFileName(files[n]) << endl;
+            RESTWarning << "Problem with start/end timestamps" << RESTendl;
+            RESTWarning << "Skipping file : " << TRestTools::GetPureFileName(files[n]) << RESTendl;
             continue;
         }
 
         for (int m = 0; m < metadataConditions.size(); m++) {
             cout << metadataConditions[m] << endl;
             if (!run->EvaluateMetadataMember(metadataConditions[m])) {
-                warning << "Condition : " << metadataConditions[m] << " not satisfied" << endl;
-                warning << "Skipping file : " << TRestTools::GetPureFileName(files[n]) << endl;
+                RESTWarning << "Condition : " << metadataConditions[m] << " not satisfied" << RESTendl;
+                RESTWarning << "Skipping file : " << TRestTools::GetPureFileName(files[n]) << RESTendl;
                 continue;
             }
         }

--- a/macros/REST_Fit.C
+++ b/macros/REST_Fit.C
@@ -17,12 +17,12 @@
 //***
 //*******************************************************************************************************
 Int_t REST_Fit(string varName, string rootFileName, double startVal, double endVal, int nBins = 100) {
-    TRestStringOutput RESTcout;
-    RESTcout << "Variable name : " << varName << RESTendl;
-    RESTcout << "Fit range : ( " << startVal << " , " << endVal << " ) " << RESTendl;
+    TRestStringOutput RESTLog;
+    RESTLog << "Variable name : " << varName << RESTendl;
+    RESTLog << "Fit range : ( " << startVal << " , " << endVal << " ) " << RESTendl;
 
     if (startVal >= endVal) {
-        RESTcout << "Start or End integration values not properly defined!!!" << RESTendl;
+        RESTLog << "Start or End integration values not properly defined!!!" << RESTendl;
         return -1;
     }
 
@@ -33,7 +33,7 @@ Int_t REST_Fit(string varName, string rootFileName, double startVal, double endV
     TRestRun* run = new TRestRun();
 
     if (inputFilesNew.size() == 0) {
-        RESTcout << "Files not found!" << RESTendl;
+        RESTLog << "Files not found!" << RESTendl;
         return -1;
     }
 
@@ -44,9 +44,9 @@ Int_t REST_Fit(string varName, string rootFileName, double startVal, double endV
 
         Int_t obsID = run->GetAnalysisTree()->GetObservableID(varName);
         if (obsID == -1) {
-            RESTcout << RESTendl;
-            RESTcout.setcolor(COLOR_BOLDRED);
-            RESTcout << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << RESTendl;
+            RESTLog << RESTendl;
+            RESTLog.setcolor(COLOR_BOLDRED);
+            RESTLog << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << RESTendl;
             continue;
         }
         for (int i = 0; i < run->GetEntries(); i++) {

--- a/macros/REST_Fit.C
+++ b/macros/REST_Fit.C
@@ -17,12 +17,12 @@
 //***
 //*******************************************************************************************************
 Int_t REST_Fit(string varName, string rootFileName, double startVal, double endVal, int nBins = 100) {
-    TRestStringOutput cout;
-    cout << "Variable name : " << varName << endl;
-    cout << "Fit range : ( " << startVal << " , " << endVal << " ) " << endl;
+    TRestStringOutput RESTcout;
+    RESTcout << "Variable name : " << varName << RESTendl;
+    RESTcout << "Fit range : ( " << startVal << " , " << endVal << " ) " << RESTendl;
 
     if (startVal >= endVal) {
-        cout << "Start or End integration values not properly defined!!!" << endl;
+        RESTcout << "Start or End integration values not properly defined!!!" << RESTendl;
         return -1;
     }
 
@@ -33,7 +33,7 @@ Int_t REST_Fit(string varName, string rootFileName, double startVal, double endV
     TRestRun* run = new TRestRun();
 
     if (inputFilesNew.size() == 0) {
-        cout << "Files not found!" << endl;
+        RESTcout << "Files not found!" << RESTendl;
         return -1;
     }
 
@@ -44,9 +44,9 @@ Int_t REST_Fit(string varName, string rootFileName, double startVal, double endV
 
         Int_t obsID = run->GetAnalysisTree()->GetObservableID(varName);
         if (obsID == -1) {
-            cout << endl;
-            cout.setcolor(COLOR_BOLDRED);
-            cout << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << endl;
+            RESTcout << RESTendl;
+            RESTcout.setcolor(COLOR_BOLDRED);
+            RESTcout << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << RESTendl;
             continue;
         }
         for (int i = 0; i < run->GetEntries(); i++) {

--- a/macros/REST_Integrate.C
+++ b/macros/REST_Integrate.C
@@ -17,19 +17,19 @@
 //***
 //*******************************************************************************************************
 Int_t REST_Integrate(string varName, string rootFileName, double startVal, double endVal) {
-    TRestStringOutput cout;
-    cout << "Variable name : " << varName << endl;
-    cout << "Integration range : ( " << startVal << " , " << endVal << " ) " << endl;
+    TRestStringOutput RESTcout;
+    RESTcout << "Variable name : " << varName << RESTendl;
+    RESTcout << "Integration range : ( " << startVal << " , " << endVal << " ) " << RESTendl;
 
     if (startVal >= endVal) {
-        cout << "Start or End integration values not properly defined!!!" << endl;
+        RESTcout << "Start or End integration values not properly defined!!!" << RESTendl;
         return -1;
     }
 
     std::vector<string> inputFilesNew = TRestTools::GetFilesMatchingPattern(rootFileName);
 
     if (inputFilesNew.size() == 0) {
-        cout << "Files not found!" << endl;
+        RESTcout << "Files not found!" << RESTendl;
         return -1;
     }
 
@@ -43,9 +43,9 @@ Int_t REST_Integrate(string varName, string rootFileName, double startVal, doubl
 
         Int_t obsID = run->GetAnalysisTree()->GetObservableID(varName);
         if (obsID == -1) {
-            cout << endl;
-            cout.setcolor(COLOR_BOLDRED);
-            cout << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << endl;
+            RESTcout << RESTendl;
+            RESTcout.setcolor(COLOR_BOLDRED);
+            RESTcout << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << RESTendl;
             continue;
         }
         for (int i = 0; i < run->GetEntries(); i++) {
@@ -55,13 +55,13 @@ Int_t REST_Integrate(string varName, string rootFileName, double startVal, doubl
         }
     }
 
-    cout.setcolor(COLOR_BOLDBLUE);
-    cout.setborder("*");
-    cout << endl;
-    cout << "=" << endl;
-    cout << "Integral : " << integral << endl;
-    cout << "=" << endl;
-    cout << endl;
+    RESTcout.setcolor(COLOR_BOLDBLUE);
+    RESTcout.setborder("*");
+    RESTcout << RESTendl;
+    RESTcout << "=" << RESTendl;
+    RESTcout << "Integral : " << integral << RESTendl;
+    RESTcout << "=" << RESTendl;
+    RESTcout << RESTendl;
 
     delete run;
 

--- a/macros/REST_Integrate.C
+++ b/macros/REST_Integrate.C
@@ -17,19 +17,19 @@
 //***
 //*******************************************************************************************************
 Int_t REST_Integrate(string varName, string rootFileName, double startVal, double endVal) {
-    TRestStringOutput RESTcout;
-    RESTcout << "Variable name : " << varName << RESTendl;
-    RESTcout << "Integration range : ( " << startVal << " , " << endVal << " ) " << RESTendl;
+    TRestStringOutput RESTLog;
+    RESTLog << "Variable name : " << varName << RESTendl;
+    RESTLog << "Integration range : ( " << startVal << " , " << endVal << " ) " << RESTendl;
 
     if (startVal >= endVal) {
-        RESTcout << "Start or End integration values not properly defined!!!" << RESTendl;
+        RESTLog << "Start or End integration values not properly defined!!!" << RESTendl;
         return -1;
     }
 
     std::vector<string> inputFilesNew = TRestTools::GetFilesMatchingPattern(rootFileName);
 
     if (inputFilesNew.size() == 0) {
-        RESTcout << "Files not found!" << RESTendl;
+        RESTLog << "Files not found!" << RESTendl;
         return -1;
     }
 
@@ -43,9 +43,9 @@ Int_t REST_Integrate(string varName, string rootFileName, double startVal, doubl
 
         Int_t obsID = run->GetAnalysisTree()->GetObservableID(varName);
         if (obsID == -1) {
-            RESTcout << RESTendl;
-            RESTcout.setcolor(COLOR_BOLDRED);
-            RESTcout << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << RESTendl;
+            RESTLog << RESTendl;
+            RESTLog.setcolor(COLOR_BOLDRED);
+            RESTLog << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << RESTendl;
             continue;
         }
         for (int i = 0; i < run->GetEntries(); i++) {
@@ -55,13 +55,13 @@ Int_t REST_Integrate(string varName, string rootFileName, double startVal, doubl
         }
     }
 
-    RESTcout.setcolor(COLOR_BOLDBLUE);
-    RESTcout.setborder("*");
-    RESTcout << RESTendl;
-    RESTcout << "=" << RESTendl;
-    RESTcout << "Integral : " << integral << RESTendl;
-    RESTcout << "=" << RESTendl;
-    RESTcout << RESTendl;
+    RESTLog.setcolor(COLOR_BOLDBLUE);
+    RESTLog.setborder("*");
+    RESTLog << RESTendl;
+    RESTLog << "=" << RESTendl;
+    RESTLog << "Integral : " << integral << RESTendl;
+    RESTLog << "=" << RESTendl;
+    RESTLog << RESTendl;
 
     delete run;
 

--- a/macros/REST_IntegrateSmearing.C
+++ b/macros/REST_IntegrateSmearing.C
@@ -17,12 +17,12 @@
 //***
 //*******************************************************************************************************
 Int_t REST_IntegrateSmearing(string varName, string rootFileName, double Middle) {
-    TRestStringOutput cout;
+    TRestStringOutput RESTcout;
 
     std::vector<string> inputFilesNew = TRestTools::GetFilesMatchingPattern(rootFileName);
 
     if (inputFilesNew.size() == 0) {
-        cout << "Files not found!" << endl;
+        RESTcout << "Files not found!" << RESTendl;
         return -1;
     }
 
@@ -41,12 +41,12 @@ Int_t REST_IntegrateSmearing(string varName, string rootFileName, double Middle)
 
         Int_t obsID = run->GetAnalysisTree()->GetObservableID(varName);
         if (obsID == -1) {
-            cout << endl;
-            cout.setcolor(COLOR_BOLDRED);
-            cout << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << endl;
+            RESTcout << RESTendl;
+            RESTcout.setcolor(COLOR_BOLDRED);
+            RESTcout << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << RESTendl;
             continue;
         }
-        cout << "Entries : " << run->GetEntries() << endl;
+        RESTcout << "Entries : " << run->GetEntries() << RESTendl;
         TH1D* h = new TH1D("histo", "histo", 180, Qbb - 90, Qbb + 90);
         Int_t peak = 0;
         for (int i = 0; i < run->GetEntries(); i++) {
@@ -78,18 +78,18 @@ Int_t REST_IntegrateSmearing(string varName, string rootFileName, double Middle)
             contribution_3 += gausFunc->Integral(mean - 2 * sigma_3, mean + 2 * sigma_3);
         }
 
-        cout.setcolor(COLOR_BOLDBLUE);
-        cout.setborder("*");
-        cout << endl;
-        cout << "=" << endl;
-        cout << "Total events : " << run->GetEntries() << endl;
-        cout << " " << endl;
-        cout << "FWHM = 0.5% -> " << contribution_1 << endl;
-        cout << "FWHM = 1.% -> " << contribution_2 << endl;
-        cout << "FWHM = 3.% -> " << contribution_3 << endl;
-        cout << "peak : " << peak << endl;
-        cout << "=" << endl;
-        cout << endl;
+        RESTcout.setcolor(COLOR_BOLDBLUE);
+        RESTcout.setborder("*");
+        RESTcout << RESTendl;
+        RESTcout << "=" << RESTendl;
+        RESTcout << "Total events : " << run->GetEntries() << RESTendl;
+        RESTcout << " " << RESTendl;
+        RESTcout << "FWHM = 0.5% -> " << contribution_1 << RESTendl;
+        RESTcout << "FWHM = 1.% -> " << contribution_2 << RESTendl;
+        RESTcout << "FWHM = 3.% -> " << contribution_3 << RESTendl;
+        RESTcout << "peak : " << peak << RESTendl;
+        RESTcout << "=" << RESTendl;
+        RESTcout << RESTendl;
 
         delete run;
     }

--- a/macros/REST_IntegrateSmearing.C
+++ b/macros/REST_IntegrateSmearing.C
@@ -17,12 +17,12 @@
 //***
 //*******************************************************************************************************
 Int_t REST_IntegrateSmearing(string varName, string rootFileName, double Middle) {
-    TRestStringOutput RESTcout;
+    TRestStringOutput RESTLog;
 
     std::vector<string> inputFilesNew = TRestTools::GetFilesMatchingPattern(rootFileName);
 
     if (inputFilesNew.size() == 0) {
-        RESTcout << "Files not found!" << RESTendl;
+        RESTLog << "Files not found!" << RESTendl;
         return -1;
     }
 
@@ -41,12 +41,12 @@ Int_t REST_IntegrateSmearing(string varName, string rootFileName, double Middle)
 
         Int_t obsID = run->GetAnalysisTree()->GetObservableID(varName);
         if (obsID == -1) {
-            RESTcout << RESTendl;
-            RESTcout.setcolor(COLOR_BOLDRED);
-            RESTcout << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << RESTendl;
+            RESTLog << RESTendl;
+            RESTLog.setcolor(COLOR_BOLDRED);
+            RESTLog << "No observable \"" << varName << "\" in file " << inputFilesNew[n] << RESTendl;
             continue;
         }
-        RESTcout << "Entries : " << run->GetEntries() << RESTendl;
+        RESTLog << "Entries : " << run->GetEntries() << RESTendl;
         TH1D* h = new TH1D("histo", "histo", 180, Qbb - 90, Qbb + 90);
         Int_t peak = 0;
         for (int i = 0; i < run->GetEntries(); i++) {
@@ -78,18 +78,18 @@ Int_t REST_IntegrateSmearing(string varName, string rootFileName, double Middle)
             contribution_3 += gausFunc->Integral(mean - 2 * sigma_3, mean + 2 * sigma_3);
         }
 
-        RESTcout.setcolor(COLOR_BOLDBLUE);
-        RESTcout.setborder("*");
-        RESTcout << RESTendl;
-        RESTcout << "=" << RESTendl;
-        RESTcout << "Total events : " << run->GetEntries() << RESTendl;
-        RESTcout << " " << RESTendl;
-        RESTcout << "FWHM = 0.5% -> " << contribution_1 << RESTendl;
-        RESTcout << "FWHM = 1.% -> " << contribution_2 << RESTendl;
-        RESTcout << "FWHM = 3.% -> " << contribution_3 << RESTendl;
-        RESTcout << "peak : " << peak << RESTendl;
-        RESTcout << "=" << RESTendl;
-        RESTcout << RESTendl;
+        RESTLog.setcolor(COLOR_BOLDBLUE);
+        RESTLog.setborder("*");
+        RESTLog << RESTendl;
+        RESTLog << "=" << RESTendl;
+        RESTLog << "Total events : " << run->GetEntries() << RESTendl;
+        RESTLog << " " << RESTendl;
+        RESTLog << "FWHM = 0.5% -> " << contribution_1 << RESTendl;
+        RESTLog << "FWHM = 1.% -> " << contribution_2 << RESTendl;
+        RESTLog << "FWHM = 3.% -> " << contribution_3 << RESTendl;
+        RESTLog << "peak : " << peak << RESTendl;
+        RESTLog << "=" << RESTendl;
+        RESTLog << RESTendl;
 
         delete run;
     }

--- a/macros/REST_MakeMetadata.C
+++ b/macros/REST_MakeMetadata.C
@@ -16,13 +16,13 @@
 //*******************************************************************************************************
 Int_t REST_MakeMetadata(TString name) {
     if (name.First("TRest") != 0) {
-        ferr << "invalid process name! REST process name must be start with \"TRest\" " << endl;
+        RESTFerr << "invalid process name! REST process name must be start with \"TRest\" " << RESTendl;
         return -1;
     }
 
     ofstream headerFile(name + ".h");
     if (headerFile.fail()) {
-        ferr << "failed to create file!" << endl;
+        RESTFerr << "failed to create file!" << RESTendl;
         return -1;
     }
 
@@ -105,7 +105,7 @@ Int_t REST_MakeMetadata(TString name) {
 
     ofstream sourceFile(name + ".cxx");
     if (headerFile.fail()) {
-        ferr << "failed to create file!" << endl;
+        RESTFerr << "failed to create file!" << RESTendl;
         return -1;
     }
 

--- a/macros/REST_MakeMetadata.C
+++ b/macros/REST_MakeMetadata.C
@@ -16,13 +16,13 @@
 //*******************************************************************************************************
 Int_t REST_MakeMetadata(TString name) {
     if (name.First("TRest") != 0) {
-        RESTFerr << "invalid process name! REST process name must be start with \"TRest\" " << RESTendl;
+        RESTError << "invalid process name! REST process name must be start with \"TRest\" " << RESTendl;
         return -1;
     }
 
     ofstream headerFile(name + ".h");
     if (headerFile.fail()) {
-        RESTFerr << "failed to create file!" << RESTendl;
+        RESTError << "failed to create file!" << RESTendl;
         return -1;
     }
 
@@ -105,7 +105,7 @@ Int_t REST_MakeMetadata(TString name) {
 
     ofstream sourceFile(name + ".cxx");
     if (headerFile.fail()) {
-        RESTFerr << "failed to create file!" << RESTendl;
+        RESTError << "failed to create file!" << RESTendl;
         return -1;
     }
 

--- a/macros/REST_MakeProcess.C
+++ b/macros/REST_MakeProcess.C
@@ -20,9 +20,9 @@ Int_t REST_MakeProcess(TString name, TString inputevent = "TRestEvent", TString 
     //    --> generate a data-conversion process template form TRestDetectorHitsEvent to TRestTrackEvent
 
     if (name.First("TRest") != 0 || name.Contains("Process") == false) {
-        RESTFerr << "invalid process name! REST process name must be start with \"TRest\" and ends with "
-                    "\"Process\"!"
-                 << RESTendl;
+        RESTError << "invalid process name! REST process name must be start with \"TRest\" and ends with "
+                     "\"Process\"!"
+                  << RESTendl;
         return -1;
     }
 
@@ -62,7 +62,7 @@ Int_t REST_MakeProcess(TString name, TString inputevent = "TRestEvent", TString 
 
     ofstream headerfile(name + ".h");
     if (headerfile.fail()) {
-        RESTFerr << "failed to create file!" << RESTendl;
+        RESTError << "failed to create file!" << RESTendl;
         return -1;
     }
 
@@ -163,7 +163,7 @@ Int_t REST_MakeProcess(TString name, TString inputevent = "TRestEvent", TString 
 
     ofstream sourcefile(name + ".cxx");
     if (headerfile.fail()) {
-        RESTFerr << "failed to create file!" << RESTendl;
+        RESTError << "failed to create file!" << RESTendl;
         return -1;
     }
 

--- a/macros/REST_MakeProcess.C
+++ b/macros/REST_MakeProcess.C
@@ -20,9 +20,9 @@ Int_t REST_MakeProcess(TString name, TString inputevent = "TRestEvent", TString 
     //    --> generate a data-conversion process template form TRestDetectorHitsEvent to TRestTrackEvent
 
     if (name.First("TRest") != 0 || name.Contains("Process") == false) {
-        ferr << "invalid process name! REST process name must be start with \"TRest\" and ends with "
-                "\"Process\"!"
-             << endl;
+        RESTFerr << "invalid process name! REST process name must be start with \"TRest\" and ends with "
+                    "\"Process\"!"
+                 << RESTendl;
         return -1;
     }
 
@@ -62,7 +62,7 @@ Int_t REST_MakeProcess(TString name, TString inputevent = "TRestEvent", TString 
 
     ofstream headerfile(name + ".h");
     if (headerfile.fail()) {
-        ferr << "failed to create file!" << endl;
+        RESTFerr << "failed to create file!" << RESTendl;
         return -1;
     }
 
@@ -163,7 +163,7 @@ Int_t REST_MakeProcess(TString name, TString inputevent = "TRestEvent", TString 
 
     ofstream sourcefile(name + ".cxx");
     if (headerfile.fail()) {
-        ferr << "failed to create file!" << endl;
+        RESTFerr << "failed to create file!" << RESTendl;
         return -1;
     }
 

--- a/macros/REST_PrintDataBase.C
+++ b/macros/REST_PrintDataBase.C
@@ -18,10 +18,10 @@ using namespace std;
 //***
 //*******************************************************************************************************
 Int_t REST_DataBase(Int_t run = -1) {
-    TRestStringOutput fout;
+    TRestStringOutput RESTfout;
     if (gDataBase == NULL) {
-        fout.setcolor(COLOR_BOLDRED);
-        fout << "gDataBase is NULL" << endl;
+        RESTfout.setcolor(COLOR_BOLDRED);
+        RESTfout << "gDataBase is NULL" << RESTendl;
     } else {
         if (run < 0) run = gDataBase->get_lastrun();
         gDataBase->print(Form("select * from rest_runs where run_id=%i", run));

--- a/macros/REST_PrintFileContents.C
+++ b/macros/REST_PrintFileContents.C
@@ -17,26 +17,26 @@
 //***
 //*******************************************************************************************************
 Int_t REST_FileContents(TString fName) {
-    TRestStringOutput fout;
+    TRestStringOutput RESTfout;
     TFile* fFile = new TFile(fName);
     if (fFile == NULL) {
-        fout << "I could not open file : " << fName << endl;
+        RESTfout << "I could not open file : " << fName << RESTendl;
         return 0;
     }
     TIter nextkey(fFile->GetListOfKeys());
     TKey* key;
     Int_t c = 0;
-    fout << "==========================================" << endl;
+    RESTfout << "==========================================" << RESTendl;
     while ((key = (TKey*)nextkey()) != NULL) {
-        if (c > 0) fout << " ------------------------------------- " << endl;
+        if (c > 0) RESTfout << " ------------------------------------- " << RESTendl;
 
-        fout << "ClassName : " << key->GetClassName() << endl;
-        fout << "Name : " << key->GetName() << endl;
-        fout << "Title : " << key->GetTitle() << endl;
+        RESTfout << "ClassName : " << key->GetClassName() << RESTendl;
+        RESTfout << "Name : " << key->GetName() << RESTendl;
+        RESTfout << "Title : " << key->GetTitle() << RESTendl;
 
         c++;
     }
-    fout << "==========================================" << endl;
+    RESTfout << "==========================================" << RESTendl;
 
     return 0;
 }

--- a/macros/REST_PrintMetadata.C
+++ b/macros/REST_PrintMetadata.C
@@ -10,17 +10,17 @@
 //***
 //*******************************************************************************************************
 Int_t REST_Metadata(TString fName, TString objName = "") {
-    TRestStringOutput cout;
-    cout.setorientation(1);
+    TRestStringOutput RESTcout;
+    RESTcout.setorientation(TRestStringOutput::REST_Display_Orientation::kLeft);
 
     TString fileName = fName;
 
-    cout << "Filename : " << fileName << endl;
+    RESTcout << "Filename : " << fileName << RESTendl;
 
     string fname = fileName.Data();
 
     if (!TRestTools::fileExists(fname)) {
-        cout << "WARNING. Input file does not exist" << endl;
+        RESTcout << "WARNING. Input file does not exist" << RESTendl;
         exit(1);
     }
 
@@ -33,12 +33,12 @@ Int_t REST_Metadata(TString fName, TString objName = "") {
         if (((string)(key->GetClassName())).find("TRest") != -1) {
             TObject* obj = f->Get(key->GetName());
             if (obj == NULL) {
-                cout << "Cannot Get object with name \"" << key->GetName() << "\"!" << endl;
-                cout << "The name may contain illegel characters which was legel in previous version."
-                     << endl;
+                RESTcout << "Cannot Get object with name \"" << key->GetName() << "\"!" << RESTendl;
+                RESTcout << "The name may contain illegel characters which was legel in previous version."
+                         << RESTendl;
             } else if (obj->InheritsFrom("TRestMetadata")) {
                 if (objName == "" || objName == obj->ClassName() || objName == obj->GetName()) {
-                    cout << n << "th object : " << endl;
+                    RESTcout << n << "th object : " << RESTendl;
                     ((TRestMetadata*)obj)->PrintMetadata();
                 }
             }

--- a/macros/REST_PrintMetadata.C
+++ b/macros/REST_PrintMetadata.C
@@ -10,17 +10,17 @@
 //***
 //*******************************************************************************************************
 Int_t REST_Metadata(TString fName, TString objName = "") {
-    TRestStringOutput RESTcout;
-    RESTcout.setorientation(TRestStringOutput::REST_Display_Orientation::kLeft);
+    TRestStringOutput RESTLog;
+    RESTLog.setorientation(TRestStringOutput::REST_Display_Orientation::kLeft);
 
     TString fileName = fName;
 
-    RESTcout << "Filename : " << fileName << RESTendl;
+    RESTLog << "Filename : " << fileName << RESTendl;
 
     string fname = fileName.Data();
 
     if (!TRestTools::fileExists(fname)) {
-        RESTcout << "WARNING. Input file does not exist" << RESTendl;
+        RESTLog << "WARNING. Input file does not exist" << RESTendl;
         exit(1);
     }
 
@@ -33,12 +33,12 @@ Int_t REST_Metadata(TString fName, TString objName = "") {
         if (((string)(key->GetClassName())).find("TRest") != -1) {
             TObject* obj = f->Get(key->GetName());
             if (obj == NULL) {
-                RESTcout << "Cannot Get object with name \"" << key->GetName() << "\"!" << RESTendl;
-                RESTcout << "The name may contain illegel characters which was legel in previous version."
-                         << RESTendl;
+                RESTLog << "Cannot Get object with name \"" << key->GetName() << "\"!" << RESTendl;
+                RESTLog << "The name may contain illegel characters which was legel in previous version."
+                        << RESTendl;
             } else if (obj->InheritsFrom("TRestMetadata")) {
                 if (objName == "" || objName == obj->ClassName() || objName == obj->GetName()) {
-                    RESTcout << n << "th object : " << RESTendl;
+                    RESTLog << n << "th object : " << RESTendl;
                     ((TRestMetadata*)obj)->PrintMetadata();
                 }
             }

--- a/macros/REST_PrintTrees.C
+++ b/macros/REST_PrintTrees.C
@@ -26,10 +26,10 @@ Int_t REST_PrintTrees(TString fName, Int_t Entry = 0) {
 
     run->GetEntry(Entry);
 
-    TRestStringOutput fout;
-    fout.setcolor(COLOR_BOLDBLUE);
-    fout << endl;
-    fout << "=====AnalysisTree Contents, Entry " << Entry << "=====" << endl;
+    TRestStringOutput RESTFout;
+    RESTFout.setcolor(COLOR_BOLDBLUE);
+    RESTFout << RESTendl;
+    RESTFout << "=====AnalysisTree Contents, Entry " << Entry << "=====" << RESTendl;
 
     run->PrintObservables();
 

--- a/macros/REST_PrintTrees.C
+++ b/macros/REST_PrintTrees.C
@@ -26,10 +26,10 @@ Int_t REST_PrintTrees(TString fName, Int_t Entry = 0) {
 
     run->GetEntry(Entry);
 
-    TRestStringOutput RESTFout;
-    RESTFout.setcolor(COLOR_BOLDBLUE);
-    RESTFout << RESTendl;
-    RESTFout << "=====AnalysisTree Contents, Entry " << Entry << "=====" << RESTendl;
+    TRestStringOutput RESTLog;
+    RESTLog.setcolor(COLOR_BOLDBLUE);
+    RESTLog << RESTendl;
+    RESTLog << "=====AnalysisTree Contents, Entry " << Entry << "=====" << RESTendl;
 
     run->PrintObservables();
 

--- a/source/bin/restManager.cxx
+++ b/source/bin/restManager.cxx
@@ -216,8 +216,8 @@ int main(int argc, char* argv[]) {
 
             int pid = 0;
             if (doFork && input_files.size() > maxForksAllowed) {
-                RESTFerr << "Fork list is larger than " << maxForksAllowed
-                         << " files. Please, use a glob pattern producing a shorter list" << RESTendl;
+                RESTError << "Fork list is larger than " << maxForksAllowed
+                          << " files. Please, use a glob pattern producing a shorter list" << RESTendl;
             } else if (doFork) {
                 for (unsigned int n = 0; n < input_files.size(); n++) {
                     string command = "restManager";

--- a/source/bin/restManager.cxx
+++ b/source/bin/restManager.cxx
@@ -49,41 +49,41 @@ int fork_n_execute(string command) {
 
 void PrintHelp() {
     TRestStringOutput fout(COLOR_BOLDYELLOW, "", TRestStringOutput::REST_Display_Orientation::kLeft);
-    RESTFout << " " << RESTendl;
+    RESTcout << " " << RESTendl;
 
-    RESTFout.setheader("Usage1 : ./restManager ");
-    RESTFout << "--c CONFIG_FILE [--i/f INPUT] [--o OUTPUT] [--j THREADS] [--e EVENTS_TO_PROCESS] [--v "
+    RESTcout.setheader("Usage1 : ./restManager ");
+    RESTcout << "--c CONFIG_FILE [--i/f INPUT] [--o OUTPUT] [--j THREADS] [--e EVENTS_TO_PROCESS] [--v "
                 "VERBOSELEVEL] [--d RUNID] [--p PDF_PLOTS.pdf]"
              << RESTendl;
-    RESTFout.setheader("Usage2 : ./restManager ");
-    RESTFout << "TASK_NAME ARG1 ARG2 ARG3" << RESTendl;
+    RESTcout.setheader("Usage2 : ./restManager ");
+    RESTcout << "TASK_NAME ARG1 ARG2 ARG3" << RESTendl;
 
-    RESTFout.setcolor(COLOR_WHITE);
-    RESTFout.setheader("");
-    RESTFout << " " << RESTendl;
-    RESTFout.setheader("CONFIG_FILE: ");
-    RESTFout << "-" << RESTendl;
-    RESTFout << "The rml configuration file. It should contain a TRestManager section. This "
+    RESTcout.setcolor(COLOR_WHITE);
+    RESTcout.setheader("");
+    RESTcout << " " << RESTendl;
+    RESTcout.setheader("CONFIG_FILE: ");
+    RESTcout << "-" << RESTendl;
+    RESTcout << "The rml configuration file. It should contain a TRestManager section. This "
                 "argument MUST be provided. The others can be also specified in the rml file."
              << RESTendl;
-    RESTFout.setheader("INPUT      : ");
-    RESTFout << "-" << RESTendl;
-    RESTFout << "Input file name. If not given it will be acquired from the rml file. If you want "
+    RESTcout.setheader("INPUT      : ");
+    RESTcout << "-" << RESTendl;
+    RESTcout << "Input file name. If not given it will be acquired from the rml file. If you want "
                 "to use multiple input file, you can either specify the string of matching pattern with "
                 "quotation marks surrounding it, or put the file names in a .list file."
              << RESTendl;
-    RESTFout.setheader("OUTPUT     : ");
-    RESTFout << "-" << RESTendl;
-    RESTFout << "Output file name. It can be given as a name string (abc.root), or as an expression "
+    RESTcout.setheader("OUTPUT     : ");
+    RESTcout << "-" << RESTendl;
+    RESTcout << "Output file name. It can be given as a name string (abc.root), or as an expression "
                 "with naming fields to be replaced (Run[RunNumber]_[Tag].root)."
              << RESTendl;
-    RESTFout.setheader("THREADS    : ");
-    RESTFout << "-" << RESTendl;
-    RESTFout << "Enable specific number of threads to run the jobs. In most time 3~6 threads are "
+    RESTcout.setheader("THREADS    : ");
+    RESTcout << "-" << RESTendl;
+    RESTcout << "Enable specific number of threads to run the jobs. In most time 3~6 threads are "
                 "enough to make full use of computer power. Maximum is 15."
              << RESTendl;
-    RESTFout.setheader("");
-    RESTFout << "=" << RESTendl;
+    RESTcout.setheader("");
+    RESTcout << "=" << RESTendl;
 }
 
 Bool_t doFork = false;
@@ -128,19 +128,19 @@ int main(int argc, char* argv[]) {
         // handle special arguments like "--batch"
         for (int i = 1; i < args.size(); i++) {
             if (args[i] == "--batch") {
-                RESTFout << "you are in batch mode, all graphical displays off" << RESTendl;
+                RESTcout << "you are in batch mode, all graphical displays off" << RESTendl;
                 argCApp = 2;
                 args.erase(args.begin() + i);
             }
             if (args[i] == "--fork") {
-                RESTFout << "Fork is enabled!" << RESTendl;
+                RESTcout << "Fork is enabled!" << RESTendl;
                 argCApp = 2;
                 args.erase(args.begin() + i);
                 doFork = true;
             }
         }
         if (Console::CompatibilityMode) {
-            RESTFout << "you are in compatibility mode, all graphical displays off" << RESTendl;
+            RESTcout << "you are in compatibility mode, all graphical displays off" << RESTendl;
             argCApp = 2;
         }
     }
@@ -201,18 +201,18 @@ int main(int argc, char* argv[]) {
                             REST_ARGS["pdfFilename"] = args[i + 1];
                             break;
                         default:
-                            RESTFout << RESTendl;
+                            RESTcout << RESTendl;
                             PrintHelp();
                             return 0;
                     }
                 }
             }
 
-            RESTFout << RESTendl;
-            RESTFout.setcolor(COLOR_BOLDBLUE);
-            RESTFout.setorientation(TRestStringOutput::REST_Display_Orientation::kMiddle);
-            RESTFout << "Launching TRestManager..." << RESTendl;
-            RESTFout << RESTendl;
+            RESTcout << RESTendl;
+            RESTcout.setcolor(COLOR_BOLDBLUE);
+            RESTcout.setorientation(TRestStringOutput::REST_Display_Orientation::kMiddle);
+            RESTcout << "Launching TRestManager..." << RESTendl;
+            RESTcout << RESTendl;
 
             int pid = 0;
             if (doFork && input_files.size() > maxForksAllowed) {
@@ -227,22 +227,22 @@ int main(int argc, char* argv[]) {
                     }
                     command +=
                         " --f " + input_files[n] + " >> /tmp/" + getenv("USER") + "_out." + ToString(n);
-                    RESTFout << "Executing : " << command << RESTendl;
+                    RESTcout << "Executing : " << command << RESTendl;
                     fork_n_execute(command);
                 }
                 exit(0);
             } else {
-                RESTFout << "Creating TRestManager" << RESTendl;
+                RESTcout << "Creating TRestManager" << RESTendl;
                 TRestManager* mgr = new TRestManager();
 
                 auto path = TRestTools::SeparatePathAndName(configFilename).first;
-                RESTFout << "path:" << path << RESTendl;
+                RESTcout << "path:" << path << RESTendl;
 
                 setenv("configPath", path.c_str(), 1);
 
                 mgr->LoadConfigFromFile(configFilename);
 
-                RESTFout << "Done!" << RESTendl;
+                RESTcout << "Done!" << RESTendl;
                 // a->GetChar();
 
                 delete mgr;
@@ -255,7 +255,7 @@ int main(int argc, char* argv[]) {
                 argumentlist.push_back(args[i]);
             }
             string type = (args[1]);
-            RESTFout << "Initializing " << type << RESTendl;
+            RESTcout << "Initializing " << type << RESTendl;
             TRestManager* a = new TRestManager();
             a->InitFromTask(type, argumentlist);
         }

--- a/source/bin/restManager.cxx
+++ b/source/bin/restManager.cxx
@@ -48,42 +48,42 @@ int fork_n_execute(string command) {
 }
 
 void PrintHelp() {
-    TRestStringOutput fout(COLOR_BOLDYELLOW, "", kLeft);
-    fout << " " << endl;
+    TRestStringOutput fout(COLOR_BOLDYELLOW, "", TRestStringOutput::REST_Display_Orientation::kLeft);
+    RESTFout << " " << RESTendl;
 
-    fout.setheader("Usage1 : ./restManager ");
-    fout << "--c CONFIG_FILE [--i/f INPUT] [--o OUTPUT] [--j THREADS] [--e EVENTS_TO_PROCESS] [--v "
-            "VERBOSELEVEL] [--d RUNID] [--p PDF_PLOTS.pdf]"
-         << endl;
-    fout.setheader("Usage2 : ./restManager ");
-    fout << "TASK_NAME ARG1 ARG2 ARG3" << endl;
+    RESTFout.setheader("Usage1 : ./restManager ");
+    RESTFout << "--c CONFIG_FILE [--i/f INPUT] [--o OUTPUT] [--j THREADS] [--e EVENTS_TO_PROCESS] [--v "
+                "VERBOSELEVEL] [--d RUNID] [--p PDF_PLOTS.pdf]"
+             << RESTendl;
+    RESTFout.setheader("Usage2 : ./restManager ");
+    RESTFout << "TASK_NAME ARG1 ARG2 ARG3" << RESTendl;
 
-    fout.setcolor(COLOR_WHITE);
-    fout.setheader("");
-    fout << " " << endl;
-    fout.setheader("CONFIG_FILE: ");
-    fout << "-" << endl;
-    fout << "The rml configuration file. It should contain a TRestManager section. This "
-            "argument MUST be provided. The others can be also specified in the rml file."
-         << endl;
-    fout.setheader("INPUT      : ");
-    fout << "-" << endl;
-    fout << "Input file name. If not given it will be acquired from the rml file. If you want "
-            "to use multiple input file, you can either specify the string of matching pattern with "
-            "quotation marks surrounding it, or put the file names in a .list file."
-         << endl;
-    fout.setheader("OUTPUT     : ");
-    fout << "-" << endl;
-    fout << "Output file name. It can be given as a name string (abc.root), or as an expression "
-            "with naming fields to be replaced (Run[RunNumber]_[Tag].root)."
-         << endl;
-    fout.setheader("THREADS    : ");
-    fout << "-" << endl;
-    fout << "Enable specific number of threads to run the jobs. In most time 3~6 threads are "
-            "enough to make full use of computer power. Maximum is 15."
-         << endl;
-    fout.setheader("");
-    fout << "=" << endl;
+    RESTFout.setcolor(COLOR_WHITE);
+    RESTFout.setheader("");
+    RESTFout << " " << RESTendl;
+    RESTFout.setheader("CONFIG_FILE: ");
+    RESTFout << "-" << RESTendl;
+    RESTFout << "The rml configuration file. It should contain a TRestManager section. This "
+                "argument MUST be provided. The others can be also specified in the rml file."
+             << RESTendl;
+    RESTFout.setheader("INPUT      : ");
+    RESTFout << "-" << RESTendl;
+    RESTFout << "Input file name. If not given it will be acquired from the rml file. If you want "
+                "to use multiple input file, you can either specify the string of matching pattern with "
+                "quotation marks surrounding it, or put the file names in a .list file."
+             << RESTendl;
+    RESTFout.setheader("OUTPUT     : ");
+    RESTFout << "-" << RESTendl;
+    RESTFout << "Output file name. It can be given as a name string (abc.root), or as an expression "
+                "with naming fields to be replaced (Run[RunNumber]_[Tag].root)."
+             << RESTendl;
+    RESTFout.setheader("THREADS    : ");
+    RESTFout << "-" << RESTendl;
+    RESTFout << "Enable specific number of threads to run the jobs. In most time 3~6 threads are "
+                "enough to make full use of computer power. Maximum is 15."
+             << RESTendl;
+    RESTFout.setheader("");
+    RESTFout << "=" << RESTendl;
 }
 
 Bool_t doFork = false;
@@ -128,19 +128,19 @@ int main(int argc, char* argv[]) {
         // handle special arguments like "--batch"
         for (int i = 1; i < args.size(); i++) {
             if (args[i] == "--batch") {
-                fout << "you are in batch mode, all graphical displays off" << endl;
+                RESTFout << "you are in batch mode, all graphical displays off" << RESTendl;
                 argCApp = 2;
                 args.erase(args.begin() + i);
             }
             if (args[i] == "--fork") {
-                fout << "Fork is enabled!" << endl;
+                RESTFout << "Fork is enabled!" << RESTendl;
                 argCApp = 2;
                 args.erase(args.begin() + i);
                 doFork = true;
             }
         }
         if (Console::CompatibilityMode) {
-            fout << "you are in compatibility mode, all graphical displays off" << endl;
+            RESTFout << "you are in compatibility mode, all graphical displays off" << RESTendl;
             argCApp = 2;
         }
     }
@@ -201,23 +201,23 @@ int main(int argc, char* argv[]) {
                             REST_ARGS["pdfFilename"] = args[i + 1];
                             break;
                         default:
-                            fout << endl;
+                            RESTFout << RESTendl;
                             PrintHelp();
                             return 0;
                     }
                 }
             }
 
-            fout << endl;
-            fout.setcolor(COLOR_BOLDBLUE);
-            fout.setorientation(0);
-            fout << "Launching TRestManager..." << endl;
-            fout << endl;
+            RESTFout << RESTendl;
+            RESTFout.setcolor(COLOR_BOLDBLUE);
+            RESTFout.setorientation(TRestStringOutput::REST_Display_Orientation::kMiddle);
+            RESTFout << "Launching TRestManager..." << RESTendl;
+            RESTFout << RESTendl;
 
             int pid = 0;
             if (doFork && input_files.size() > maxForksAllowed) {
-                ferr << "Fork list is larger than " << maxForksAllowed
-                     << " files. Please, use a glob pattern producing a shorter list" << endl;
+                RESTFerr << "Fork list is larger than " << maxForksAllowed
+                         << " files. Please, use a glob pattern producing a shorter list" << RESTendl;
             } else if (doFork) {
                 for (unsigned int n = 0; n < input_files.size(); n++) {
                     string command = "restManager";
@@ -227,21 +227,22 @@ int main(int argc, char* argv[]) {
                     }
                     command +=
                         " --f " + input_files[n] + " >> /tmp/" + getenv("USER") + "_out." + ToString(n);
-                    fout << "Executing : " << command << endl;
+                    RESTFout << "Executing : " << command << RESTendl;
                     fork_n_execute(command);
                 }
                 exit(0);
             } else {
-                fout << "Creating TRestManager" << endl;
+                RESTFout << "Creating TRestManager" << RESTendl;
                 TRestManager* mgr = new TRestManager();
 
                 auto path = TRestTools::SeparatePathAndName(configFilename).first;
-                fout << "path:" << path << endl;
+                RESTFout << "path:" << path << RESTendl;
+
                 setenv("configPath", path.c_str(), 1);
 
                 mgr->LoadConfigFromFile(configFilename);
 
-                fout << "Done!" << endl;
+                RESTFout << "Done!" << RESTendl;
                 // a->GetChar();
 
                 delete mgr;
@@ -254,7 +255,7 @@ int main(int argc, char* argv[]) {
                 argumentlist.push_back(args[i]);
             }
             string type = (args[1]);
-            fout << "Initializing " << type << endl;
+            RESTFout << "Initializing " << type << RESTendl;
             TRestManager* a = new TRestManager();
             a->InitFromTask(type, argumentlist);
         }

--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -57,10 +57,10 @@ int main(int argc, char* argv[]) {
     }
 
     bool silent = false;
-    if (gVerbose == REST_Silent) silent = true;
+    if (gVerbose == TRestStringOutput::REST_Verbose_Level::REST_Silent) silent = true;
 
     bool debug = false;
-    if (gVerbose >= REST_Debug) debug = true;
+    if (gVerbose >= TRestStringOutput::REST_Verbose_Level::REST_Debug) debug = true;
 
     // load rest library and macros
     TRestTools::LoadRESTLibrary(silent);
@@ -131,7 +131,6 @@ int main(int argc, char* argv[]) {
                 if (debug) printf("%s\n", evcmd.c_str());
                 gROOT->ProcessLine(evcmd.c_str());
             }
-
 
             printf("\n%s\n", "Attaching metadata structures...");
             Int_t Nmetadata = runTmp->GetNumberOfMetadataStructures();

--- a/source/framework/analysis/src/TRestBenchMarkProcess.cxx
+++ b/source/framework/analysis/src/TRestBenchMarkProcess.cxx
@@ -30,7 +30,7 @@ void TRestBenchMarkProcess::Initialize() {
 #else
     fCPUNumber = 0;
     fMemNumber = 0;
-    RESTFerr << "TRestBenchMarkProcess is not available yet on MACOS!!" << RESTendl;
+    RESTError << "TRestBenchMarkProcess is not available yet on MACOS!!" << RESTendl;
 #endif
     fPid = getpid();
     fRefreshRate = 10;
@@ -55,7 +55,7 @@ void TRestBenchMarkProcess::SysMonitorFunc(int pid, double refreshRate) {
 
 void TRestBenchMarkProcess::InitProcess() {
     if (fHostmgr == nullptr || fHostmgr->GetProcessRunner() == nullptr) {
-        RESTFerr << "TRestBenchMarkProcess: the process is not hosted by TRestProcessRunner!" << RESTendl;
+        RESTError << "TRestBenchMarkProcess: the process is not hosted by TRestProcessRunner!" << RESTendl;
         exit(1);
     }
 

--- a/source/framework/analysis/src/TRestBenchMarkProcess.cxx
+++ b/source/framework/analysis/src/TRestBenchMarkProcess.cxx
@@ -30,7 +30,7 @@ void TRestBenchMarkProcess::Initialize() {
 #else
     fCPUNumber = 0;
     fMemNumber = 0;
-    ferr << "TRestBenchMarkProcess is not available yet on MACOS!!" << endl;
+    RESTFerr << "TRestBenchMarkProcess is not available yet on MACOS!!" << RESTendl;
 #endif
     fPid = getpid();
     fRefreshRate = 10;
@@ -55,7 +55,7 @@ void TRestBenchMarkProcess::SysMonitorFunc(int pid, double refreshRate) {
 
 void TRestBenchMarkProcess::InitProcess() {
     if (fHostmgr == nullptr || fHostmgr->GetProcessRunner() == nullptr) {
-        ferr << "TRestBenchMarkProcess: the process is not hosted by TRestProcessRunner!" << endl;
+        RESTFerr << "TRestBenchMarkProcess: the process is not hosted by TRestProcessRunner!" << RESTendl;
         exit(1);
     }
 
@@ -96,12 +96,13 @@ void TRestBenchMarkProcess::EndProcess() {
 void TRestBenchMarkProcess::PrintMetadata() {
     BeginPrintProcess();
 
-    metadata << "REST pid: " << fPid << endl;
-    metadata << "Number of CPUs: " << fCPUNumber << endl;
-    metadata << "Total Memory: " << round((double)fMemNumber / 1024 / 1024 * 10) / 10 << " GB" << endl;
-    metadata << "System information refresh rate: " << fRefreshRate << " Hz" << endl;
-    metadata << "Monitoring thread: " << fMonitorThread
-             << ", status: " << (fMonitorFlag == 0 ? "stopped" : "running") << endl;
+    RESTMetadata << "REST pid: " << fPid << RESTendl;
+    RESTMetadata << "Number of CPUs: " << fCPUNumber << RESTendl;
+    RESTMetadata << "Total Memory: " << round((double)fMemNumber / 1024 / 1024 * 10) / 10 << " GB"
+                 << RESTendl;
+    RESTMetadata << "System information refresh rate: " << fRefreshRate << " Hz" << RESTendl;
+    RESTMetadata << "Monitoring thread: " << fMonitorThread
+                 << ", status: " << (fMonitorFlag == 0 ? "stopped" : "running") << RESTendl;
 
     EndPrintProcess();
 }

--- a/source/framework/analysis/src/TRestDataQualityProcess.cxx
+++ b/source/framework/analysis/src/TRestDataQualityProcess.cxx
@@ -156,7 +156,7 @@ void TRestDataQualityProcess::EndProcess() {
         }
     }
 
-    if (GetVerboseLevel() >= REST_Info) PrintMetadata();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) PrintMetadata();
 
     ///// Just some examples accessing analysis tree
     ///// We can get now any entry.
@@ -187,8 +187,8 @@ void TRestDataQualityProcess::InitFromConfigFile() {
 
         TRestDataQualityRules rules;
 
-        debug << "Quality number tag : " << name << endl;
-        debug << "------------------" << endl;
+        RESTDebug << "Quality number tag : " << name << RESTendl;
+        RESTDebug << "------------------" << RESTendl;
 
         size_t position_2 = 0;
         string ruleDefinition;
@@ -213,17 +213,17 @@ void TRestDataQualityProcess::InitFromConfigFile() {
             // If everything in TODO is ok we push the rule!
             rules.AddRule(type, value, range, bit);
 
-            debug << "Rule " << rules.GetNumberOfRules() << endl;
-            debug << "+++++++++++" << endl;
-            debug << "Type : " << type << endl;
-            debug << "Value : " << value << endl;
-            debug << "Bit : " << bit << endl;
-            debug << "Range : (" << range.X() << ", " << range.Y() << ")" << endl;
+            RESTDebug << "Rule " << rules.GetNumberOfRules() << RESTendl;
+            RESTDebug << "+++++++++++" << RESTendl;
+            RESTDebug << "Type : " << type << RESTendl;
+            RESTDebug << "Value : " << value << RESTendl;
+            RESTDebug << "Bit : " << bit << RESTendl;
+            RESTDebug << "Range : (" << range.X() << ", " << range.Y() << ")" << RESTendl;
         }
         fRules.push_back(rules);
     }
 
-    if (GetVerboseLevel() >= REST_Extreme) GetChar();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
 }
 
 ///////////////////////////////////////////////
@@ -234,33 +234,33 @@ void TRestDataQualityProcess::PrintMetadata() {
     BeginPrintProcess();
 
     for (int n = 0; n < fQualityNumber.size(); n++) {
-        metadata << "    " << endl;
-        metadata << "xxxxxxxxxxxxxxxxxxxxxx" << endl;
-        metadata << " tag : " << fQualityTag[n] << ". Quality number : " << fQualityNumber[n] << endl;
-        metadata << "xxxxxxxxxxxxxxxxxxxxxx" << endl;
-        metadata << "  " << endl;
-        metadata << "Rules that have been found in range:" << endl;
-        metadata << "  -----------------  " << endl;
+        RESTMetadata << "    " << RESTendl;
+        RESTMetadata << "xxxxxxxxxxxxxxxxxxxxxx" << RESTendl;
+        RESTMetadata << " tag : " << fQualityTag[n] << ". Quality number : " << fQualityNumber[n] << RESTendl;
+        RESTMetadata << "xxxxxxxxxxxxxxxxxxxxxx" << RESTendl;
+        RESTMetadata << "  " << RESTendl;
+        RESTMetadata << "Rules that have been found in range:" << RESTendl;
+        RESTMetadata << "  -----------------  " << RESTendl;
         Int_t rulesInRange = 0;
         for (int r = 0; r < fRules[n].GetNumberOfRules(); r++)
             if (isBitEnabled(fQualityNumber[n], fRules[n].GetBit(r))) {
-                metadata << fRules[n].GetValue(r) << " is in range (" << fRules[n].GetRange(r).X() << ", "
-                         << fRules[n].GetRange(r).Y() << ")" << endl;
+                RESTMetadata << fRules[n].GetValue(r) << " is in range (" << fRules[n].GetRange(r).X() << ", "
+                             << fRules[n].GetRange(r).Y() << ")" << RESTendl;
                 rulesInRange++;
             }
-        if (!rulesInRange) metadata << "No rules found in range!" << endl;
-        metadata << " " << endl;
+        if (!rulesInRange) RESTMetadata << "No rules found in range!" << RESTendl;
+        RESTMetadata << " " << RESTendl;
 
-        metadata << "Rules that have NOT been found in range:" << endl;
-        metadata << "  -----------------  " << endl;
+        RESTMetadata << "Rules that have NOT been found in range:" << RESTendl;
+        RESTMetadata << "  -----------------  " << RESTendl;
         Int_t rulesOutRange = 0;
         for (int r = 0; r < fRules[n].GetNumberOfRules(); r++)
             if (!isBitEnabled(fQualityNumber[n], fRules[n].GetBit(r))) {
-                metadata << fRules[n].GetValue(r) << " is NOT in range (" << fRules[n].GetRange(r).X() << ", "
-                         << fRules[n].GetRange(r).Y() << ")" << endl;
+                RESTMetadata << fRules[n].GetValue(r) << " is NOT in range (" << fRules[n].GetRange(r).X()
+                             << ", " << fRules[n].GetRange(r).Y() << ")" << RESTendl;
                 rulesOutRange++;
             }
-        if (!rulesOutRange) metadata << "No rules found outside range!" << endl;
+        if (!rulesOutRange) RESTMetadata << "No rules found outside range!" << RESTendl;
     }
 
     EndPrintProcess();
@@ -283,10 +283,11 @@ Bool_t TRestDataQualityProcess::EvaluateMetadataRule(TString value, TVector2 ran
             // If the metadata value is in range we return true
             if (dblVal >= range.X() && dblVal <= range.Y()) return true;
         } else {
-            ferr << "TRestDataQualityProcess::EvaluateMetadataRule." << endl;
-            ferr << "Metadata class " << results[0] << " is not available inside TRestRun" << endl;
+            RESTFerr << "TRestDataQualityProcess::EvaluateMetadataRule." << RESTendl;
+            RESTFerr << "Metadata class " << results[0] << " is not available inside TRestRun" << RESTendl;
         }
     } else
-        ferr << "TRestDataQualityProcess::EvaluateMetadataRule. Wrong number of elements found" << endl;
+        RESTFerr << "TRestDataQualityProcess::EvaluateMetadataRule. Wrong number of elements found"
+                 << RESTendl;
     return false;
 }

--- a/source/framework/analysis/src/TRestDataQualityProcess.cxx
+++ b/source/framework/analysis/src/TRestDataQualityProcess.cxx
@@ -283,11 +283,11 @@ Bool_t TRestDataQualityProcess::EvaluateMetadataRule(TString value, TVector2 ran
             // If the metadata value is in range we return true
             if (dblVal >= range.X() && dblVal <= range.Y()) return true;
         } else {
-            RESTFerr << "TRestDataQualityProcess::EvaluateMetadataRule." << RESTendl;
-            RESTFerr << "Metadata class " << results[0] << " is not available inside TRestRun" << RESTendl;
+            RESTError << "TRestDataQualityProcess::EvaluateMetadataRule." << RESTendl;
+            RESTError << "Metadata class " << results[0] << " is not available inside TRestRun" << RESTendl;
         }
     } else
-        RESTFerr << "TRestDataQualityProcess::EvaluateMetadataRule. Wrong number of elements found"
-                 << RESTendl;
+        RESTError << "TRestDataQualityProcess::EvaluateMetadataRule. Wrong number of elements found"
+                  << RESTendl;
     return false;
 }

--- a/source/framework/analysis/src/TRestEventRateAnalysisProcess.cxx
+++ b/source/framework/analysis/src/TRestEventRateAnalysisProcess.cxx
@@ -151,7 +151,7 @@ TRestEvent* TRestEventRateAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) 
     if (fPreviousEventTime.size() == 10) meanRate = 10. / (fEvent->GetTime() - fPreviousEventTime.front());
     SetObservableValue("MeanRate_InHz", meanRate);
 
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         for (auto i : fObservablesDefined) {
             fAnalysisTree->PrintObservable(i.second);
         }

--- a/source/framework/analysis/src/TRestEventSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventSelectionProcess.cxx
@@ -141,9 +141,9 @@ TRestEvent* TRestEventSelectionProcess::ProcessEvent(TRestEvent* inputEvent) {
 void TRestEventSelectionProcess::PrintMetadata() {
     BeginPrintProcess();
 
-    metadata << "File with IDs: " << fFileWithIDs << endl;
+    RESTMetadata << "File with IDs: " << fFileWithIDs << RESTendl;
     if (fFileWithIDs.substr(fFileWithIDs.length() - 4) == "root") {
-        metadata << "Conditions: " << fConditions << endl;
+        RESTMetadata << "Conditions: " << fConditions << RESTendl;
     }
 
     EndPrintProcess();

--- a/source/framework/analysis/src/TRestMySQLToAnalysisProcess.cxx
+++ b/source/framework/analysis/src/TRestMySQLToAnalysisProcess.cxx
@@ -146,9 +146,10 @@ void TRestMySQLToAnalysisProcess::InitProcess() {
     if (fSQLVariables.size() > 0)
         FillDBArrays();
     else {
-        warning << "TRestMySQLToAnalysisProcess::InitProcess. No data base field entries have been specified!"
-                << endl;
-        warning << "This process will do nothing!" << endl;
+        RESTWarning
+            << "TRestMySQLToAnalysisProcess::InitProcess. No data base field entries have been specified!"
+            << RESTendl;
+        RESTWarning << "This process will do nothing!" << RESTendl;
     }
 }
 
@@ -165,21 +166,22 @@ TRestEvent* TRestMySQLToAnalysisProcess::ProcessEvent(TRestEvent* inputEvent) {
     fEvent = inputEvent;
 
 #if defined USE_SQL
-    debug << "TRestMySQLToAnalysisProcess. Ev ID : " << fEvent->GetID() << endl;
-    debug << "TRestMySQLToAnalysisProcess. Get timestamp : " << fEvent->GetTime() << endl;
+    RESTDebug << "TRestMySQLToAnalysisProcess. Ev ID : " << fEvent->GetID() << RESTendl;
+    RESTDebug << "TRestMySQLToAnalysisProcess. Get timestamp : " << fEvent->GetTime() << RESTendl;
     for (int n = 0; n < fAnaTreeVariables.size(); n++)
-        debug << "TRestMySQLToAnalysisProcess. Variable : " << fAnaTreeVariables[n]
-              << " value : " << GetDBValueAtTimestamp(n, fEvent->GetTime()) << endl;
+        RESTDebug << "TRestMySQLToAnalysisProcess. Variable : " << fAnaTreeVariables[n]
+                  << " value : " << GetDBValueAtTimestamp(n, fEvent->GetTime()) << RESTendl;
 
-    if (GetVerboseLevel() >= REST_Extreme) GetChar();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
 
     for (int n = 0; n < fAnaTreeVariables.size(); n++)
         SetObservableValue((string)fAnaTreeVariables[n], GetDBValueAtTimestamp(n, fEvent->GetTime()));
 #else
     if (fCheckSQL) {
-        warning << "REST was not linked to SQL libraries. Run cmake using -DREST_SQL=ON" << endl;
-        warning << "Clearing process metadata info." << endl;
-        warning << "Please, remove this process from the data chain or enable support for MySQL." << endl;
+        RESTWarning << "REST was not linked to SQL libraries. Run cmake using -DREST_SQL=ON" << RESTendl;
+        RESTWarning << "Clearing process metadata info." << RESTendl;
+        RESTWarning << "Please, remove this process from the data chain or enable support for MySQL."
+                    << RESTendl;
 
         fAnaTreeVariables.clear();
         fSQLVariables.clear();
@@ -204,19 +206,22 @@ void TRestMySQLToAnalysisProcess::InitFromConfigFile() {
     size_t pos = 0;
 
     fDBServerName = GetParameter("server", "");
-    if (fDBServerName == "") ferr << "TRestMySQLToAnalysisProcess. Database server name not found!" << endl;
+    if (fDBServerName == "")
+        RESTFerr << "TRestMySQLToAnalysisProcess. Database server name not found!" << RESTendl;
 
     fDBName = GetParameter("database", "");
-    if (fDBName == "") ferr << "TRestMySQLToAnalysisProcess. Database not found!" << endl;
+    if (fDBName == "") RESTFerr << "TRestMySQLToAnalysisProcess. Database not found!" << RESTendl;
 
     fDBUserName = GetParameter("user", "");
-    if (fDBUserName == "") ferr << "TRestMySQLToAnalysisProcess. Database user name not found!" << endl;
+    if (fDBUserName == "")
+        RESTFerr << "TRestMySQLToAnalysisProcess. Database user name not found!" << RESTendl;
 
     fDBUserPass = GetParameter("password", "");
-    if (fDBUserPass == "") ferr << "TRestMySQLToAnalysisProcess. Database user password not found!" << endl;
+    if (fDBUserPass == "")
+        RESTFerr << "TRestMySQLToAnalysisProcess. Database user password not found!" << RESTendl;
 
     fDBTable = GetParameter("table", "");
-    if (fDBTable == "") ferr << "TRestMySQLToAnalysisProcess. Database table name not found!" << endl;
+    if (fDBTable == "") RESTFerr << "TRestMySQLToAnalysisProcess. Database table name not found!" << RESTendl;
 
     string definition;
     while ((definition = GetKEYDefinition("dbEntry", pos)) != "") {
@@ -236,19 +241,19 @@ void TRestMySQLToAnalysisProcess::InitFromConfigFile() {
 void TRestMySQLToAnalysisProcess::PrintMetadata() {
     BeginPrintProcess();
 
-    metadata << "SQL data extracted from:" << endl;
-    metadata << "- database : " << fDBName << endl;
-    metadata << "- table : " << fDBTable << endl;
-    metadata << " " << endl;
+    RESTMetadata << "SQL data extracted from:" << RESTendl;
+    RESTMetadata << "- database : " << fDBName << RESTendl;
+    RESTMetadata << "- table : " << fDBTable << RESTendl;
+    RESTMetadata << " " << RESTendl;
 
-    metadata << "List of variables added to the analysis tree" << endl;
-    metadata << " ------------------------------------------ " << endl;
+    RESTMetadata << "List of variables added to the analysis tree" << RESTendl;
+    RESTMetadata << " ------------------------------------------ " << RESTendl;
     for (int n = 0; n < fAnaTreeVariables.size(); n++) {
-        metadata << " + SQL field : " << fSQLVariables[n] << endl;
-        metadata << "   - Tree name : " << fAnaTreeVariables[n] << endl;
-        metadata << "   - Min value : " << fMinValues[n] << endl;
-        metadata << "   - Max value : " << fMaxValues[n] << endl;
-        metadata << "  " << endl;
+        RESTMetadata << " + SQL field : " << fSQLVariables[n] << RESTendl;
+        RESTMetadata << "   - Tree name : " << fAnaTreeVariables[n] << RESTendl;
+        RESTMetadata << "   - Min value : " << fMinValues[n] << RESTendl;
+        RESTMetadata << "   - Max value : " << fMaxValues[n] << RESTendl;
+        RESTMetadata << "  " << RESTendl;
     }
     EndPrintProcess();
 }
@@ -266,32 +271,32 @@ void TRestMySQLToAnalysisProcess::FillDBArrays() {
 #if defined USE_SQL
     MYSQL* conn = mysql_init(nullptr);
     if (conn == nullptr) {
-        ferr << "TRestMySQLToAnalysisProcess::InitProcess. mysql_init() failed" << endl;
+        RESTFerr << "TRestMySQLToAnalysisProcess::InitProcess. mysql_init() failed" << RESTendl;
         exit(1);
     }
 
     if (!mysql_real_connect(conn, fDBServerName.c_str(), fDBUserName.c_str(), fDBUserPass.c_str(),
                             fDBName.c_str(), 0, nullptr, 0)) {
-        ferr << "TRestMySQLToAnalysisProcess::InitProcess. Connection to DB failed!" << endl;
-        ferr << mysql_error(conn) << endl;
+        RESTFerr << "TRestMySQLToAnalysisProcess::InitProcess. Connection to DB failed!" << RESTendl;
+        RESTFerr << mysql_error(conn) << RESTendl;
         exit(1);
     }
 
     string sqlQuery = BuildQueryString();
-    debug << sqlQuery << endl;
+    RESTDebug << sqlQuery << RESTendl;
     if (mysql_query(conn, sqlQuery.c_str())) {
-        ferr << "Error making query to SQL database" << endl;
-        ferr << mysql_error(conn) << endl;
-        ferr << "Query string : " << sqlQuery << endl;
+        RESTFerr << "Error making query to SQL database" << RESTendl;
+        RESTFerr << mysql_error(conn) << RESTendl;
+        RESTFerr << "Query string : " << sqlQuery << RESTendl;
         exit(1);
     }
 
     MYSQL_RES* result = mysql_store_result(conn);
 
     if (result == nullptr) {
-        ferr << "Error getting result from SQL query" << endl;
-        ferr << mysql_error(conn) << endl;
-        ferr << "Query string : " << sqlQuery << endl;
+        RESTFerr << "Error getting result from SQL query" << RESTendl;
+        RESTFerr << mysql_error(conn) << RESTendl;
+        RESTFerr << "Query string : " << sqlQuery << RESTendl;
         exit(1);
     }
 
@@ -302,9 +307,10 @@ void TRestMySQLToAnalysisProcess::FillDBArrays() {
     fSampling = (fEndTimestamp - fStartTimestamp) / num_rows / 2;
 
     if (num_rows < 3) {
-        ferr << "Not enough data found on the event data range" << endl;
-        ferr << "If no database entries exist remove TRestMySQLToAnalysisProcess from your processing chain"
-             << endl;
+        RESTFerr << "Not enough data found on the event data range" << RESTendl;
+        RESTFerr
+            << "If no database entries exist remove TRestMySQLToAnalysisProcess from your processing chain"
+            << RESTendl;
         // We take the decision to stop processing to make sure we are aware of the problem.
         // Specially to identify possible errors in this code.
         // But we might get more flexible with time, and this process just prompts a worning and does nothing.
@@ -344,7 +350,7 @@ void TRestMySQLToAnalysisProcess::FillDBArrays() {
         }
     }
 
-    debug << "Raw data size " << data.size() << endl;
+    RESTDebug << "Raw data size " << data.size() << RESTendl;
 
     fDBdata.clear();
     cout.precision(10);
@@ -379,12 +385,13 @@ void TRestMySQLToAnalysisProcess::FillDBArrays() {
         fDBdata.push_back(dataBuff);
     }
 
-    debug << "Added entries : " << fDBdata.size() << endl;
-    if (GetVerboseLevel() >= REST_Debug) TRestTools::PrintTable(fDBdata, 0, 5);
+    RESTDebug << "Added entries : " << fDBdata.size() << RESTendl;
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
+        TRestTools::PrintTable(fDBdata, 0, 5);
 
     mysql_close(conn);
 #else
-    warning << "REST was not linked to SQL libraries. Run cmake using -DREST_SQL=ON" << endl;
+    RESTWarning << "REST was not linked to SQL libraries. Run cmake using -DREST_SQL=ON" << RESTendl;
 #endif
 }
 

--- a/source/framework/analysis/src/TRestMySQLToAnalysisProcess.cxx
+++ b/source/framework/analysis/src/TRestMySQLToAnalysisProcess.cxx
@@ -207,21 +207,22 @@ void TRestMySQLToAnalysisProcess::InitFromConfigFile() {
 
     fDBServerName = GetParameter("server", "");
     if (fDBServerName == "")
-        RESTFerr << "TRestMySQLToAnalysisProcess. Database server name not found!" << RESTendl;
+        RESTError << "TRestMySQLToAnalysisProcess. Database server name not found!" << RESTendl;
 
     fDBName = GetParameter("database", "");
-    if (fDBName == "") RESTFerr << "TRestMySQLToAnalysisProcess. Database not found!" << RESTendl;
+    if (fDBName == "") RESTError << "TRestMySQLToAnalysisProcess. Database not found!" << RESTendl;
 
     fDBUserName = GetParameter("user", "");
     if (fDBUserName == "")
-        RESTFerr << "TRestMySQLToAnalysisProcess. Database user name not found!" << RESTendl;
+        RESTError << "TRestMySQLToAnalysisProcess. Database user name not found!" << RESTendl;
 
     fDBUserPass = GetParameter("password", "");
     if (fDBUserPass == "")
-        RESTFerr << "TRestMySQLToAnalysisProcess. Database user password not found!" << RESTendl;
+        RESTError << "TRestMySQLToAnalysisProcess. Database user password not found!" << RESTendl;
 
     fDBTable = GetParameter("table", "");
-    if (fDBTable == "") RESTFerr << "TRestMySQLToAnalysisProcess. Database table name not found!" << RESTendl;
+    if (fDBTable == "")
+        RESTError << "TRestMySQLToAnalysisProcess. Database table name not found!" << RESTendl;
 
     string definition;
     while ((definition = GetKEYDefinition("dbEntry", pos)) != "") {
@@ -271,32 +272,32 @@ void TRestMySQLToAnalysisProcess::FillDBArrays() {
 #if defined USE_SQL
     MYSQL* conn = mysql_init(nullptr);
     if (conn == nullptr) {
-        RESTFerr << "TRestMySQLToAnalysisProcess::InitProcess. mysql_init() failed" << RESTendl;
+        RESTError << "TRestMySQLToAnalysisProcess::InitProcess. mysql_init() failed" << RESTendl;
         exit(1);
     }
 
     if (!mysql_real_connect(conn, fDBServerName.c_str(), fDBUserName.c_str(), fDBUserPass.c_str(),
                             fDBName.c_str(), 0, nullptr, 0)) {
-        RESTFerr << "TRestMySQLToAnalysisProcess::InitProcess. Connection to DB failed!" << RESTendl;
-        RESTFerr << mysql_error(conn) << RESTendl;
+        RESTError << "TRestMySQLToAnalysisProcess::InitProcess. Connection to DB failed!" << RESTendl;
+        RESTError << mysql_error(conn) << RESTendl;
         exit(1);
     }
 
     string sqlQuery = BuildQueryString();
     RESTDebug << sqlQuery << RESTendl;
     if (mysql_query(conn, sqlQuery.c_str())) {
-        RESTFerr << "Error making query to SQL database" << RESTendl;
-        RESTFerr << mysql_error(conn) << RESTendl;
-        RESTFerr << "Query string : " << sqlQuery << RESTendl;
+        RESTError << "Error making query to SQL database" << RESTendl;
+        RESTError << mysql_error(conn) << RESTendl;
+        RESTError << "Query string : " << sqlQuery << RESTendl;
         exit(1);
     }
 
     MYSQL_RES* result = mysql_store_result(conn);
 
     if (result == nullptr) {
-        RESTFerr << "Error getting result from SQL query" << RESTendl;
-        RESTFerr << mysql_error(conn) << RESTendl;
-        RESTFerr << "Query string : " << sqlQuery << RESTendl;
+        RESTError << "Error getting result from SQL query" << RESTendl;
+        RESTError << mysql_error(conn) << RESTendl;
+        RESTError << "Query string : " << sqlQuery << RESTendl;
         exit(1);
     }
 
@@ -307,8 +308,8 @@ void TRestMySQLToAnalysisProcess::FillDBArrays() {
     fSampling = (fEndTimestamp - fStartTimestamp) / num_rows / 2;
 
     if (num_rows < 3) {
-        RESTFerr << "Not enough data found on the event data range" << RESTendl;
-        RESTFerr
+        RESTError << "Not enough data found on the event data range" << RESTendl;
+        RESTError
             << "If no database entries exist remove TRestMySQLToAnalysisProcess from your processing chain"
             << RESTendl;
         // We take the decision to stop processing to make sure we are aware of the problem.

--- a/source/framework/analysis/src/TRestRealTimeAddInputFileProcess.cxx
+++ b/source/framework/analysis/src/TRestRealTimeAddInputFileProcess.cxx
@@ -89,7 +89,7 @@ void TRestRealTimeAddInputFileProcess::InitProcess() {
     fMessenger = GetMetadata<TRestMessenger>();
 
     if (fMessenger == nullptr) {
-        ferr << "messenger not found!" << endl;
+        RESTFerr << "messenger not found!" << RESTendl;
         exit(1);
     }
 
@@ -115,7 +115,7 @@ void TRestRealTimeAddInputFileProcess::FileNotificationFunc() {
     while (fMonitorFlag == 1) {
         string message = fMessenger->ConsumeMessage();
         if (message != "") {
-            essential << "Recieveing message: " << message << endl;
+            RESTEssential << "Recieveing message: " << message << RESTendl;
             // 7788->/data2/2MM/M1/graw/CoBo_AsAd1_2020-07-19T13:50:49.519_0000.graw
             // 7788->finish
 
@@ -125,12 +125,12 @@ void TRestRealTimeAddInputFileProcess::FileNotificationFunc() {
                 if (runid == fRunInfo->GetRunNumber()) {
                     string msgContent = runid_filename[1];
                     if (TRestTools::fileExists(msgContent)) {
-                        essential << "Adding file... " << endl;
+                        RESTEssential << "Adding file... " << RESTendl;
                         fRunInfo->AddInputFileExternal(msgContent);
                     } else if (msgContent == "finish") {
                         fRunInfo->ReleaseEndFile();
                     } else {
-                        warning << "illegal message!" << endl;
+                        RESTWarning << "illegal message!" << RESTendl;
                     }
                 } else {
                     // if the runnumber does not match, we put this message back to pool
@@ -138,7 +138,7 @@ void TRestRealTimeAddInputFileProcess::FileNotificationFunc() {
                     fMessenger->SendMessage(message);
                 }
             } else {
-                warning << "illegal message!" << endl;
+                RESTWarning << "illegal message!" << RESTendl;
             }
         }
         usleep(1000);

--- a/source/framework/analysis/src/TRestRealTimeAddInputFileProcess.cxx
+++ b/source/framework/analysis/src/TRestRealTimeAddInputFileProcess.cxx
@@ -89,7 +89,7 @@ void TRestRealTimeAddInputFileProcess::InitProcess() {
     fMessenger = GetMetadata<TRestMessenger>();
 
     if (fMessenger == nullptr) {
-        RESTFerr << "messenger not found!" << RESTendl;
+        RESTError << "messenger not found!" << RESTendl;
         exit(1);
     }
 

--- a/source/framework/analysis/src/TRestRealTimeDrawingProcess.cxx
+++ b/source/framework/analysis/src/TRestRealTimeDrawingProcess.cxx
@@ -143,8 +143,8 @@ void TRestRealTimeDrawingProcess::InitProcess() {
         while (ele != nullptr) {
             string proc = GetParameter("processName", ele);
             if (GetFriendLive(proc) == nullptr) {
-                RESTFerr << "TRestRealTimeDrawingProcess: cannot find process \"" << proc
-                         << "\" to call drawing!" << RESTendl;
+                RESTError << "TRestRealTimeDrawingProcess: cannot find process \"" << proc
+                          << "\" to call drawing!" << RESTendl;
                 exit(1);
             }
             fProcessesToDraw.push_back(proc);
@@ -235,8 +235,9 @@ void TRestRealTimeDrawingProcess::DrawWithNotification() {
     auto messager = GetMetadata<TRestMessenger>();
     int runNumber = StringToInteger(GetParameter("runNumber"));
     if (runNumber == -1) {
-        RESTFerr << "TRestRealTimeDrawingProcess::DrawWithNotification: runNumber must be given!" << RESTendl;
-        RESTFerr << "consider adding \"--d xx\" in restManager command" << RESTendl;
+        RESTError << "TRestRealTimeDrawingProcess::DrawWithNotification: runNumber must be given!"
+                  << RESTendl;
+        RESTError << "consider adding \"--d xx\" in restManager command" << RESTendl;
         abort();
     }
     while (true) {

--- a/source/framework/analysis/src/TRestRealTimeDrawingProcess.cxx
+++ b/source/framework/analysis/src/TRestRealTimeDrawingProcess.cxx
@@ -143,8 +143,8 @@ void TRestRealTimeDrawingProcess::InitProcess() {
         while (ele != nullptr) {
             string proc = GetParameter("processName", ele);
             if (GetFriendLive(proc) == nullptr) {
-                ferr << "TRestRealTimeDrawingProcess: cannot find process \"" << proc << "\" to call drawing!"
-                     << endl;
+                RESTFerr << "TRestRealTimeDrawingProcess: cannot find process \"" << proc
+                         << "\" to call drawing!" << RESTendl;
                 exit(1);
             }
             fProcessesToDraw.push_back(proc);
@@ -177,8 +177,8 @@ TRestEvent* TRestRealTimeDrawingProcess::ProcessEvent(TRestEvent* inputEvent) {
     if (GetFullAnalysisTree()->GetEntries() >= fDrawInterval + fLastDrawnEntry) {
         fPauseInvoke = true;
 
-        info << "TRestRealTimeDrawingProcess: reached drawing flag. Waiting for other processes to pause"
-             << endl;
+        RESTInfo << "TRestRealTimeDrawingProcess: reached drawing flag. Waiting for other processes to pause"
+                 << RESTendl;
         // wait while all other TRestRealTimeDrawingProcess is paused
         for (auto iter = fPauseResponse.begin(); iter != fPauseResponse.end(); iter++) {
             if (iter->first == this) continue;
@@ -188,9 +188,9 @@ TRestEvent* TRestRealTimeDrawingProcess::ProcessEvent(TRestEvent* inputEvent) {
                 i++;
                 if (i > fThreadWaitTimeoutMs) {
                     // to prevent last event in the process chain
-                    warning
+                    RESTWarning
                         << "TRestRealTimeDrawingProcess: waiting time reaches maximum, plotting job aborted"
-                        << endl;
+                        << RESTendl;
                     fPauseInvoke = false;
                     return fEvent;
                 }
@@ -198,7 +198,7 @@ TRestEvent* TRestRealTimeDrawingProcess::ProcessEvent(TRestEvent* inputEvent) {
         }
 
         // starts drawing
-        info << "TRestRealTimeDrawingProcess: drawing..." << endl;
+        RESTInfo << "TRestRealTimeDrawingProcess: drawing..." << RESTendl;
         DrawOnce();
 
         fLastDrawnEntry = GetFullAnalysisTree()->GetEntries();
@@ -213,7 +213,7 @@ TRestEvent* TRestRealTimeDrawingProcess::ProcessEvent(TRestEvent* inputEvent) {
 ///
 void TRestRealTimeDrawingProcess::EndProcess() {
     if (fPauseInvoke == false) {
-        info << "TRestRealTimeDrawingProcess: end drawing..." << endl;
+        RESTInfo << "TRestRealTimeDrawingProcess: end drawing..." << RESTendl;
         DrawOnce();
 
         fPauseInvoke = true;
@@ -235,15 +235,15 @@ void TRestRealTimeDrawingProcess::DrawWithNotification() {
     auto messager = GetMetadata<TRestMessenger>();
     int runNumber = StringToInteger(GetParameter("runNumber"));
     if (runNumber == -1) {
-        ferr << "TRestRealTimeDrawingProcess::DrawWithNotification: runNumber must be given!" << endl;
-        ferr << "consider adding \"--d xx\" in restManager command" << endl;
+        RESTFerr << "TRestRealTimeDrawingProcess::DrawWithNotification: runNumber must be given!" << RESTendl;
+        RESTFerr << "consider adding \"--d xx\" in restManager command" << RESTendl;
         abort();
     }
     while (true) {
         // consmue the message, take out from the message pool
         string message = messager->ConsumeMessage();
         if (message != "") {
-            info << "Recieveing message: " << message << endl;
+            RESTInfo << "Recieveing message: " << message << RESTendl;
             if (TRestTools::fileExists(message) && TRestTools::isRootFile(message)) {
                 TRestRun* run = new TRestRun(message);
                 int _runNumber = run->GetRunNumber();
@@ -256,9 +256,9 @@ void TRestRealTimeDrawingProcess::DrawWithNotification() {
                 } else {
                     // if the runnumber does not match, we put this message back to pool
                     // maybe other processes need it
-                    warning << "file: " << message << endl;
-                    warning << "It is not the file we wanted! runNumber in file: " << _runNumber
-                            << ", run we are processing: " << runNumber << endl;
+                    RESTWarning << "file: " << message << RESTendl;
+                    RESTWarning << "It is not the file we wanted! runNumber in file: " << _runNumber
+                                << ", run we are processing: " << runNumber << RESTendl;
                     messager->SendMessage(message);
                 }
             }
@@ -274,18 +274,18 @@ void TRestRealTimeDrawingProcess::DrawWithNotification() {
 void TRestRealTimeDrawingProcess::PrintMetadata() {
     BeginPrintProcess();
 
-    metadata << "Number of AnalysisPlots added: " << fPlots.size() << endl;
+    RESTMetadata << "Number of AnalysisPlots added: " << fPlots.size() << RESTendl;
     for (auto p : fPlots) {
-        metadata << p->GetName();
+        RESTMetadata << p->GetName();
     }
-    metadata << endl;
-    metadata << "Number of process plots added: " << fProcessesToDraw.size() << endl;
+    RESTMetadata << RESTendl;
+    RESTMetadata << "Number of process plots added: " << fProcessesToDraw.size() << RESTendl;
     for (auto p : fProcessesToDraw) {
-        metadata << p;
+        RESTMetadata << p;
     }
-    metadata << endl;
-    metadata << "Draw interval" << fDrawInterval << endl;
-    metadata << "Waiting time for other thread to stop " << fThreadWaitTimeoutMs << endl;
+    RESTMetadata << RESTendl;
+    RESTMetadata << "Draw interval" << fDrawInterval << RESTendl;
+    RESTMetadata << "Waiting time for other thread to stop " << fThreadWaitTimeoutMs << RESTendl;
 
     EndPrintProcess();
 }

--- a/source/framework/analysis/src/TRestSummaryProcess.cxx
+++ b/source/framework/analysis/src/TRestSummaryProcess.cxx
@@ -197,7 +197,7 @@ void TRestSummaryProcess::EndProcess() {
         fMinimum[x.first] = this->GetFullAnalysisTree()->GetObservableMinimum(x.first, range.X(), range.Y());
     }
 
-    if (GetVerboseLevel() >= REST_Info) PrintMetadata();
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Info) PrintMetadata();
 }
 
 ///////////////////////////////////////////////
@@ -246,31 +246,35 @@ void TRestSummaryProcess::InitFromConfigFile() {
 void TRestSummaryProcess::PrintMetadata() {
     BeginPrintProcess();
 
-    metadata << " - Mean rate : " << fMeanRate << " Hz" << endl;
-    metadata << " - Mean rate sigma : " << fMeanRateSigma << " Hz" << endl;
+    RESTMetadata << " - Mean rate : " << fMeanRate << " Hz" << RESTendl;
+    RESTMetadata << " - Mean rate sigma : " << fMeanRateSigma << " Hz" << RESTendl;
     for (auto const& x : fAverage) {
-        metadata << " " << endl;
-        metadata << x.first << " average:" << x.second << endl;
+        RESTMetadata << " " << RESTendl;
+        RESTMetadata << x.first << " average:" << x.second << RESTendl;
         TVector2 a = fAverageRange[x.first];
-        if (a.X() != -1 && a.Y() != -1) metadata << "    range : (" << a.X() << ", " << a.Y() << ")" << endl;
+        if (a.X() != -1 && a.Y() != -1)
+            RESTMetadata << "    range : (" << a.X() << ", " << a.Y() << ")" << RESTendl;
     }
     for (auto const& x : fRMS) {
-        metadata << " " << endl;
-        metadata << x.first << " RMS:" << x.second << endl;
+        RESTMetadata << " " << RESTendl;
+        RESTMetadata << x.first << " RMS:" << x.second << RESTendl;
         TVector2 a = fRMSRange[x.first];
-        if (a.X() != -1 && a.Y() != -1) metadata << "    range : (" << a.X() << ", " << a.Y() << ")" << endl;
+        if (a.X() != -1 && a.Y() != -1)
+            RESTMetadata << "    range : (" << a.X() << ", " << a.Y() << ")" << RESTendl;
     }
     for (auto const& x : fMaximum) {
-        metadata << " " << endl;
-        metadata << x.first << " Maximum:" << x.second << endl;
+        RESTMetadata << " " << RESTendl;
+        RESTMetadata << x.first << " Maximum:" << x.second << RESTendl;
         TVector2 a = fMaximumRange[x.first];
-        if (a.X() != -1 && a.Y() != -1) metadata << "    range : (" << a.X() << ", " << a.Y() << ")" << endl;
+        if (a.X() != -1 && a.Y() != -1)
+            RESTMetadata << "    range : (" << a.X() << ", " << a.Y() << ")" << RESTendl;
     }
     for (auto const& x : fMinimum) {
-        metadata << " " << endl;
-        metadata << x.first << " Minimum:" << x.second << endl;
+        RESTMetadata << " " << RESTendl;
+        RESTMetadata << x.first << " Minimum:" << x.second << RESTendl;
         TVector2 a = fMinimumRange[x.first];
-        if (a.X() != -1 && a.Y() != -1) metadata << "    range : (" << a.X() << ", " << a.Y() << ")" << endl;
+        if (a.X() != -1 && a.Y() != -1)
+            RESTMetadata << "    range : (" << a.X() << ", " << a.Y() << ")" << RESTendl;
     }
     EndPrintProcess();
 }

--- a/source/framework/core/inc/TRestAnalysisTree.h
+++ b/source/framework/core/inc/TRestAnalysisTree.h
@@ -45,7 +45,7 @@ class TRestAnalysisTree : public TTree {
     Bool_t fQuickSetObservableValue = true;       //!
     std::vector<RESTValue> fObservables;          //!
     std::map<std::string, int> fObservableIdMap;  //!
-    TChain* fChain = nullptr;                        //! in case multiple files for reading
+    TChain* fChain = nullptr;                     //! in case multiple files for reading
 
     // for storage
     Int_t fNObservables;
@@ -133,7 +133,7 @@ class TRestAnalysisTree : public TTree {
     T GetObservableValue(Int_t n) {
         // id check
         if (n >= fNObservables) {
-            std::cout << "Error! TRestAnalysisTree::GetObservableValue(): index outside limits!" << endl;
+            std::cout << "Error! TRestAnalysisTree::GetObservableValue(): index outside limits!" << std::endl;
             return T();
         }
         if (fChain != nullptr) {
@@ -164,11 +164,11 @@ class TRestAnalysisTree : public TTree {
     void SetObservableValue(const Int_t& id, const T& value) {
         // id check
         if (id >= fNObservables) {
-            std::cout << "Error! TRestAnalysisTree::SetObservableValue(): index outside limits!" << endl;
+            std::cout << "Error! TRestAnalysisTree::SetObservableValue(): index outside limits!" << std::endl;
             return;
         }
         if (fChain != nullptr) {
-            std::cout << "Error! cannot set observable! AnalysisTree is in chain state" << endl;
+            std::cout << "Error! cannot set observable! AnalysisTree is in chain state" << std::endl;
             return;
         }
         fObservables[id].SetValue(value);

--- a/source/framework/core/inc/TRestMetadata.h
+++ b/source/framework/core/inc/TRestMetadata.h
@@ -164,9 +164,10 @@ class TRestMetadata : public TNamed {
     std::string messageBuffer;
 
     /// Verbose level used to print debug info
-    REST_Verbose_Level fVerboseLevel;  //!
+    TRestStringOutput::REST_Verbose_Level fVerboseLevel;  //!
     /// Termination flag object for TRestStringOutput
-    endl_t endl;  //!
+    endl_t RESTendl;  //!
+
     /// All metadata classes can be initialized and managed by TRestManager
     TRestManager* fHostmgr;  //!
     /// This variable is used to determine if the metadata structure should be stored in the ROOT file.
@@ -288,8 +289,8 @@ class TRestMetadata : public TNamed {
         return dataPath;
     }
 
-    /// returns the verbose level in type of REST_Verbose_Level enumerator
-    inline REST_Verbose_Level GetVerboseLevel() const { return fVerboseLevel; }
+    /// returns the verboselevel in type of REST_Verbose_Level enumerator
+    inline TRestStringOutput::REST_Verbose_Level GetVerboseLevel() { return fVerboseLevel; }
 
     /// returns the verbose level in type of TString
     TString GetVerboseLevelString();
@@ -315,8 +316,9 @@ class TRestMetadata : public TNamed {
     void SetConfigFile(std::string configFilename) { fConfigFileName = configFilename; }
     /// Set the host manager for this class.
     void SetHostmgr(TRestManager* m) { fHostmgr = m; }
+
     /// sets the verbose level
-    void SetVerboseLevel(REST_Verbose_Level v) { fVerboseLevel = v; }
+    void SetVerboseLevel(TRestStringOutput::REST_Verbose_Level v) { fVerboseLevel = v; }
     /// overwriting the write() method with fStore considered
     virtual Int_t Write(const char* name = nullptr, Int_t option = 0, Int_t bufsize = 0);
 

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -88,8 +88,8 @@ class TRestRun : public TRestMetadata {
         }
 
         if (i >= GetEntries()) {
-            warning << "TRestRun::GetEntry. Entry requested out of limits" << endl;
-            warning << "Total number of entries is : " << GetEntries() << endl;
+            RESTWarning << "TRestRun::GetEntry. Entry requested out of limits" << RESTendl;
+            RESTWarning << "Total number of entries is : " << GetEntries() << RESTendl;
         }
 
         fCurrentEvent = i;
@@ -121,7 +121,7 @@ class TRestRun : public TRestMetadata {
         if (meta != nullptr) {
             fMetadata.push_back(meta);
         } else {
-            warning << "REST Warning! A null metadata wants to be added in TRestRun!" << endl;
+            RESTWarning << "REST Warning! A null metadata wants to be added in TRestRun!" << RESTendl;
         }
     }
     void AddEventBranch(TRestEvent* eve);
@@ -233,13 +233,13 @@ class TRestRun : public TRestMetadata {
     }
     inline void PrintTrees() const {
         if (fEventTree != nullptr) {
-            fout << endl;
-            fout << "=====EventTree=====" << endl;
+            RESTFout << RESTendl;
+            RESTFout << "=====EventTree=====" << RESTendl;
             fEventTree->Print();
         }
         if (fAnalysisTree != nullptr) {
-            fout << endl;
-            fout << "=====AnalysisTree=====" << endl;
+            RESTFout << RESTendl;
+            RESTFout << "=====AnalysisTree=====" << RESTendl;
             fAnalysisTree->Print();
         }
     }

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -233,13 +233,13 @@ class TRestRun : public TRestMetadata {
     }
     inline void PrintTrees() const {
         if (fEventTree != nullptr) {
-            RESTFout << RESTendl;
-            RESTFout << "=====EventTree=====" << RESTendl;
+            RESTcout << RESTendl;
+            RESTcout << "=====EventTree=====" << RESTendl;
             fEventTree->Print();
         }
         if (fAnalysisTree != nullptr) {
-            RESTFout << RESTendl;
-            RESTFout << "=====AnalysisTree=====" << RESTendl;
+            RESTcout << RESTendl;
+            RESTcout << "=====AnalysisTree=====" << RESTendl;
             fAnalysisTree->Print();
         }
     }

--- a/source/framework/core/inc/TRestThread.h
+++ b/source/framework/core/inc/TRestThread.h
@@ -33,11 +33,11 @@ class TRestThread {
     TFile* fOutputFile;                             //!
     TTree* fEventTree;                              //!
 
-    std::thread t;                //!
-    Bool_t isFinished;            //!
-    Bool_t fProcessNullReturned;  //!
-    Int_t fCompressionLevel;      //!
-    Int_t fVerboseLevel;          //!
+    std::thread t;                                        //!
+    Bool_t isFinished;                                    //!
+    Bool_t fProcessNullReturned;                          //!
+    Int_t fCompressionLevel;                              //!
+    TRestStringOutput::REST_Verbose_Level fVerboseLevel;  //!
 
    public:
     void Initialize();
@@ -58,18 +58,18 @@ class TRestThread {
     inline void SetOutputTree(TRestAnalysisTree* t) { fAnalysisTree = t; }
     inline void SetProcessRunner(TRestProcessRunner* r) { fHostRunner = r; }
     inline void SetCompressionLevel(Int_t comp) { fCompressionLevel = comp; }
-    inline void SetVerboseLevel(Int_t verb) { fVerboseLevel = verb; }
+    inline void SetVerboseLevel(TRestStringOutput::REST_Verbose_Level verb) { fVerboseLevel = verb; }
 
     inline Int_t GetThreadId() const { return fThreadId; }
     inline TRestEvent* GetInputEvent() { return fInputEvent; }
-    inline  TFile* GetOutputFile() { return fOutputFile; };
+    inline TFile* GetOutputFile() { return fOutputFile; };
     inline TRestEvent* GetOutputEvent() { return fProcessNullReturned ? 0 : fOutputEvent; }
-    inline  Int_t GetProcessnum() const { return fProcessChain.size(); }
+    inline Int_t GetProcessnum() const { return fProcessChain.size(); }
     inline TRestEventProcess* GetProcess(int i) const { return fProcessChain[i]; }
     inline TRestAnalysisTree* GetAnalysisTree() const { return fAnalysisTree; }
     inline TTree* GetEventTree() { return fEventTree; }
     inline Bool_t Finished() const { return isFinished; }
-    inline Int_t GetVerboseLevel() const { return fVerboseLevel; }
+    inline TRestStringOutput::REST_Verbose_Level GetVerboseLevel() const { return fVerboseLevel; }
 
     // Constructor & Destructor
     TRestThread() { Initialize(); }

--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -232,8 +232,9 @@ void TRestAnalysisPlot::InitFromConfigFile() {
         if (ToUpper(active) == "ON") {
             int N = fPlots.size();
             if (N >= maxPlots) {
-                RESTFerr << "Your canvas divisions (" << fCanvasDivisions.X() << " , " << fCanvasDivisions.Y()
-                         << ") are not enough to show " << N + 1 << " plots" << RESTendl;
+                RESTError << "Your canvas divisions (" << fCanvasDivisions.X() << " , "
+                          << fCanvasDivisions.Y() << ") are not enough to show " << N + 1 << " plots"
+                          << RESTendl;
                 exit(1);
             }
             Plot_Info_Set plot;
@@ -309,9 +310,9 @@ void TRestAnalysisPlot::InitFromConfigFile() {
         if (ToUpper(active) == "ON") {
             int N = fPanels.size();
             if (N >= maxPlots) {
-                RESTFerr << "Your canvas divisions (" << fCanvasDivisions.X() << " , " << fCanvasDivisions.Y()
-                         << ") are not enough to show " << fPlots.size() << " plots, and " << N + 1
-                         << " info panels" << RESTendl;
+                RESTError << "Your canvas divisions (" << fCanvasDivisions.X() << " , "
+                          << fCanvasDivisions.Y() << ") are not enough to show " << fPlots.size()
+                          << " plots, and " << N + 1 << " info panels" << RESTendl;
                 exit(1);
             }
 
@@ -351,10 +352,10 @@ TRestAnalysisPlot::Histo_Info_Set TRestAnalysisPlot::SetupHistogramFromConfigFil
 
     for (int n = 0; n < fPlotNamesCheck.size(); n++)
         if (hist.name == fPlotNamesCheck[n]) {
-            RESTFerr
+            RESTError
                 << "Repeated plot/histo names were found! Please, use different names for different plots!"
                 << RESTendl;
-            RESTFerr << "<plot/histo name=\"" << hist.name << "\" already defined!" << RESTendl;
+            RESTError << "<plot/histo name=\"" << hist.name << "\" already defined!" << RESTendl;
             exit(1);
         }
 
@@ -429,16 +430,16 @@ TRestAnalysisPlot::Histo_Info_Set TRestAnalysisPlot::SetupHistogramFromConfigFil
         if (ToUpper(cutActive) == "ON") {
             string cutVariable = GetParameter("variable", cutele);
             if (cutVariable == PARAMETER_NOT_FOUND_STR) {
-                RESTFerr << "Variable was not found! There is a problem inside <cut definition. Check it."
-                         << RESTendl;
+                RESTError << "Variable was not found! There is a problem inside <cut definition. Check it."
+                          << RESTendl;
                 cout << "Contents of entire <histo definition : " << ElementToString(histele) << endl;
                 cout << endl;
             }
 
             string cutCondition = GetParameter("condition", cutele);
             if (cutCondition == PARAMETER_NOT_FOUND_STR) {
-                RESTFerr << "Condition was not found! There is a problem inside <cut definition. Check it."
-                         << RESTendl;
+                RESTError << "Condition was not found! There is a problem inside <cut definition. Check it."
+                          << RESTendl;
                 cout << "Contents of entire <histo definition : " << ElementToString(histele) << endl;
                 cout << endl;
             }
@@ -463,7 +464,7 @@ TRestAnalysisPlot::Histo_Info_Set TRestAnalysisPlot::SetupHistogramFromConfigFil
         if (ToUpper(cutActive) == "ON") {
             string cutStr = GetParameter("string", cutstrele);
             if (cutStr == PARAMETER_NOT_FOUND_STR) {
-                RESTFerr
+                RESTError
                     << "Cut string was not found! There is a problem inside <cutString definition. Check it."
                     << RESTendl;
                 cout << "Contents of entire <histo definition : " << ElementToString(histele) << endl;
@@ -763,15 +764,15 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
                     RESTInfo << "File: " << fRunInputFileName[j] << ": No entries are drawn" << RESTendl;
                     RESTInfo << "AnalysisTree is empty? cut is too hard?" << RESTendl;
                 } else if (outVal == -1) {
-                    RESTFerr << RESTendl;
-                    RESTFerr
+                    RESTError << RESTendl;
+                    RESTError
                         << "TRestAnalysisPlot::PlotCombinedCanvas. Plot string not properly constructed. "
                            "Does the analysis observable exist inside the file?"
                         << RESTendl;
-                    RESTFerr << "Use \" restManager PrintTrees FILE.ROOT\" to get a list of "
-                                "existing observables."
-                             << RESTendl;
-                    RESTFerr << RESTendl;
+                    RESTError << "Use \" restManager PrintTrees FILE.ROOT\" to get a list of "
+                                 "existing observables."
+                              << RESTendl;
+                    RESTError << RESTendl;
                     exit(1);
                 }
 

--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -76,16 +76,16 @@ void TRestAnalysisPlot::InitFromConfigFile() {
     if (fNFiles == 0) AddFileFromEnv();
 
     if (fNFiles == 0) {
-        warning << "TRestAnalysisPlot: No input files are added!" << endl;
+        RESTWarning << "TRestAnalysisPlot: No input files are added!" << RESTendl;
         // exit(1);
     }
 
 #pragma region ReadLabels
-    debug << "TRestAnalysisPlot: Reading canvas settings" << endl;
+    RESTDebug << "TRestAnalysisPlot: Reading canvas settings" << RESTendl;
     position = 0;
     TiXmlElement* formatDefinition = GetElement("labels");
     if (formatDefinition != nullptr) {
-        if (GetVerboseLevel() >= REST_Debug) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             cout << formatDefinition << endl;
             cout << "Reading format definition : " << endl;
             cout << "---------------------------" << endl;
@@ -109,7 +109,7 @@ void TRestAnalysisPlot::InitFromConfigFile() {
         if (fLabelScaleX == -1) fLabelScaleX = 1.3;
         if (fLabelScaleY == -1) fLabelScaleY = 1.3;
 
-        if (GetVerboseLevel() >= REST_Debug) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             cout << "ticks scale X : " << fTicksScaleX << endl;
             cout << "ticks scale Y : " << fTicksScaleY << endl;
             cout << "label scale X : " << fLabelScaleX << endl;
@@ -117,7 +117,7 @@ void TRestAnalysisPlot::InitFromConfigFile() {
             cout << "label offset X : " << fLabelOffsetX << endl;
             cout << "label offset Y : " << fLabelOffsetY << endl;
 
-            if (GetVerboseLevel() >= REST_Extreme) GetChar();
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
         }
     }
 #pragma endregion
@@ -126,7 +126,7 @@ void TRestAnalysisPlot::InitFromConfigFile() {
     position = 0;
     TiXmlElement* legendDefinition = GetElement("legendPosition");
     if (legendDefinition != nullptr) {
-        if (GetVerboseLevel() >= REST_Debug) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             cout << legendDefinition << endl;
             cout << "Reading legend definition : " << endl;
             cout << "---------------------------" << endl;
@@ -144,11 +144,11 @@ void TRestAnalysisPlot::InitFromConfigFile() {
         if (fLegendX2 == -1) fLegendX2 = 0.88;
         if (fLegendY2 == -1) fLegendY2 = 0.88;
 
-        if (GetVerboseLevel() >= REST_Debug) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             cout << "x1 : " << fLegendX1 << " y1 : " << fLegendY1 << endl;
             cout << "x2 : " << fLegendX2 << " y2 : " << fLegendY2 << endl;
 
-            if (GetVerboseLevel() >= REST_Extreme) GetChar();
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
         }
     }
 #pragma endregion
@@ -174,7 +174,7 @@ void TRestAnalysisPlot::InitFromConfigFile() {
 #pragma endregion
 
 #pragma region ReadGlobalCuts
-    debug << "TRestAnalysisPlot: Reading global cuts" << endl;
+    RESTDebug << "TRestAnalysisPlot: Reading global cuts" << RESTendl;
     vector<string> globalCuts;
     TiXmlElement* gCutele = GetElement("globalCut");
     while (gCutele != nullptr)  // general cuts
@@ -186,8 +186,8 @@ void TRestAnalysisPlot::InitFromConfigFile() {
             if (obsName == "") {
                 obsName = GetParameter("name", gCutele, "");
                 if (obsName != "") {
-                    warning << "<globalCut name=\"var\" is now obsolete." << endl;
-                    warning << "Please, replace by : <globalCut variable=\"var\" " << endl;
+                    RESTWarning << "<globalCut name=\"var\" is now obsolete." << RESTendl;
+                    RESTWarning << "Please, replace by : <globalCut variable=\"var\" " << RESTendl;
                     cout << endl;
                 }
             }
@@ -205,7 +205,7 @@ void TRestAnalysisPlot::InitFromConfigFile() {
 #pragma endregion
 
 #pragma region ReadGlobalCutStrings
-    debug << "TRestAnalysisPlot: Reading global cut strings" << endl;
+    RESTDebug << "TRestAnalysisPlot: Reading global cut strings" << RESTendl;
     TiXmlElement* gCutStrele = GetElement("globalCutString");
     while (gCutStrele != nullptr)  // general cuts
     {
@@ -224,7 +224,7 @@ void TRestAnalysisPlot::InitFromConfigFile() {
 #pragma endregion
 
 #pragma region ReadPlot
-    debug << "TRestAnalysisPlot: Reading plot sections" << endl;
+    RESTDebug << "TRestAnalysisPlot: Reading plot sections" << RESTendl;
     Int_t maxPlots = (Int_t)fCanvasDivisions.X() * (Int_t)fCanvasDivisions.Y();
     TiXmlElement* plotele = GetElement("plot");
     while (plotele != nullptr) {
@@ -232,8 +232,8 @@ void TRestAnalysisPlot::InitFromConfigFile() {
         if (ToUpper(active) == "ON") {
             int N = fPlots.size();
             if (N >= maxPlots) {
-                ferr << "Your canvas divisions (" << fCanvasDivisions.X() << " , " << fCanvasDivisions.Y()
-                     << ") are not enough to show " << N + 1 << " plots" << endl;
+                RESTFerr << "Your canvas divisions (" << fCanvasDivisions.X() << " , " << fCanvasDivisions.Y()
+                         << ") are not enough to show " << N + 1 << " plots" << RESTendl;
                 exit(1);
             }
             Plot_Info_Set plot;
@@ -273,7 +273,7 @@ void TRestAnalysisPlot::InitFromConfigFile() {
                 // add global cut
                 for (unsigned int i = 0; i < globalCuts.size(); i++) {
                     if (i > 0 || hist.cutString != "") hist.cutString += " && ";
-                    if (GetVerboseLevel() >= REST_Debug)
+                    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
                         cout << "Adding global cut : " << globalCuts[i] << endl;
                     hist.cutString += globalCuts[i];
                 }
@@ -283,7 +283,7 @@ void TRestAnalysisPlot::InitFromConfigFile() {
                 //}
 
                 if (hist.plotString == "") {
-                    warning << "No variables or histograms defined in the plot, skipping!" << endl;
+                    RESTWarning << "No variables or histograms defined in the plot, skipping!" << RESTendl;
                 } else {
                     plot.histos.push_back(hist);
                 }
@@ -301,7 +301,7 @@ void TRestAnalysisPlot::InitFromConfigFile() {
 #pragma endregion
 
 #pragma region ReadPanel
-    debug << "TRestAnalysisPlot: Reading panel sections" << endl;
+    RESTDebug << "TRestAnalysisPlot: Reading panel sections" << RESTendl;
     maxPlots -= fPlots.size();  // remaining spaces on canvas
     TiXmlElement* panelele = GetElement("panel");
     while (panelele != nullptr) {
@@ -309,9 +309,9 @@ void TRestAnalysisPlot::InitFromConfigFile() {
         if (ToUpper(active) == "ON") {
             int N = fPanels.size();
             if (N >= maxPlots) {
-                ferr << "Your canvas divisions (" << fCanvasDivisions.X() << " , " << fCanvasDivisions.Y()
-                     << ") are not enough to show " << fPlots.size() << " plots, and " << N + 1
-                     << " info panels" << endl;
+                RESTFerr << "Your canvas divisions (" << fCanvasDivisions.X() << " , " << fCanvasDivisions.Y()
+                         << ") are not enough to show " << fPlots.size() << " plots, and " << N + 1
+                         << " info panels" << RESTendl;
                 exit(1);
             }
 
@@ -333,11 +333,11 @@ void TRestAnalysisPlot::InitFromConfigFile() {
     }
 
     for (int n = 0; n < fPanels.size(); n++) {
-        extreme << "Panel " << n << " with font size : " << fPanels[n].font_size << endl;
+        RESTExtreme << "Panel " << n << " with font size : " << fPanels[n].font_size << RESTendl;
         for (int m = 0; m < fPanels[n].posX.size(); m++) {
-            extreme << "Label : " << fPanels[n].label[m] << endl;
-            extreme << "Pos X : " << fPanels[n].posX[m] << endl;
-            extreme << "Pos Y : " << fPanels[n].posY[m] << endl;
+            RESTExtreme << "Label : " << fPanels[n].label[m] << RESTendl;
+            RESTExtreme << "Pos X : " << fPanels[n].posX[m] << RESTendl;
+            RESTExtreme << "Pos Y : " << fPanels[n].posY[m] << RESTendl;
         }
     }
 }
@@ -351,9 +351,10 @@ TRestAnalysisPlot::Histo_Info_Set TRestAnalysisPlot::SetupHistogramFromConfigFil
 
     for (int n = 0; n < fPlotNamesCheck.size(); n++)
         if (hist.name == fPlotNamesCheck[n]) {
-            ferr << "Repeated plot/histo names were found! Please, use different names for different plots!"
-                 << endl;
-            ferr << "<plot/histo name=\"" << hist.name << "\" already defined!" << endl;
+            RESTFerr
+                << "Repeated plot/histo names were found! Please, use different names for different plots!"
+                << RESTendl;
+            RESTFerr << "<plot/histo name=\"" << hist.name << "\" already defined!" << RESTendl;
             exit(1);
         }
 
@@ -376,7 +377,7 @@ TRestAnalysisPlot::Histo_Info_Set TRestAnalysisPlot::SetupHistogramFromConfigFil
         bins.push_back(StringToInteger(GetParameter("nbins", varele)));
         varele = GetNextElement(varele);
     }
-    if (GetVerboseLevel() >= REST_Debug) {
+    if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
         for (unsigned int n = 0; n < bins.size(); n++) {
             cout << "Variable " << varNames[n] << endl;
             cout << "------------------------------------------" << endl;
@@ -428,22 +429,22 @@ TRestAnalysisPlot::Histo_Info_Set TRestAnalysisPlot::SetupHistogramFromConfigFil
         if (ToUpper(cutActive) == "ON") {
             string cutVariable = GetParameter("variable", cutele);
             if (cutVariable == PARAMETER_NOT_FOUND_STR) {
-                ferr << "Variable was not found! There is a problem inside <cut definition. Check it."
-                     << endl;
+                RESTFerr << "Variable was not found! There is a problem inside <cut definition. Check it."
+                         << RESTendl;
                 cout << "Contents of entire <histo definition : " << ElementToString(histele) << endl;
                 cout << endl;
             }
 
             string cutCondition = GetParameter("condition", cutele);
             if (cutCondition == PARAMETER_NOT_FOUND_STR) {
-                ferr << "Condition was not found! There is a problem inside <cut definition. Check it."
-                     << endl;
+                RESTFerr << "Condition was not found! There is a problem inside <cut definition. Check it."
+                         << RESTendl;
                 cout << "Contents of entire <histo definition : " << ElementToString(histele) << endl;
                 cout << endl;
             }
 
             if (cutString.length() > 0) cutString += " && ";
-            debug << "Adding local cut : " << cutVariable << cutCondition << endl;
+            RESTDebug << "Adding local cut : " << cutVariable << cutCondition << RESTendl;
 
             cutCondition = RemoveWhiteSpaces(cutCondition);
             if (cutCondition.find("==") == 0) {
@@ -462,14 +463,15 @@ TRestAnalysisPlot::Histo_Info_Set TRestAnalysisPlot::SetupHistogramFromConfigFil
         if (ToUpper(cutActive) == "ON") {
             string cutStr = GetParameter("string", cutstrele);
             if (cutStr == PARAMETER_NOT_FOUND_STR) {
-                ferr << "Cut string was not found! There is a problem inside <cutString definition. Check it."
-                     << endl;
+                RESTFerr
+                    << "Cut string was not found! There is a problem inside <cutString definition. Check it."
+                    << RESTendl;
                 cout << "Contents of entire <histo definition : " << ElementToString(histele) << endl;
                 cout << endl;
             }
 
             if (cutString.length() > 0) cutString += " && ";
-            debug << "Adding local cut : " << cutStr << endl;
+            RESTDebug << "Adding local cut : " << cutStr << RESTendl;
 
             cutString += "(" + cutStr + ")";
         }
@@ -505,8 +507,8 @@ TRestAnalysisPlot::Histo_Info_Set TRestAnalysisPlot::SetupHistogramFromConfigFil
 }
 
 void TRestAnalysisPlot::AddFile(TString fileName) {
-    debug << "TRestAnalysisPlot::AddFile. Adding file. " << endl;
-    debug << "File name: " << fileName << endl;
+    RESTDebug << "TRestAnalysisPlot::AddFile. Adding file. " << RESTendl;
+    RESTDebug << "File name: " << fileName << RESTendl;
     fRunInputFileName.push_back((string)fileName);
     fNFiles++;
 }
@@ -535,7 +537,7 @@ void TRestAnalysisPlot::AddFileFromEnv() {
         auto files = TRestTools::GetFilesMatchingPattern(filepattern);
 
         for (unsigned int n = 0; n < files.size(); n++) {
-            essential << "Adding file : " << files[n] << endl;
+            RESTEssential << "Adding file : " << files[n] << RESTendl;
             AddFile(files[n]);
         }
     }
@@ -545,7 +547,7 @@ Int_t TRestAnalysisPlot::GetPlotIndex(TString plotName) {
     for (unsigned int n = 0; n < fPlots.size(); n++)
         if (fPlots[n].name == plotName) return n;
 
-    warning << "TRestAnalysisPlot::GetPlotIndex. Plot name " << plotName << " not found" << endl;
+    RESTWarning << "TRestAnalysisPlot::GetPlotIndex. Plot name " << plotName << " not found" << RESTendl;
     return -1;
 }
 
@@ -593,7 +595,7 @@ Int_t TRestAnalysisPlot::GetColorIDFromString(string in) {
     } else if (ColorIdMap.count(in) != 0) {
         return ColorIdMap.at(in);
     } else {
-        warning << "cannot find color with name \"" << in << "\"" << endl;
+        RESTWarning << "cannot find color with name \"" << in << "\"" << RESTendl;
     }
     return -1;
 }
@@ -604,7 +606,7 @@ Int_t TRestAnalysisPlot::GetFillStyleIDFromString(string in) {
     } else if (FillStyleMap.count(in) != 0) {
         return FillStyleMap.at(in);
     } else {
-        warning << "cannot find fill style with name \"" << in << "\"" << endl;
+        RESTWarning << "cannot find fill style with name \"" << in << "\"" << RESTendl;
     }
     return -1;
 }
@@ -615,7 +617,7 @@ Int_t TRestAnalysisPlot::GetLineStyleIDFromString(string in) {
     } else if (LineStyleMap.count(in) != 0) {
         return LineStyleMap.at(in);
     } else {
-        warning << "cannot find line style with name \"" << in << "\"" << endl;
+        RESTWarning << "cannot find line style with name \"" << in << "\"" << RESTendl;
     }
     return -1;
 }
@@ -717,7 +719,7 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
             rangeString = Replace((string)rangeString, "MIN_TIME", (string)Form("%9f", startTime), pos);
             rangeString = Replace((string)rangeString, "MAX_TIME", (string)Form("%9f", endTime), pos);
 
-            if (GetVerboseLevel() >= REST_Debug) {
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << endl;
                 cout << "--------------------------------------" << endl;
                 cout << "Plot string : " << plotString << endl;
@@ -751,24 +753,25 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
                 int outVal;
                 TString reducedHistoName = nameString + "_" + std::to_string(j);
                 TString histoName = nameString + "_" + std::to_string(j) + rangeString;
-                info << "AnalysisTree->Draw(\"" << plotString << ">>" << histoName << "\", \"" << cutString
-                     << "\", \"" << optString << "\", " << fDrawNEntries << ", " << fDrawFirstEntry << ")"
-                     << endl;
+                RESTInfo << "AnalysisTree->Draw(\"" << plotString << ">>" << histoName << "\", \""
+                         << cutString << "\", \"" << optString << "\", " << fDrawNEntries << ", "
+                         << fDrawFirstEntry << ")" << RESTendl;
                 outVal = tree->Draw(plotString + ">>" + histoName, cutString, optString, fDrawNEntries,
                                     fDrawFirstEntry);
                 TH3F* hh = (TH3F*)gPad->GetPrimitive(reducedHistoName);
                 if (outVal == 0) {
-                    info << "File: " << fRunInputFileName[j] << ": No entries are drawn" << endl;
-                    info << "AnalysisTree is empty? cut is too hard?" << endl;
+                    RESTInfo << "File: " << fRunInputFileName[j] << ": No entries are drawn" << RESTendl;
+                    RESTInfo << "AnalysisTree is empty? cut is too hard?" << RESTendl;
                 } else if (outVal == -1) {
-                    ferr << endl;
-                    ferr << "TRestAnalysisPlot::PlotCombinedCanvas. Plot string not properly constructed. "
-                            "Does the analysis observable exist inside the file?"
-                         << endl;
-                    ferr << "Use \" restManager PrintTrees FILE.ROOT\" to get a list of "
-                            "existing observables."
-                         << endl;
-                    ferr << endl;
+                    RESTFerr << RESTendl;
+                    RESTFerr
+                        << "TRestAnalysisPlot::PlotCombinedCanvas. Plot string not properly constructed. "
+                           "Does the analysis observable exist inside the file?"
+                        << RESTendl;
+                    RESTFerr << "Use \" restManager PrintTrees FILE.ROOT\" to get a list of "
+                                "existing observables."
+                             << RESTendl;
+                    RESTFerr << RESTendl;
                     exit(1);
                 }
 
@@ -797,7 +800,7 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
             }
 
             if (hTotal == nullptr) {
-                warning << "Histogram \"" << nameString << "\" is nullptr" << endl;
+                RESTWarning << "Histogram \"" << nameString << "\" is nullptr" << RESTendl;
             } else if (firstdraw) {
                 // adjust the histogram
                 hTotal->SetTitle(plot.title.c_str());
@@ -839,7 +842,7 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
             }
         }
         if (allempty) {
-            warning << "TRestAnalysisPlot: pad empty for the plot: " << plot.name << endl;
+            RESTWarning << "TRestAnalysisPlot: pad empty for the plot: " << plot.name << RESTendl;
             continue;
         }
 

--- a/source/framework/core/src/TRestAnalysisTree.cxx
+++ b/source/framework/core/src/TRestAnalysisTree.cxx
@@ -415,7 +415,7 @@ void TRestAnalysisTree::ReadLeafValueToObservable(TLeaf* lf, RESTValue& obs) {
                     type = "bool";
                     break;
                 default:
-                    ferr << "Unsupported leaf definition: " << leafdef << "! Assuming int" << endl;
+                    RESTFerr << "Unsupported leaf definition: " << leafdef << "! Assuming int" << RESTendl;
                     type = "int";
             }
         } else {
@@ -430,7 +430,8 @@ void TRestAnalysisTree::ReadLeafValueToObservable(TLeaf* lf, RESTValue& obs) {
                     type = "vector<double>";
                     break;
                 default:
-                    ferr << "Unsupported leaf definition: " << leafdef << "! Assuming vector<int>" << endl;
+                    RESTFerr << "Unsupported leaf definition: " << leafdef << "! Assuming vector<int>"
+                             << RESTendl;
                     type = "vector<int>";
             }
         }
@@ -458,7 +459,7 @@ void TRestAnalysisTree::ReadLeafValueToObservable(TLeaf* lf, RESTValue& obs) {
         string val(ptr, lf->GetLen());
         obs.SetValue(val);
     } else {
-        warning << "Unsupported observable type to convert from TLeaf!" << endl;
+        RESTWarning << "Unsupported observable type to convert from TLeaf!" << RESTendl;
     }
 }
 
@@ -666,7 +667,6 @@ Int_t TRestAnalysisTree::GetEntry(Long64_t entry, Int_t getall) {
         return TTree::GetEntry(entry, getall);
     }
 }
-
 
 void TRestAnalysisTree::SetEventInfo(TRestAnalysisTree* tree) {
     if (fChain != NULL) {
@@ -1029,7 +1029,7 @@ Int_t TRestAnalysisTree::WriteAsTTree(const char* name, Int_t option, Int_t bufs
 Bool_t TRestAnalysisTree::AddChainFile(string _file) {
     auto file = std::unique_ptr<TFile>{TFile::Open(_file.c_str(), "update")};
     if (!file->IsOpen()) {
-        warning << "TRestAnalysisTree::AddChainFile(): failed to open file " << _file << endl;
+        RESTWarning << "TRestAnalysisTree::AddChainFile(): failed to open file " << _file << RESTendl;
         return false;
     }
 
@@ -1046,21 +1046,24 @@ Bool_t TRestAnalysisTree::AddChainFile(string _file) {
                 }
                 return fChain->Add(_file.c_str()) == 1;
             }
-            warning << "TRestAnalysisTree::AddChainFile(): invalid file, AnalysisTree in file has different "
-                       "run id!"
-                    << endl;
+            RESTWarning
+                << "TRestAnalysisTree::AddChainFile(): invalid file, AnalysisTree in file has different "
+                   "run id!"
+                << RESTendl;
         }
-        warning << "TRestAnalysisTree::AddChainFile(): invalid file, AnalysisTree in file is empty!" << endl;
+        RESTWarning << "TRestAnalysisTree::AddChainFile(): invalid file, AnalysisTree in file is empty!"
+                    << RESTendl;
         delete tree;
     }
-    warning << "TRestAnalysisTree::AddChainFile(): invalid file, file does not contain an AnalysisTree!"
-            << endl;
+    RESTWarning << "TRestAnalysisTree::AddChainFile(): invalid file, file does not contain an AnalysisTree!"
+                << RESTendl;
 
     return false;
 }
 
 /// <summary>
-/// Overrides TTree::GetTree(), to get the actual tree used in case of chain operation(fCurrentTree != nullptr)
+/// Overrides TTree::GetTree(), to get the actual tree used in case of chain operation(fCurrentTree !=
+/// nullptr)
 /// </summary>
 /// <returns></returns>
 TTree* TRestAnalysisTree::GetTree() const {

--- a/source/framework/core/src/TRestAnalysisTree.cxx
+++ b/source/framework/core/src/TRestAnalysisTree.cxx
@@ -415,7 +415,7 @@ void TRestAnalysisTree::ReadLeafValueToObservable(TLeaf* lf, RESTValue& obs) {
                     type = "bool";
                     break;
                 default:
-                    RESTFerr << "Unsupported leaf definition: " << leafdef << "! Assuming int" << RESTendl;
+                    RESTError << "Unsupported leaf definition: " << leafdef << "! Assuming int" << RESTendl;
                     type = "int";
             }
         } else {
@@ -430,8 +430,8 @@ void TRestAnalysisTree::ReadLeafValueToObservable(TLeaf* lf, RESTValue& obs) {
                     type = "vector<double>";
                     break;
                 default:
-                    RESTFerr << "Unsupported leaf definition: " << leafdef << "! Assuming vector<int>"
-                             << RESTendl;
+                    RESTError << "Unsupported leaf definition: " << leafdef << "! Assuming vector<int>"
+                              << RESTendl;
                     type = "vector<int>";
             }
         }

--- a/source/framework/core/src/TRestBrowser.cxx
+++ b/source/framework/core/src/TRestBrowser.cxx
@@ -57,7 +57,7 @@ void TRestBrowser::Initialize(TString opt) {
     b = new TBrowser("Browser", 0, "REST Browser", opt);
     TGMainFrame* fr = b->GetBrowserImp()->GetMainFrame();
     if (fr == nullptr) {
-        warning << "No x11 interface is available. Cannot call the browser window!" << endl;
+        RESTWarning << "No x11 interface is available. Cannot call the browser window!" << RESTendl;
         exit(1);
     }
     fr->DontCallClose();
@@ -98,9 +98,10 @@ void TRestBrowser::SetViewer(TString viewerName) {
         if (viewer != nullptr) {
             SetViewer(viewer);
         } else {
-            ferr << viewerName << " not recoginzed! Did you install the corresponding library?" << endl;
-            ferr << "Also check EVE feature is turned on in REST for 3d event viewing." << endl;
-            warning << "Using default event viewer" << endl;
+            RESTFerr << viewerName << " not recoginzed! Did you install the corresponding library?"
+                     << RESTendl;
+            RESTFerr << "Also check EVE feature is turned on in REST for 3d event viewing." << RESTendl;
+            RESTWarning << "Using default event viewer" << RESTendl;
         }
     } else {
         cout << "illegal viewer : " << viewerName << endl;
@@ -208,11 +209,11 @@ void TRestBrowser::SetInputEvent(TRestEvent* eve) {
 
 Bool_t TRestBrowser::LoadEventEntry(Int_t n) {
     if (r->GetInputFile() == nullptr || r->GetInputFile()->IsZombie()) {
-        warning << "TRestBrowser::LoadEventEntry. No File..." << endl;
+        RESTWarning << "TRestBrowser::LoadEventEntry. No File..." << RESTendl;
         return kFALSE;
     }
     if (pureAnalysis) {
-        warning << "TRestBrowser::LoadEventEntry. This is a pure analysis file..." << endl;
+        RESTWarning << "TRestBrowser::LoadEventEntry. This is a pure analysis file..." << RESTendl;
         return kFALSE;
     }
 
@@ -220,7 +221,7 @@ Bool_t TRestBrowser::LoadEventEntry(Int_t n) {
         r->GetEntry(n);
         TRestEvent* ev = r->GetInputEvent();
         if (!ev) {
-            ferr << "internal error!" << endl;
+            RESTFerr << "internal error!" << RESTendl;
             return kFALSE;
         } else {
             fEventRow = r->GetCurrentEntry();
@@ -233,7 +234,7 @@ Bool_t TRestBrowser::LoadEventEntry(Int_t n) {
             r->GetAnalysisTree()->PrintObservables();
         }
     } else {
-        warning << "TRestBrowser::LoadEventEntry. Event out of limits" << endl;
+        RESTWarning << "TRestBrowser::LoadEventEntry. Event out of limits" << RESTendl;
         return kFALSE;
     }
 
@@ -249,19 +250,19 @@ Bool_t TRestBrowser::LoadEventEntry(Int_t n) {
 
 Bool_t TRestBrowser::LoadEventId(Int_t id, Int_t subid) {
     if (r->GetInputFile() == nullptr || r->GetInputFile()->IsZombie()) {
-        warning << "TRestBrowser::LoadEventEntry. No File..." << endl;
+        RESTWarning << "TRestBrowser::LoadEventEntry. No File..." << RESTendl;
         return kFALSE;
     }
     if (pureAnalysis) {
         cout << "" << endl;
-        warning << "TRestBrowser::LoadEventEntry. This is a pure analysis file..." << endl;
+        RESTWarning << "TRestBrowser::LoadEventEntry. This is a pure analysis file..." << RESTendl;
         return kFALSE;
     }
 
     if (r->GetAnalysisTree() != nullptr && r->GetAnalysisTree()->GetEntries() > 0) {
         TRestEvent* ev = r->GetEventWithID(id, subid);
         if (!ev) {
-            warning << "Event ID : " << id << " with sub ID : " << subid << " not found!" << endl;
+            RESTWarning << "Event ID : " << id << " with sub ID : " << subid << " not found!" << RESTendl;
             return kFALSE;
         } else {
             fEventRow = r->GetCurrentEntry();
@@ -274,7 +275,7 @@ Bool_t TRestBrowser::LoadEventId(Int_t id, Int_t subid) {
             r->GetAnalysisTree()->PrintObservables();
         }
     } else {
-        warning << "TRestBrowser::LoadEventEntry. Event out of limits" << endl;
+        RESTWarning << "TRestBrowser::LoadEventEntry. Event out of limits" << RESTendl;
         return kFALSE;
     }
 
@@ -325,7 +326,7 @@ Bool_t TRestBrowser::OpenFile(TString filename) {
 
         TRestEvent* ev = r->GetInputEvent();
         if (!ev) {
-            ferr << "internal error!" << endl;
+            RESTFerr << "internal error!" << RESTendl;
         } else {
             fEventRowNumberBox->SetIntNumber(r->GetCurrentEntry());
             fEventIdNumberBox->SetIntNumber(ev->GetID());
@@ -333,7 +334,7 @@ Bool_t TRestBrowser::OpenFile(TString filename) {
         }
         return true;
     } else {
-        ferr << "file: " << filename << " does not exist!" << endl;
+        RESTFerr << "file: " << filename << " does not exist!" << RESTendl;
     }
     return false;
 }
@@ -372,7 +373,7 @@ void TRestBrowser::RowValueChangedAction(Long_t val) {
     int rowold = fEventRow;
     fEventRow = (Int_t)fEventRowNumberBox->GetNumber();
 
-    debug << "TRestBrowser::LoadEventAction. Entry:" << fEventRow << endl;
+    RESTDebug << "TRestBrowser::LoadEventAction. Entry:" << fEventRow << RESTendl;
 
     bool success = LoadEventEntry(fEventRow);
 
@@ -399,7 +400,8 @@ void TRestBrowser::IdValueChangedAction(Long_t val) {
     fEventId = (Int_t)fEventIdNumberBox->GetNumber();
     fEventSubId = (Int_t)fEventSubIdNumberBox->GetNumber();
 
-    debug << "TRestBrowser::LoadEventAction. Event ID: " << fEventId << ", Sub ID: " << fEventSubId << endl;
+    RESTDebug << "TRestBrowser::LoadEventAction. Event ID: " << fEventId << ", Sub ID: " << fEventSubId
+              << RESTendl;
 
     bool success = LoadEventId(fEventId, fEventSubId);
 

--- a/source/framework/core/src/TRestBrowser.cxx
+++ b/source/framework/core/src/TRestBrowser.cxx
@@ -98,9 +98,9 @@ void TRestBrowser::SetViewer(TString viewerName) {
         if (viewer != nullptr) {
             SetViewer(viewer);
         } else {
-            RESTFerr << viewerName << " not recoginzed! Did you install the corresponding library?"
-                     << RESTendl;
-            RESTFerr << "Also check EVE feature is turned on in REST for 3d event viewing." << RESTendl;
+            RESTError << viewerName << " not recoginzed! Did you install the corresponding library?"
+                      << RESTendl;
+            RESTError << "Also check EVE feature is turned on in REST for 3d event viewing." << RESTendl;
             RESTWarning << "Using default event viewer" << RESTendl;
         }
     } else {
@@ -221,7 +221,7 @@ Bool_t TRestBrowser::LoadEventEntry(Int_t n) {
         r->GetEntry(n);
         TRestEvent* ev = r->GetInputEvent();
         if (!ev) {
-            RESTFerr << "internal error!" << RESTendl;
+            RESTError << "internal error!" << RESTendl;
             return kFALSE;
         } else {
             fEventRow = r->GetCurrentEntry();
@@ -326,7 +326,7 @@ Bool_t TRestBrowser::OpenFile(TString filename) {
 
         TRestEvent* ev = r->GetInputEvent();
         if (!ev) {
-            RESTFerr << "internal error!" << RESTendl;
+            RESTError << "internal error!" << RESTendl;
         } else {
             fEventRowNumberBox->SetIntNumber(r->GetCurrentEntry());
             fEventIdNumberBox->SetIntNumber(ev->GetID());
@@ -334,7 +334,7 @@ Bool_t TRestBrowser::OpenFile(TString filename) {
         }
         return true;
     } else {
-        RESTFerr << "file: " << filename << " does not exist!" << RESTendl;
+        RESTError << "file: " << filename << " does not exist!" << RESTendl;
     }
     return false;
 }

--- a/source/framework/core/src/TRestCut.cxx
+++ b/source/framework/core/src/TRestCut.cxx
@@ -78,14 +78,15 @@ void TRestCut::InitFromConfigFile() {
 
 void TRestCut::AddCut(TCut cut) {
     if ((string)cut.GetName() == "") {
-        warning << "TRestCut::AddCut: cannot add cut without name!" << endl;
+        RESTWarning << "TRestCut::AddCut: cannot add cut without name!" << RESTendl;
     }
     if ((string)cut.GetTitle() == "") {
-        warning << "TRestCut::AddCut: cannot add empty cut!" << endl;
+        RESTWarning << "TRestCut::AddCut: cannot add empty cut!" << RESTendl;
     }
     for (auto c : fCuts) {
         if ((string)c.GetName() == (string)cut.GetName()) {
-            warning << "TRestCut::AddCut: cut with name \"" << c.GetName() << "\" already added!" << endl;
+            RESTWarning << "TRestCut::AddCut: cut with name \"" << c.GetName() << "\" already added!"
+                        << RESTendl;
             return;
         }
     }
@@ -103,10 +104,10 @@ TCut TRestCut::GetCut(string name) {
 
 void TRestCut::PrintMetadata() {
     TRestMetadata::PrintMetadata();
-    metadata << " " << endl;
-    metadata << "Number of TCut objects added: " << fCuts.size() << endl;
-    metadata << " " << endl;
-    metadata << "+++" << endl;
+    RESTMetadata << " " << RESTendl;
+    RESTMetadata << "Number of TCut objects added: " << fCuts.size() << RESTendl;
+    RESTMetadata << " " << RESTendl;
+    RESTMetadata << "+++" << RESTendl;
 }
 
 Int_t TRestCut::Write(const char* name, Int_t option, Int_t bufsize) {

--- a/source/framework/core/src/TRestDBEntryLogger.cxx
+++ b/source/framework/core/src/TRestDBEntryLogger.cxx
@@ -39,7 +39,7 @@ void TRestDBEntryLogger::InitFromConfigFile() {
         } else if (!fSkipIfNotEmpty) {
             AskForFilling(runs[0]);
         } else {
-            RESTFout << "TRestDBEntryLogger: skipping existing run" << RESTendl;
+            RESTcout << "TRestDBEntryLogger: skipping existing run" << RESTendl;
         }
     }
 }
@@ -187,7 +187,7 @@ void TRestDBEntryLogger::AskForFilling(int run_id) {
         }
     }
 
-    RESTFout << "TRestDBEntryLogger: DataBase writing successful" << RESTendl;
+    RESTcout << "TRestDBEntryLogger: DataBase writing successful" << RESTendl;
 }
 
 void TRestDBEntryLogger::Initialize() {}

--- a/source/framework/core/src/TRestDBEntryLogger.cxx
+++ b/source/framework/core/src/TRestDBEntryLogger.cxx
@@ -13,7 +13,7 @@ TRestDBEntryLogger::TRestDBEntryLogger() { Initialize(); }
 void TRestDBEntryLogger::InitFromConfigFile() {
     // check environment
     if (gDataBase == nullptr) {
-        RESTFerr << "REST database is not initailized!" << RESTendl;
+        RESTError << "REST database is not initailized!" << RESTendl;
         abort();
     }
 

--- a/source/framework/core/src/TRestDBEntryLogger.cxx
+++ b/source/framework/core/src/TRestDBEntryLogger.cxx
@@ -13,7 +13,7 @@ TRestDBEntryLogger::TRestDBEntryLogger() { Initialize(); }
 void TRestDBEntryLogger::InitFromConfigFile() {
     // check environment
     if (gDataBase == nullptr) {
-        ferr << "REST database is not initailized!" << endl;
+        RESTFerr << "REST database is not initailized!" << RESTendl;
         abort();
     }
 
@@ -39,7 +39,7 @@ void TRestDBEntryLogger::InitFromConfigFile() {
         } else if (!fSkipIfNotEmpty) {
             AskForFilling(runs[0]);
         } else {
-            fout << "TRestDBEntryLogger: skipping existing run" << endl;
+            RESTFout << "TRestDBEntryLogger: skipping existing run" << RESTendl;
         }
     }
 }
@@ -92,7 +92,7 @@ void TRestDBEntryLogger::AskForFilling(int run_id) {
     while (getline(ifs, s)) {
         if (!valid) {
             if (s[0] != '-') {
-                warning << "TRestDBEntryLogger: DataBase writing cancelled" << endl;
+                RESTWarning << "TRestDBEntryLogger: DataBase writing cancelled" << RESTendl;
                 ifs.close();
                 return;
             } else {
@@ -187,7 +187,7 @@ void TRestDBEntryLogger::AskForFilling(int run_id) {
         }
     }
 
-    fout << "TRestDBEntryLogger: DataBase writing successful" << endl;
+    RESTFout << "TRestDBEntryLogger: DataBase writing successful" << RESTendl;
 }
 
 void TRestDBEntryLogger::Initialize() {}

--- a/source/framework/core/src/TRestEventProcess.cxx
+++ b/source/framework/core/src/TRestEventProcess.cxx
@@ -125,7 +125,7 @@ vector<string> TRestEventProcess::ReadObservables() {
 
         if (ToUpper(value) == "ON") {
             if (obschr != nullptr) {
-                debug << this->ClassName() << " : setting observable \"" << obschr << "\"" << endl;
+                RESTDebug << this->ClassName() << " : setting observable \"" << obschr << "\"" << RESTendl;
                 // vector<string> tmp = Split(obsstring, ":");
                 obsnames.push_back(obschr);
                 obstypes.push_back(type);
@@ -333,7 +333,8 @@ cout << GetName() << ": Process initialization..." << endl;
 /// as
 /// input event
 void TRestEventProcess::BeginOfEventProcess(TRestEvent* inEv) {
-    debug << "Entering " << ClassName() << "::BeginOfEventProcess, Initializing output event..." << endl;
+    RESTDebug << "Entering " << ClassName() << "::BeginOfEventProcess, Initializing output event..."
+              << RESTendl;
     if (inEv != nullptr && GetOutputEvent().address != nullptr && (TRestEvent*)GetOutputEvent() != inEv) {
         TRestEvent* outEv = GetOutputEvent();
         outEv->Initialize();
@@ -367,16 +368,17 @@ void TRestEventProcess::ProcessEvent( TRestEvent *inputEvent )
 /// \brief End of event process. Validate the updated observable number matches total defined observable
 /// number
 void TRestEventProcess::EndOfEventProcess(TRestEvent* inputEvent) {
-    debug << "Entering TRestEventProcess::EndOfEventProcess (" << ClassName() << ")" << endl;
+    RESTDebug << "Entering TRestEventProcess::EndOfEventProcess (" << ClassName() << ")" << RESTendl;
     if (fValidateObservables) {
         if (fObservablesDefined.size() != fObservablesUpdated.size()) {
             for (auto x : fObservablesDefined) {
                 if (fObservablesUpdated.count(x.first) == 0) {
                     // the observable is added through <observable section but not set in the process
-                    warning << "The observable  '" << x.first << "' is defined but not set by "
-                            << this->ClassName()
-                            << ", the event is empty? Makesure all observables are set through ProcessEvent()"
-                            << endl;
+                    RESTWarning
+                        << "The observable  '" << x.first << "' is defined but not set by "
+                        << this->ClassName()
+                        << ", the event is empty? Makesure all observables are set through ProcessEvent()"
+                        << RESTendl;
                 }
             }
         }
@@ -400,32 +402,32 @@ cout << GetName() << ": Process ending..." << endl;
 /// Prints process type, name, title, verboselevel, outputlevel, input/output
 /// event type, and several separators
 void TRestEventProcess::BeginPrintProcess() {
-    metadata.setcolor(COLOR_BOLDGREEN);
-    metadata.setborder("||");
-    metadata.setlength(100);
+    RESTMetadata.setcolor(COLOR_BOLDGREEN);
+    RESTMetadata.setborder("||");
+    RESTMetadata.setlength(100);
     // metadata << " " << endl;
     cout << endl;
-    metadata << "=" << endl;
-    metadata << "Process : " << ClassName() << endl;
-    metadata << "Name: " << GetName() << "  Title: " << GetTitle()
-             << "  VerboseLevel: " << GetVerboseLevelString() << endl;
-    metadata << " ----------------------------------------------- " << endl;
-    metadata << " " << endl;
+    RESTMetadata << "=" << RESTendl;
+    RESTMetadata << "Process : " << ClassName() << RESTendl;
+    RESTMetadata << "Name: " << GetName() << "  Title: " << GetTitle()
+                 << "  VerboseLevel: " << GetVerboseLevelString() << RESTendl;
+    RESTMetadata << " ----------------------------------------------- " << RESTendl;
+    RESTMetadata << " " << RESTendl;
 
     if (fObservablesDefined.size() > 0) {
-        metadata << " Analysis tree observables added by this process " << endl;
-        metadata << " +++++++++++++++++++++++++++++++++++++++++++++++ " << endl;
+        RESTMetadata << " Analysis tree observables added by this process " << RESTendl;
+        RESTMetadata << " +++++++++++++++++++++++++++++++++++++++++++++++ " << RESTendl;
     }
 
     auto iter = fObservablesDefined.begin();
     while (iter != fObservablesDefined.end()) {
-        metadata << " ++ " << iter->first << endl;
+        RESTMetadata << " ++ " << iter->first << RESTendl;
         iter++;
     }
 
     if (fObservablesDefined.size() > 0) {
-        metadata << " +++++++++++++++++++++++++++++++++++++++++++++++ " << endl;
-        metadata << " " << endl;
+        RESTMetadata << " +++++++++++++++++++++++++++++++++++++++++++++++ " << RESTendl;
+        RESTMetadata << " " << RESTendl;
     }
 }
 
@@ -436,24 +438,24 @@ void TRestEventProcess::BeginPrintProcess() {
 /// Prints several separators. Prints cuts.
 void TRestEventProcess::EndPrintProcess() {
     if (fCuts.size() > 0) {
-        metadata << "Cuts enabled" << endl;
-        metadata << "------------" << endl;
+        RESTMetadata << "Cuts enabled" << RESTendl;
+        RESTMetadata << "------------" << RESTendl;
 
         auto iter = fCuts.begin();
         while (iter != fCuts.end()) {
             if (iter->second.X() != iter->second.Y())
-                metadata << iter->first << ", range : ( " << iter->second.X() << " , " << iter->second.Y()
-                         << " ) " << endl;
+                RESTMetadata << iter->first << ", range : ( " << iter->second.X() << " , " << iter->second.Y()
+                             << " ) " << RESTendl;
             iter++;
         }
     }
 
-    metadata << " " << endl;
-    metadata << "=" << endl;
-    metadata << endl;
-    metadata.resetcolor();
-    metadata.setborder("");
-    metadata.setlength(10000);
+    RESTMetadata << " " << RESTendl;
+    RESTMetadata << "=" << RESTendl;
+    RESTMetadata << RESTendl;
+    RESTMetadata.resetcolor();
+    RESTMetadata.setborder("");
+    RESTMetadata.setlength(10000);
 }
 
 ////////////////////////////////////////////////////////////////////////////

--- a/source/framework/core/src/TRestGDMLParser.cxx
+++ b/source/framework/core/src/TRestGDMLParser.cxx
@@ -76,8 +76,8 @@ void TRestGDMLParser::Load(const string& filename) {
         }
 
     } else {
-        RESTFerr << "TRestGDMLParser: Input GDML file: \"" << filename
-                 << "\" does not exist. Please double check your current path and filename" << RESTendl;
+        RESTError << "TRestGDMLParser: Input GDML file: \"" << filename
+                  << "\" does not exist. Please double check your current path and filename" << RESTendl;
         exit(1);
     }
 }

--- a/source/framework/core/src/TRestGDMLParser.cxx
+++ b/source/framework/core/src/TRestGDMLParser.cxx
@@ -76,8 +76,8 @@ void TRestGDMLParser::Load(const string& filename) {
         }
 
     } else {
-        ferr << "TRestGDMLParser: Input GDML file: \"" << filename
-             << "\" does not exist. Please double check your current path and filename" << endl;
+        RESTFerr << "TRestGDMLParser: Input GDML file: \"" << filename
+                 << "\" does not exist. Please double check your current path and filename" << RESTendl;
         exit(1);
     }
 }

--- a/source/framework/core/src/TRestManager.cxx
+++ b/source/framework/core/src/TRestManager.cxx
@@ -103,19 +103,19 @@ Int_t TRestManager::ReadConfig(string keydeclare, TiXmlElement* e) {
     else if (keydeclare == "addTask") {
         string active = GetParameter("value", e, "");
         if (active != "ON" && active != "On" && active != "on") {
-            debug << "Inactived task : \"" << ElementToString(e) << "\"" << endl;
+            RESTDebug << "Inactived task : \"" << ElementToString(e) << "\"" << RESTendl;
             return 0;
         }
-        debug << "Loading Task...";
+        RESTDebug << "Loading Task...";
 
         const char* type = e->Attribute("type");
         const char* cmd = e->Attribute("command");
         if (type == nullptr && cmd == nullptr) {
-            warning << "command or type should be given!" << endl;
+            RESTWarning << "command or type should be given!" << RESTendl;
             return -1;
         }
         if (type != nullptr) {
-            debug << " \"" << type << "\" " << endl;
+            RESTDebug << " \"" << type << "\" " << RESTendl;
             if ((string)type == "processEvents") {
                 auto pr = GetProcessRunner();
                 if (pr != nullptr) pr->RunProcess();
@@ -131,8 +131,8 @@ Int_t TRestManager::ReadConfig(string keydeclare, TiXmlElement* e) {
             } else {
                 TRestTask* tsk = TRestTask::GetTaskFromMacro(type);
                 if (tsk == nullptr) {
-                    warning << "REST ERROR. Task : " << type << " not found!!" << endl;
-                    warning << "This task will be skipped." << endl;
+                    RESTWarning << "REST ERROR. Task : " << type << " not found!!" << RESTendl;
+                    RESTWarning << "This task will be skipped." << RESTendl;
                     return -1;
                 }
                 tsk->LoadConfigFromElement(e, fElementGlobal);
@@ -140,12 +140,12 @@ Int_t TRestManager::ReadConfig(string keydeclare, TiXmlElement* e) {
                 return 0;
             }
         } else if (cmd != nullptr) {
-            debug << " \"" << cmd << "\" " << endl;
+            RESTDebug << " \"" << cmd << "\" " << RESTendl;
 
             TRestTask* tsk = TRestTask::GetTaskFromCommand(cmd);
             if (tsk == nullptr) {
-                warning << "REST ERROR. Command : " << cmd << " cannot be parsed!!" << endl;
-                warning << "This task will be skipped." << endl;
+                RESTWarning << "REST ERROR. Command : " << cmd << " cannot be parsed!!" << RESTendl;
+                RESTWarning << "This task will be skipped." << RESTendl;
                 return -1;
             }
             tsk->RunTask(this);

--- a/source/framework/core/src/TRestMessenger.cxx
+++ b/source/framework/core/src/TRestMessenger.cxx
@@ -215,7 +215,7 @@ bool TRestMessenger::unlock(messagepool_t* pool, int timeoutMs) {
         usleep(1000);
         i++;
         if (i >= timeoutMs) {
-            RESTFerr << "unlocking pool failed!" << RESTendl;
+            RESTError << "unlocking pool failed!" << RESTendl;
             abort();
         }
     }

--- a/source/framework/core/src/TRestMessenger.cxx
+++ b/source/framework/core/src/TRestMessenger.cxx
@@ -139,27 +139,28 @@ void TRestMessenger::InitFromConfigFile() {
         if (shmid == -1) {
             shmid = shmget(key, 30000, SHMFLAG_CREATEUNIQUE);
             if (shmid == -1) {
-                warning << "TRestMessenger: unknown error!" << endl;
+                RESTWarning << "TRestMessenger: unknown error!" << RESTendl;
                 return;
             } else {
                 created = true;
             }
         } else {
-            warning << "TRestMessenger: shmget error!" << endl;
-            warning << "Shared memory not deleted? type \"ipcrm -m " << shmid << "\" in the bash" << endl;
+            RESTWarning << "TRestMessenger: shmget error!" << RESTendl;
+            RESTWarning << "Shared memory not deleted? type \"ipcrm -m " << shmid << "\" in the bash"
+                        << RESTendl;
             return;
         }
     } else if (fMode == MessagePool_Client) {
         if (shmid == -1) {
-            warning << "TRestMessenger: shmget error!" << endl;
-            warning << "Shared memory not initialized? Launch Host process first!" << endl;
+            RESTWarning << "TRestMessenger: shmget error!" << RESTendl;
+            RESTWarning << "Shared memory not initialized? Launch Host process first!" << RESTendl;
             return;
         }
     } else if (fMode == MessagePool_TwoWay) {
         if (shmid == -1) {
             shmid = shmget(key, 30000, SHMFLAG_CREATEUNIQUE);
             if (shmid == -1) {
-                warning << "TRestMessenger: unknown error!" << endl;
+                RESTWarning << "TRestMessenger: unknown error!" << RESTendl;
                 return;
             } else {
                 created = true;
@@ -181,8 +182,8 @@ void TRestMessenger::InitFromConfigFile() {
         cout << "Created shared memory: " << shmid << endl;
     } else {
         if (strcmp(message->name, this->GetName()) != 0) {
-            warning << "TRestMessenger: connected message pool name(" << message->name
-                    << ") is different with this(" << this->GetName() << ")!" << endl;
+            RESTWarning << "TRestMessenger: connected message pool name(" << message->name
+                        << ") is different with this(" << this->GetName() << ")!" << RESTendl;
         }
         cout << "Connected to shared memory: " << shmid << endl;
     }
@@ -214,7 +215,7 @@ bool TRestMessenger::unlock(messagepool_t* pool, int timeoutMs) {
         usleep(1000);
         i++;
         if (i >= timeoutMs) {
-            ferr << "unlocking pool failed!" << endl;
+            RESTFerr << "unlocking pool failed!" << RESTendl;
             abort();
         }
     }
@@ -226,7 +227,7 @@ bool TRestMessenger::unlock(messagepool_t* pool, int timeoutMs) {
 
 void TRestMessenger::AddPool(string message) {
     if (!IsConnected()) {
-        warning << "TRestMessenger: Not connected!" << endl;
+        RESTWarning << "TRestMessenger: Not connected!" << RESTendl;
         return;
     }
 
@@ -234,13 +235,13 @@ void TRestMessenger::AddPool(string message) {
         message = message.substr(0, MsgLength - 2);
     }
     if (message == "") {
-        warning << "cannot add empty message!" << endl;
+        RESTWarning << "cannot add empty message!" << RESTendl;
         return;
     }
 
     messagepool_t* pool = fMessagePool;
     if (!lock(pool)) {
-        warning << "cannot add message to pool: " << pool->name << ": lock failed!" << endl;
+        RESTWarning << "cannot add message to pool: " << pool->name << ": lock failed!" << RESTendl;
         return;
     }
 
@@ -251,7 +252,7 @@ void TRestMessenger::AddPool(string message) {
         strcpy(msg.content, message.c_str());
         memcpy(&pool->messages[pos], &msg, sizeof(msg));
     } else {
-        warning << "cannot send message: message pool is full!" << endl;
+        RESTWarning << "cannot send message: message pool is full!" << RESTendl;
     }
 
     unlock(pool);
@@ -259,11 +260,11 @@ void TRestMessenger::AddPool(string message) {
 
 void TRestMessenger::SendMessage(string message) {
     if (!IsConnected()) {
-        warning << "TRestMessenger: Not connected!" << endl;
+        RESTWarning << "TRestMessenger: Not connected!" << RESTendl;
         return;
     }
     if (fMode == MessagePool_Client) {
-        warning << "TRestMessenger: Forbidden to send message from client!" << endl;
+        RESTWarning << "TRestMessenger: Forbidden to send message from client!" << RESTendl;
         return;
     }
 
@@ -286,12 +287,12 @@ vector<string> TRestMessenger::ShowMessagePool() {
     vector<string> result;
 
     if (!IsConnected()) {
-        warning << "TRestMessenger: Not connected!" << endl;
+        RESTWarning << "TRestMessenger: Not connected!" << RESTendl;
         return result;
     }
 
     if (!lock(fMessagePool)) {
-        warning << "cannot read message to pool: " << fMessagePool->name << ": lock failed!" << endl;
+        RESTWarning << "cannot read message to pool: " << fMessagePool->name << ": lock failed!" << RESTendl;
         return result;
     }
 
@@ -310,16 +311,16 @@ vector<string> TRestMessenger::ShowMessagePool() {
 
 string TRestMessenger::ConsumeMessage() {
     if (!IsConnected()) {
-        warning << "TRestMessenger: Not connected!" << endl;
+        RESTWarning << "TRestMessenger: Not connected!" << RESTendl;
         return "";
     }
     if (fMode == MessagePool_Host) {
-        warning << "TRestMessenger: Forbidden to consume message from host!" << endl;
+        RESTWarning << "TRestMessenger: Forbidden to consume message from host!" << RESTendl;
         return "";
     }
 
     if (!lock(fMessagePool)) {
-        warning << "cannot read message to pool: " << fMessagePool->name << ": lock failed!" << endl;
+        RESTWarning << "cannot read message to pool: " << fMessagePool->name << ": lock failed!" << RESTendl;
         return "";
     }
 
@@ -345,13 +346,13 @@ void TRestMessenger::PrintMetadata() {
     TRestMetadata::PrintMetadata();
 
     if (IsConnected()) {
-        metadata << "Connected : "
-                 << " (token: " << fPoolToken << ", shmid: " << fShmId << ", source: " << fPoolSource << ")"
-                 << endl;
+        RESTMetadata << "Connected : "
+                     << " (token: " << fPoolToken << ", shmid: " << fShmId << ", source: " << fPoolSource
+                     << ")" << RESTendl;
     } else {
-        metadata << "Not Connected" << endl;
+        RESTMetadata << "Not Connected" << RESTendl;
     }
-    metadata << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
-    metadata << endl;
-    metadata << endl;
+    RESTMetadata << "+++++++++++++++++++++++++++++++++++++++++++++" << RESTendl;
+    RESTMetadata << RESTendl;
+    RESTMetadata << RESTendl;
 }

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -474,7 +474,7 @@ ClassImp(TRestMetadata);
 ///////////////////////////////////////////////
 /// \brief TRestMetadata default constructor
 ///
-TRestMetadata::TRestMetadata() : endl(this) {
+TRestMetadata::TRestMetadata() : RESTendl(this) {
     fStore = true;
     fElementGlobal = nullptr;
     fElement = nullptr;
@@ -485,7 +485,7 @@ TRestMetadata::TRestMetadata() : endl(this) {
 
     fConfigFileName = "null";
     configBuffer = "";
-    metadata.setlength(100);
+    RESTMetadata.setlength(100);
 
     if (TRestTools::Execute("rest-config --release") == "Yes") fOfficialRelease = true;
     if (TRestTools::Execute("rest-config --clean") == "Yes") fCleanState = true;
@@ -494,7 +494,7 @@ TRestMetadata::TRestMetadata() : endl(this) {
 ///////////////////////////////////////////////
 /// \brief constructor
 ///
-TRestMetadata::TRestMetadata(const char* configFilename) : endl(this) {
+TRestMetadata::TRestMetadata(const char* configFilename) : RESTendl(this) {
     fStore = true;
     fElementGlobal = nullptr;
     fElement = nullptr;
@@ -505,7 +505,7 @@ TRestMetadata::TRestMetadata(const char* configFilename) : endl(this) {
 
     fConfigFileName = configFilename;
     configBuffer = "";
-    metadata.setlength(100);
+    RESTMetadata.setlength(100);
 
     if (TRestTools::Execute("rest-config --release") == "Yes") fOfficialRelease = true;
     if (TRestTools::Execute("rest-config --clean") == "Yes") fCleanState = true;
@@ -534,9 +534,9 @@ Int_t TRestMetadata::LoadConfigFromFile(const string& configFilename, const stri
         // find the xml section corresponding to the sectionName
         TiXmlElement* Sectional = GetElementFromFile(fConfigFileName, thisSectionName);
         if (Sectional == nullptr) {
-            ferr << "cannot find xml section \"" << ClassName() << "\" with name \"" << thisSectionName
-                 << "\"" << endl;
-            ferr << "in config file: " << fConfigFileName << endl;
+            RESTFerr << "cannot find xml section \"" << ClassName() << "\" with name \"" << sectionName
+                     << "\"" << RESTendl;
+            RESTFerr << "in config file: " << fConfigFileName << RESTendl;
             exit(1);
         }
 
@@ -563,8 +563,8 @@ Int_t TRestMetadata::LoadConfigFromFile(const string& configFilename, const stri
         delete rootEle;
         return result;
     } else {
-        ferr << "Filename: " << fConfigFileName << endl;
-        ferr << "Config File does not exist. Right path/filename?" << endl;
+        RESTFerr << "Filename: " << fConfigFileName << RESTendl;
+        RESTFerr << "Config File does not exist. Right path/filename?" << RESTendl;
         GetChar();
         return -1;
     }
@@ -572,9 +572,9 @@ Int_t TRestMetadata::LoadConfigFromFile(const string& configFilename, const stri
     // find the xml section corresponding to the sectionName
     TiXmlElement* sectional = GetElementFromFile(fConfigFileName, thisSectionName);
     if (sectional == nullptr) {
-        ferr << "cannot find xml section \"" << ClassName() << "\" with name \"" << thisSectionName << "\""
-             << endl;
-        ferr << "in config file: " << fConfigFileName << endl;
+        RESTFerr << "cannot find xml section \"" << ClassName() << "\" with name \"" << thisSectionName
+                 << "\"" << RESTendl;
+        RESTFerr << "in config file: " << fConfigFileName << RESTendl;
         exit(1);
     }
 
@@ -637,7 +637,7 @@ Int_t TRestMetadata::LoadConfigFromElement(TiXmlElement* eSectional, TiXmlElemen
 
     int result = LoadSectionMetadata();
     if (result == 0) InitFromConfigFile();
-    debug << ClassName() << " has finished preparing config data" << endl;
+    RESTDebug << ClassName() << " has finished preparing config data" << RESTendl;
     return result;
 }
 
@@ -667,10 +667,10 @@ Int_t TRestMetadata::LoadConfigFromBuffer() {
 ///
 Int_t TRestMetadata::LoadSectionMetadata() {
     // get debug level
-    string debugStr = GetParameter("verboseLevel", ToString(fVerboseLevel));
+    string debugStr = GetParameter("verboseLevel", ToString(static_cast<int>(fVerboseLevel)));
     fVerboseLevel = StringToVerboseLevel(debugStr);
 
-    debug << "Loading Config for : " << this->ClassName() << endl;
+    RESTDebug << "Loading Config for : " << this->ClassName() << RESTendl;
 
     // set env first from global section
     if (fElementGlobal != nullptr) {
@@ -694,7 +694,7 @@ Int_t TRestMetadata::LoadSectionMetadata() {
     ReadElement(fElement);
 
     // get debug level again in case it is defined in the included file
-    debugStr = GetParameter("verboseLevel", ToString(fVerboseLevel));
+    debugStr = GetParameter("verboseLevel", ToString(static_cast<int>(fVerboseLevel)));
     fVerboseLevel = StringToVerboseLevel(debugStr);
 
     // fill the general metadata info: name, title, fstore
@@ -716,14 +716,14 @@ Int_t TRestMetadata::LoadSectionMetadata() {
 TiXmlElement* TRestMetadata::ReplaceElementAttributes(TiXmlElement* e) {
     if (e == nullptr) return nullptr;
 
-    debug << "Entering ... TRestMetadata::ReplaceElementAttributes" << endl;
+    RESTDebug << "Entering ... TRestMetadata::ReplaceElementAttributes" << RESTendl;
 
     std::string parName = "";
     TiXmlAttribute* attr = e->FirstAttribute();
     while (attr != nullptr) {
         const char* val = attr->Value();
         const char* name = attr->Name();
-        debug << "Element name : " << name << " value : " << val << endl;
+        RESTDebug << "Element name : " << name << " value : " << val << RESTendl;
 
         string newVal = val != nullptr ? val : "";
         newVal = ReplaceVariables(newVal);
@@ -775,7 +775,7 @@ void TRestMetadata::ReadEnvInElement(TiXmlElement* e, bool overwrite) {
         if (!overwrite && fVariables.count(name) > 0) return;
         fConstants[name] = value;
     } else if ((string)e->Value() == "myParameter") {
-        warning << "myParameter is obsolete now! use \"constant\" instead" << endl;
+        RESTWarning << "myParameter is obsolete now! use \"constant\" instead" << RESTendl;
         if (!overwrite && fVariables.count(name) > 0) return;
         fConstants[name] = value;
     }
@@ -790,7 +790,7 @@ void TRestMetadata::ReadEnvInElement(TiXmlElement* e, bool overwrite) {
 /// sections will also be processed. Before expansion,
 /// ReplaceElementAttributes() will first be called.
 void TRestMetadata::ReadElement(TiXmlElement* e, bool recursive) {
-    debug << ClassName() << "::ReadElement(<" << e->Value() << ")" << endl;
+    RESTDebug << ClassName() << "::ReadElement(<" << e->Value() << ")" << RESTendl;
     if (e == nullptr) return;
 
     ReplaceElementAttributes(e);
@@ -809,12 +809,12 @@ void TRestMetadata::ReadElement(TiXmlElement* e, bool recursive) {
         while (contentelement != nullptr) {
             TiXmlElement* nxt = contentelement->NextSiblingElement();
             if (recursive || ((string)contentelement->Value()).find("TRest") == -1) {
-                debug << "into child element \"" << contentelement->Value() << "\" of \"" << e->Value()
-                      << "\"" << endl;
+                RESTDebug << "into child element \"" << contentelement->Value() << "\" of \"" << e->Value()
+                          << "\"" << RESTendl;
                 ReadElement(contentelement, recursive);
             } else {
-                debug << "skipping child element \"" << contentelement->Value() << "\" of \"" << e->Value()
-                      << "\"" << endl;
+                RESTDebug << "skipping child element \"" << contentelement->Value() << "\" of \""
+                          << e->Value() << "\"" << RESTendl;
             }
             contentelement = nxt;
         }
@@ -853,7 +853,7 @@ void TRestMetadata::ExpandIfSections(TiXmlElement* e) {
     const char* condition = e->Attribute("condition");
 
     if (condition == nullptr || string(condition).find_first_of("=!<>") == -1) {
-        warning << "Invalid \"IF\" structure!" << endl;
+        RESTWarning << "Invalid \"IF\" structure!" << RESTendl;
         return;
     }
 
@@ -867,7 +867,7 @@ void TRestMetadata::ExpandIfSections(TiXmlElement* e) {
     } else if (p1 > 0) {
         v1 = string(condition).substr(0, p1);
     } else {
-        warning << "Invalid \"IF\" structure!" << endl;
+        RESTWarning << "Invalid \"IF\" structure!" << RESTendl;
         return;
     }
 
@@ -911,7 +911,7 @@ void TRestMetadata::ExpandIfSections(TiXmlElement* e) {
             if (v1 <= v2) matches = true;
         }
     } else {
-        warning << "Invalid \"IF\" structure!" << endl;
+        RESTWarning << "Invalid \"IF\" structure!" << RESTendl;
         return;
     }
 
@@ -922,7 +922,7 @@ void TRestMetadata::ExpandIfSections(TiXmlElement* e) {
         while (contentelement != nullptr) {
             TiXmlElement* attachedelement = (TiXmlElement*)contentelement->Clone();
             ReadElement(attachedelement, true);
-            // debug << *attachedelement << endl;
+            // RESTDebug << *attachedelement << RESTendl;
             parele->InsertBeforeChild(e, *attachedelement);
             delete attachedelement;
             contentelement = contentelement->NextSiblingElement();
@@ -950,7 +950,7 @@ void TRestMetadata::ExpandForLoopOnce(TiXmlElement* e, map<string, string> forLo
             TiXmlElement* attachedelement = (TiXmlElement*)contentelement->Clone();
             ReplaceForLoopVars(attachedelement, forLoopVar);
             ReadElement(attachedelement, true);
-            // debug << *attachedelement << endl;
+            // RESTDebug << *attachedelement << RESTendl;
             parele->InsertBeforeChild(e, *attachedelement);
             delete attachedelement;
             contentelement = contentelement->NextSiblingElement();
@@ -964,13 +964,13 @@ void TRestMetadata::ExpandForLoopOnce(TiXmlElement* e, map<string, string> forLo
 void TRestMetadata::ReplaceForLoopVars(TiXmlElement* e, map<string, string> forLoopVar) {
     if (e == nullptr) return;
 
-    debug << "Entering ... TRestMetadata::ReplaceForLoopVars" << endl;
+    RESTDebug << "Entering ... TRestMetadata::ReplaceForLoopVars" << RESTendl;
     std::string parName = "";
     TiXmlAttribute* attr = e->FirstAttribute();
     while (attr != nullptr) {
         const char* val = attr->Value();
         const char* name = attr->Name();
-        debug << "Attribute name : " << name << " value : " << val << endl;
+        RESTDebug << "Attribute name : " << name << " value : " << val << RESTendl;
 
         if (strcmp(name, "name") == 0) parName = (string)val;
 
@@ -979,8 +979,9 @@ void TRestMetadata::ReplaceForLoopVars(TiXmlElement* e, map<string, string> forL
             string outputBuffer = val;
 
             if (outputBuffer.find("[") != (int)string::npos || outputBuffer.find("]") != (int)string::npos) {
-                ferr << "TRestMetadata::ReplaceForLoopVars. Old for-loop construction identified" << endl;
-                ferr << "Please, replace [] variable nomenclature by ${}." << endl;
+                RESTFerr << "TRestMetadata::ReplaceForLoopVars. Old for-loop construction identified"
+                         << RESTendl;
+                RESTFerr << "Please, replace [] variable nomenclature by ${}." << RESTendl;
                 exit(1);
             }
 
@@ -1004,8 +1005,8 @@ void TRestMetadata::ReplaceForLoopVars(TiXmlElement* e, map<string, string> forL
                     outputBuffer.replace(replacePos, replaceLen, proenv);
                     endPosition = 0;
                 } else {
-                    ferr << this->ClassName() << ", replace for loop env : cannot find \"{" << expression
-                         << "}\"" << endl;
+                    RESTFerr << this->ClassName() << ", replace for loop env : cannot find \"{" << expression
+                             << "}\"" << RESTendl;
                     exit(1);
                 }
             }
@@ -1030,7 +1031,7 @@ void TRestMetadata::ReplaceForLoopVars(TiXmlElement* e, map<string, string> forL
 void TRestMetadata::ExpandForLoops(TiXmlElement* e, map<string, string> forloopvar) {
     if (e == nullptr) return;
     if ((string)e->Value() != "for") return;
-    debug << "Entering ... ExpandForLoops" << endl;
+    RESTDebug << "Entering ... ExpandForLoops" << RESTendl;
     ReplaceElementAttributes(e);
 
     TString varname = TString(e->Attribute("variable"));
@@ -1039,8 +1040,8 @@ void TRestMetadata::ExpandForLoops(TiXmlElement* e, map<string, string> forloopv
     TString varstep = TString(e->Attribute("step"));
     TString varin = TString(e->Attribute("in"));
 
-    debug << "variable: " << varname << " from: " << varfrom << " to: " << varto << " step: " << varstep
-          << " in: " << varin << endl;
+    RESTDebug << "variable: " << varname << " from: " << varfrom << " to: " << varto << " step: " << varstep
+              << " in: " << varin << RESTendl;
 
     if ((varin == "") && (varname == "" || varfrom == "" || varto == "")) return;
     if (varstep == "") varstep = "1";
@@ -1052,13 +1053,13 @@ void TRestMetadata::ExpandForLoops(TiXmlElement* e, map<string, string> forloopv
     string _to = (string)varto;
     string _step = (string)varstep;
     string _in = (string)varin;
-    debug << "_from: " << _from << " _to: " << _to << " _step: " << _step << endl;
+    RESTDebug << "_from: " << _from << " _to: " << _to << " _step: " << _step << RESTendl;
     if (isANumber(_from) && isANumber(_to) && isANumber(_step)) {
         double from = StringToDouble(_from);
         double to = StringToDouble(_to);
         double step = StringToDouble(_step);
 
-        debug << "----expanding for loop----" << endl;
+        RESTDebug << "----expanding for loop----" << RESTendl;
         double i = 0;
         for (i = from; i <= to; i = i + step) {
             forloopvar[_name] = ToString(i);
@@ -1067,12 +1068,12 @@ void TRestMetadata::ExpandForLoops(TiXmlElement* e, map<string, string> forloopv
         }
         parele->RemoveChild(e);
 
-        if (fVerboseLevel >= REST_Extreme) parele->Print(stdout, 0);
-        debug << "----end of for loop----" << endl;
+        if (fVerboseLevel >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) parele->Print(stdout, 0);
+        RESTDebug << "----end of for loop----" << RESTendl;
     } else if (_in != "") {
         vector<string> loopvars = Split(_in, ":");
 
-        debug << "----expanding for loop----" << endl;
+        RESTDebug << "----expanding for loop----" << RESTendl;
         for (string loopvar : loopvars) {
             forloopvar[_name] = loopvar;
             fVariables[_name] = loopvar;
@@ -1080,8 +1081,8 @@ void TRestMetadata::ExpandForLoops(TiXmlElement* e, map<string, string> forloopv
         }
         parele->RemoveChild(e);
 
-        if (fVerboseLevel >= REST_Extreme) parele->Print(stdout, 0);
-        debug << "----end of for loop----" << endl;
+        if (fVerboseLevel >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) parele->Print(stdout, 0);
+        RESTDebug << "----end of for loop----" << RESTendl;
     }
     // variable defined in for loop should be temporal
     fVariables.erase(_name);
@@ -1108,7 +1109,7 @@ void TRestMetadata::ExpandForLoops(TiXmlElement* e, map<string, string> forloopv
 /// name="sAna" file="abc.rml"/> \endcode If the target file is a root file,
 /// there will be a different way to load, see TRestRun::ImportMetadata()
 void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
-    debug << "Entering ... " << __PRETTY_FUNCTION__ << endl;
+    RESTDebug << "Entering ... " << __PRETTY_FUNCTION__ << RESTendl;
     if (e == nullptr) return;
 
     ReplaceElementAttributes(e);
@@ -1128,14 +1129,14 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
     }
 
     if (filename == "") {
-        ferr << "TRestMetadata::ExpandIncludeFile. Include file \"" << _filename << "\" does not exist!"
-             << endl;
+        RESTFerr << "TRestMetadata::ExpandIncludeFile. Include file \"" << _filename << "\" does not exist!"
+                 << RESTendl;
         exit(1);
         return;
     }
     if (!TRestTools::isRootFile(filename))  // root file inclusion is implemented in TRestRun
     {
-        debug << "----expanding include file----" << endl;
+        RESTDebug << "----expanding include file----" << RESTendl;
         // we find the local element(the element to receive content)
         // and the remote element(the element to provide content)
         TiXmlElement* remoteele = nullptr;
@@ -1157,7 +1158,7 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
             if (localele->Attribute("expanded") == nullptr
                     ? false
                     : ((string)localele->Attribute("expanded") == "true")) {
-                debug << "----already expanded----" << endl;
+                RESTDebug << "----already expanded----" << RESTendl;
                 return;
             }
 
@@ -1165,8 +1166,9 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
 
             TiXmlElement* ele = GetElementFromFile(filename);
             if (ele == nullptr) {
-                ferr << "TRestMetadata::ExpandIncludeFile. No xml elements contained in the include file \""
-                     << filename << "\"" << endl;
+                RESTFerr
+                    << "TRestMetadata::ExpandIncludeFile. No xml elements contained in the include file \""
+                    << filename << "\"" << RESTendl;
                 exit(1);
             }
             while (ele != nullptr) {
@@ -1194,7 +1196,7 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
             if (localele->Attribute("expanded") == nullptr
                     ? false
                     : ((string)localele->Attribute("expanded") == "true")) {
-                debug << "----already expanded----" << endl;
+                RESTDebug << "----already expanded----" << RESTendl;
                 return;
             }
 
@@ -1204,8 +1206,8 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
             // get the root element
             TiXmlElement* rootele = GetElementFromFile(filename);
             if (rootele == nullptr) {
-                ferr << "TRestMetaddata::ExpandIncludeFile. Include file " << filename
-                     << " is of wrong xml format!" << endl;
+                RESTFerr << "TRestMetaddata::ExpandIncludeFile. Include file " << filename
+                         << " is of wrong xml format!" << RESTendl;
                 exit(1);
                 return;
             }
@@ -1236,9 +1238,9 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
                     }
                     // more than 1 elements found
                     if (eles.size() > 1) {
-                        warning << "(expand include file): find multiple xml sections with same name!"
-                                << endl;
-                        warning << "Using the first one!" << endl;
+                        RESTWarning << "(expand include file): find multiple xml sections with same name!"
+                                    << RESTendl;
+                        RESTWarning << "Using the first one!" << RESTendl;
                     }
 
                     if (eles.size() > 0) remoteele = (TiXmlElement*)eles[0]->Clone();
@@ -1247,18 +1249,19 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
                 }
 
                 if (remoteele == nullptr) {
-                    warning << "Cannot find the needed xml section in "
-                               "include file!"
-                            << endl;
-                    warning << "type: \"" << type << "\" , name: \"" << name << "\" . Skipping" << endl;
-                    warning << endl;
+                    RESTWarning << "Cannot find the needed xml section in "
+                                   "include file!"
+                                << RESTendl;
+                    RESTWarning << "type: \"" << type << "\" , name: \"" << name << "\" . Skipping"
+                                << RESTendl;
+                    RESTWarning << RESTendl;
                     return;
                 }
                 delete rootele;
             }
         }
 
-        debug << "Target xml element spotted" << endl;
+        RESTDebug << "Target xml element spotted" << RESTendl;
 
         ///////////////////////////////////////
         // begin inserting remote element into local element
@@ -1284,13 +1287,13 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
         }
 
         localele->SetAttribute("expanded", "true");
-        if (fVerboseLevel >= REST_Debug) {
+        if (fVerboseLevel >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             localele->Print(stdout, 0);
             cout << endl;
         }
         delete remoteele;
-        debug << nattr << " attributes and " << nele << " xml elements added by inclusion" << endl;
-        debug << "----end of expansion file----" << endl;
+        RESTDebug << nattr << " attributes and " << nele << " xml elements added by inclusion" << RESTendl;
+        RESTDebug << "----end of expansion file----" << RESTendl;
     }
 }
 
@@ -1346,9 +1349,7 @@ string TRestMetadata::GetParameter(std::string parName, TString defaultValue) {
 /// \return A string of result, with env and expressions replaced
 string TRestMetadata::GetParameter(std::string parName, TiXmlElement* e, TString defaultValue) {
     if (e == nullptr) {
-        if (GetVerboseLevel() > REST_Debug) {
-            cout << "Element is null" << endl;
-        }
+        RESTDebug << "Element is null" << RESTendl;
         return (string)defaultValue;
     }
     string result = (string)defaultValue;
@@ -1362,7 +1363,7 @@ string TRestMetadata::GetParameter(std::string parName, TiXmlElement* e, TString
         if (element != nullptr && element->Attribute("value") != nullptr) {
             result = element->Attribute("value");
         } else {
-            debug << ClassName() << ": Parameter : " << parName << " not found!" << endl;
+            RESTDebug << ClassName() << ": Parameter : " << parName << " not found!" << RESTendl;
         }
     }
 
@@ -1432,9 +1433,7 @@ TVector3 TRestMetadata::Get3DVectorParameterWithUnits(std::string parName, TiXml
 ///
 std::string TRestMetadata::GetFieldValue(std::string parName, TiXmlElement* e) {
     if (e == nullptr) {
-        if (GetVerboseLevel() > REST_Debug) {
-            cout << "Element is null" << endl;
-        }
+        RESTDebug << "Element is null" << RESTendl;
         return "Not defined";
     }
     const char* val = e->Attribute(parName.c_str());
@@ -1546,18 +1545,19 @@ TiXmlElement* TRestMetadata::GetElementFromFile(std::string configFilename, std:
         filename = TRestMetadata_UpdatedConfigFile[filename];
 
     if (!TRestTools::fileExists(filename)) {
-        ferr << "Config file does not exist. The file is: " << filename << endl;
+        RESTFerr << "Config file does not exist. The file is: " << filename << RESTendl;
         exit(1);
     }
 
     if (!doc.LoadFile(filename.c_str())) {
-        ferr << "Failed to load xml file, syntax maybe wrong. The file is: " << filename << endl;
+        RESTFerr << "Failed to load xml file, syntax maybe wrong. The file is: " << filename << RESTendl;
         exit(1);
     }
 
     rootele = doc.RootElement();
     if (rootele == nullptr) {
-        ferr << "The rml file \"" << configFilename << "\" does not contain any valid elements!" << endl;
+        RESTFerr << "The rml file \"" << configFilename << "\" does not contain any valid elements!"
+                 << RESTendl;
         exit(1);
     }
     if (NameOrDecalre == "") {
@@ -1658,7 +1658,7 @@ TiXmlElement* TRestMetadata::GetElementWithName(std::string eleDeclare, std::str
 ///	e.g. <... value="3" units="mm" .../>
 string TRestMetadata::GetUnits(TiXmlElement* e) {
     if (e == nullptr) {
-        warning << "TRestMetadata::GetUnits(): NULL element given!" << endl;
+        RESTWarning << "TRestMetadata::GetUnits(): NULL element given!" << RESTendl;
         return "";
     }
 
@@ -1804,7 +1804,8 @@ string TRestMetadata::GetKEYStructure(std::string keyName, size_t& fromPosition,
 string TRestMetadata::GetKEYStructure(std::string keyName, size_t& fromPosition, TiXmlElement* ele) {
     size_t position = fromPosition;
 
-    debug << "Finding " << fromPosition << "th appearance of KEY Structure \"" << keyName << "\"..." << endl;
+    RESTDebug << "Finding " << fromPosition << "th appearance of KEY Structure \"" << keyName << "\"..."
+              << RESTendl;
 
     TiXmlElement* childele = ele->FirstChildElement(keyName);
     for (int i = 0; childele != nullptr && i < fromPosition; i++) {
@@ -1813,12 +1814,12 @@ string TRestMetadata::GetKEYStructure(std::string keyName, size_t& fromPosition,
     if (childele != nullptr) {
         string result = ElementToString(childele);
         fromPosition = fromPosition + 1;
-        debug << "Found Key : " << result << endl;
-        // debug << "New position : " << fromPosition << endl;
+        RESTDebug << "Found Key : " << result << RESTendl;
+        // RESTDebug << "New position : " << fromPosition << RESTendl;
         return result;
     }
 
-    debug << "Finding hit the end, KEY Structure not found!!" << endl;
+    RESTDebug << "Finding hit the end, KEY Structure not found!!" << RESTendl;
     return "";
 }
 
@@ -1938,7 +1939,7 @@ string TRestMetadata::GetParameter(string parName, size_t& pos, string inputStri
 /// found, try to replace <variable section, if still not found, try to replace
 /// with command line arguments. If all not found, return the initial value.
 string TRestMetadata::ReplaceVariables(const string buffer) {
-    debug << "Entering ... TRestMetadata::ReplaceVariables (" << buffer << ")" << endl;
+    RESTDebug << "Entering ... TRestMetadata::ReplaceVariables (" << buffer << ")" << RESTendl;
     string outputBuffer = buffer;
 
     // replace variables with mark ${}
@@ -1967,13 +1968,13 @@ string TRestMetadata::ReplaceVariables(const string buffer) {
             outputBuffer.replace(replacePos, replaceLen, proenv);
             endPosition = 0;
         } else {
-            ferr << this->ClassName() << ", replace env : cannot find \"${" << expression
-                 << "}\" in either system or program env, exiting..." << endl;
+            RESTFerr << this->ClassName() << ", replace env : cannot find \"${" << expression
+                     << "}\" in either system or program env, exiting..." << RESTendl;
             exit(1);
         }
     }
 
-    if (buffer != outputBuffer) debug << "Replaced by : " << outputBuffer << endl;
+    if (buffer != outputBuffer) RESTDebug << "Replaced by : " << outputBuffer << RESTendl;
     return outputBuffer;
 }
 
@@ -1982,7 +1983,7 @@ string TRestMetadata::ReplaceVariables(const string buffer) {
 ///
 /// Constans are the substrings directly appeared in the buffer
 string TRestMetadata::ReplaceConstants(const string buffer) {
-    debug << "Entering ... TRestMetadata::ReplaceConstants (" << buffer << ")" << endl;
+    RESTDebug << "Entering ... TRestMetadata::ReplaceConstants (" << buffer << ")" << RESTendl;
     string outputBuffer = buffer;
 
     int startPosition = 0;
@@ -2005,7 +2006,7 @@ string TRestMetadata::ReplaceConstants(const string buffer) {
         }
     }
 
-    if (buffer != outputBuffer) debug << "Replaced by : " << outputBuffer << endl;
+    if (buffer != outputBuffer) RESTDebug << "Replaced by : " << outputBuffer << RESTendl;
     return outputBuffer;
 }
 
@@ -2078,7 +2079,7 @@ void TRestMetadata::WriteConfigBuffer(string fname) {
         return;
     }
 
-    ferr << "Something missing here. Call the police" << endl;
+    RESTFerr << "Something missing here. Call the police" << RESTendl;
 }
 
 void TRestMetadata::PrintMessageBuffer() { cout << messageBuffer << endl; }
@@ -2088,24 +2089,25 @@ void TRestMetadata::PrintMessageBuffer() { cout << messageBuffer << endl; }
 /// metadata class.
 ///
 void TRestMetadata::PrintMetadata() {
-    metadata << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
-    metadata << this->ClassName() << " content" << endl;
-    metadata << "Config file : " << fConfigFileName << endl;
-    metadata << "+++++++++++++++++++++++++++++++++++++++++++++" << endl;
-    metadata << "Name : " << GetName() << endl;
-    metadata << "Title : " << GetTitle() << endl;
-    metadata << "REST Version : " << GetVersion() << endl;
+    RESTMetadata << "+++++++++++++++++++++++++++++++++++++++++++++" << RESTendl;
+    RESTMetadata << this->ClassName() << " content" << RESTendl;
+    RESTMetadata << "Config file : " << fConfigFileName << RESTendl;
+    RESTMetadata << "+++++++++++++++++++++++++++++++++++++++++++++" << RESTendl;
+    RESTMetadata << "Name : " << GetName() << RESTendl;
+    RESTMetadata << "Title : " << GetTitle() << RESTendl;
+    RESTMetadata << "REST Version : " << GetVersion() << RESTendl;
     if (fOfficialRelease)
-        metadata << "REST Official release: Yes" << endl;
+        RESTMetadata << "REST Official release: Yes" << RESTendl;
     else
-        metadata << "REST Official release: No" << endl;
+        RESTMetadata << "REST Official release: No" << RESTendl;
     if (fCleanState)
-        metadata << "Clean state: Yes" << endl;
+        RESTMetadata << "Clean state: Yes" << RESTendl;
     else
-        metadata << "Clean state: No" << endl;
-    metadata << "REST Commit : " << GetCommit() << endl;
-    if (GetLibraryVersion() != "0.0") metadata << "REST Library version : " << GetLibraryVersion() << endl;
-    metadata << "---------------------------------------" << endl;
+        RESTMetadata << "Clean state: No" << RESTendl;
+    RESTMetadata << "REST Commit : " << GetCommit() << RESTendl;
+    if (GetLibraryVersion() != "0.0")
+        RESTMetadata << "REST Library version : " << GetLibraryVersion() << RESTendl;
+    RESTMetadata << "---------------------------------------" << RESTendl;
 }
 
 ///////////////////////////////////////////////
@@ -2128,9 +2130,9 @@ TString TRestMetadata::GetLibraryVersion() { return fLibraryVersion; }
 /// allowed to update version.
 void TRestMetadata::ReSetVersion() {
     if (!this->InheritsFrom("TRestRun"))
-        ferr << "version is a static value, you cannot set version "
-                "for a class!"
-             << endl;
+        RESTFerr << "version is a static value, you cannot set version "
+                    "for a class!"
+                 << RESTendl;
     else {
         fVersion = REST_RELEASE;
     }
@@ -2141,9 +2143,9 @@ void TRestMetadata::ReSetVersion() {
 /// Only TRestRun is allowed to update version.
 void TRestMetadata::UnSetVersion() {
     if (!this->InheritsFrom("TRestRun"))
-        ferr << "version is a static value, you cannot set version "
-                "for a class!"
-             << endl;
+        RESTFerr << "version is a static value, you cannot set version "
+                    "for a class!"
+                 << RESTendl;
     else {
         fVersion = -1;
         fCommit = -1;
@@ -2203,10 +2205,10 @@ std::vector<string> TRestMetadata::GetDataMemberValues(string memberName) {
 ///
 TString TRestMetadata::GetVerboseLevelString() {
     TString level = "unknown";
-    if (this->GetVerboseLevel() == REST_Debug) level = "debug";
-    if (this->GetVerboseLevel() == REST_Info) level = "info";
-    if (this->GetVerboseLevel() == REST_Essential) level = "warning";
-    if (this->GetVerboseLevel() == REST_Silent) level = "silent";
+    if (this->GetVerboseLevel() == TRestStringOutput::REST_Verbose_Level::REST_Debug) level = "debug";
+    if (this->GetVerboseLevel() == TRestStringOutput::REST_Verbose_Level::REST_Info) level = "info";
+    if (this->GetVerboseLevel() == TRestStringOutput::REST_Verbose_Level::REST_Essential) level = "warning";
+    if (this->GetVerboseLevel() == TRestStringOutput::REST_Verbose_Level::REST_Silent) level = "silent";
 
     return level;
 }
@@ -2349,7 +2351,7 @@ std::map<string, string> TRestMetadata::GetParametersList() {
         TString units = paraele->Attribute("units");
 
         if (name == "") {
-            warning << "bad <parameter section: " << *paraele << endl;
+            RESTWarning << "bad <parameter section: " << *paraele << RESTendl;
         } else {
             if (parameters.count(name) == 0) {
                 parameters[name] = value + units;
@@ -2372,8 +2374,8 @@ void TRestMetadata::ReadOneParameter(string name, string value) {
         if (datamembername != "") {
             RESTValue datamember = thisactual.GetDataMember(datamembername);
             if (!datamember.IsZombie()) {
-                debug << this->ClassName() << "::ReadAllParameters(): parsing value \"" << value
-                      << "\" to data member \"" << datamembername << "\"" << endl;
+                RESTDebug << this->ClassName() << "::ReadAllParameters(): parsing value \"" << value
+                          << "\" to data member \"" << datamembername << "\"" << RESTendl;
 
                 if (REST_Units::FindRESTUnitsInString(value) != "") {
                     // there is units contained in this parameter.
@@ -2395,10 +2397,10 @@ void TRestMetadata::ReadOneParameter(string name, string value) {
                         Double_t valueZ = REST_Units::ConvertValueToRESTUnits(value.Z(), unit);
                         *(TVector3*)datamember = TVector3(valueX, valueY, valueZ);
                     } else {
-                        warning
+                        RESTWarning
                             << this->ClassName() << " find unit definition in parameter: " << name
                             << ", but the corresponding data member doesn't support it. Data member type: "
-                            << datamember.type << endl;
+                            << datamember.type << RESTendl;
                         datamember.ParseString(value);
                     }
                 } else {
@@ -2408,8 +2410,8 @@ void TRestMetadata::ReadOneParameter(string name, string value) {
                 // this mean the datamember is found with type not recognized.
                 // We won't try to find the misspelling
             } else {
-                debug << this->ClassName() << "::ReadAllParameters(): parameter \"" << name
-                      << "\" not recognized for automatic load" << endl;
+                RESTDebug << this->ClassName() << "::ReadAllParameters(): parameter \"" << name
+                          << "\" not recognized for automatic load" << RESTendl;
                 vector<string> availableparameters;
 
                 vector<string> datamembers = thisactual.GetListOfDataMembers();
@@ -2437,9 +2439,9 @@ void TRestMetadata::ReadOneParameter(string name, string value) {
                 // we regard the unset parameter with less than 2 characters different from
                 // the data member as "misspelling" parameter. We prompt a warning for it.
                 if (hintParameter != "" && mindiff <= 2) {
-                    warning << this->ClassName() << "::ReadAllParameters(): parameter \"" << name
-                            << "\" not recognized for automatic load, did you mean \"" << hintParameter
-                            << "\" ?" << endl;
+                    RESTWarning << this->ClassName() << "::ReadAllParameters(): parameter \"" << name
+                                << "\" not recognized for automatic load, did you mean \"" << hintParameter
+                                << "\" ?" << RESTendl;
                     GetChar();
                 }
             }
@@ -2448,15 +2450,15 @@ void TRestMetadata::ReadOneParameter(string name, string value) {
 }
 
 TRestStringOutput& TRestStringOutput::operator<<(endl_t et) {
-    if (et.TRestMetadataPtr->GetVerboseLevel() <= REST_Info) {
+    if (et.TRestMetadataPtr->GetVerboseLevel() <= TRestStringOutput::REST_Verbose_Level::REST_Info) {
         et.TRestMetadataPtr->AddLog(this->buf.str());
     }
 
     if (this->iserror) {
-        if (this->verbose == REST_Warning) {
+        if (this->verbose == TRestStringOutput::REST_Verbose_Level::REST_Warning) {
             et.TRestMetadataPtr->SetWarning(this->buf.str(), false);
         }
-        if (this->verbose == REST_Silent) {
+        if (this->verbose == TRestStringOutput::REST_Verbose_Level::REST_Silent) {
             et.TRestMetadataPtr->SetError(this->buf.str(), false);
         }
     }
@@ -2494,7 +2496,7 @@ void TRestMetadata::SetWarning(string message, bool print) {
     if (message != "") {
         fWarningMessage += message + "\n";
         if (print) {
-            if (fVerboseLevel >= REST_Warning) cout << message << endl;
+            RESTWarning << message << RESTendl;
         }
     }
 }

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -534,9 +534,9 @@ Int_t TRestMetadata::LoadConfigFromFile(const string& configFilename, const stri
         // find the xml section corresponding to the sectionName
         TiXmlElement* Sectional = GetElementFromFile(fConfigFileName, thisSectionName);
         if (Sectional == nullptr) {
-            RESTFerr << "cannot find xml section \"" << ClassName() << "\" with name \"" << sectionName
-                     << "\"" << RESTendl;
-            RESTFerr << "in config file: " << fConfigFileName << RESTendl;
+            RESTError << "cannot find xml section \"" << ClassName() << "\" with name \"" << sectionName
+                      << "\"" << RESTendl;
+            RESTError << "in config file: " << fConfigFileName << RESTendl;
             exit(1);
         }
 
@@ -563,8 +563,8 @@ Int_t TRestMetadata::LoadConfigFromFile(const string& configFilename, const stri
         delete rootEle;
         return result;
     } else {
-        RESTFerr << "Filename: " << fConfigFileName << RESTendl;
-        RESTFerr << "Config File does not exist. Right path/filename?" << RESTendl;
+        RESTError << "Filename: " << fConfigFileName << RESTendl;
+        RESTError << "Config File does not exist. Right path/filename?" << RESTendl;
         GetChar();
         return -1;
     }
@@ -572,9 +572,9 @@ Int_t TRestMetadata::LoadConfigFromFile(const string& configFilename, const stri
     // find the xml section corresponding to the sectionName
     TiXmlElement* sectional = GetElementFromFile(fConfigFileName, thisSectionName);
     if (sectional == nullptr) {
-        RESTFerr << "cannot find xml section \"" << ClassName() << "\" with name \"" << thisSectionName
-                 << "\"" << RESTendl;
-        RESTFerr << "in config file: " << fConfigFileName << RESTendl;
+        RESTError << "cannot find xml section \"" << ClassName() << "\" with name \"" << thisSectionName
+                  << "\"" << RESTendl;
+        RESTError << "in config file: " << fConfigFileName << RESTendl;
         exit(1);
     }
 
@@ -979,9 +979,9 @@ void TRestMetadata::ReplaceForLoopVars(TiXmlElement* e, map<string, string> forL
             string outputBuffer = val;
 
             if (outputBuffer.find("[") != (int)string::npos || outputBuffer.find("]") != (int)string::npos) {
-                RESTFerr << "TRestMetadata::ReplaceForLoopVars. Old for-loop construction identified"
-                         << RESTendl;
-                RESTFerr << "Please, replace [] variable nomenclature by ${}." << RESTendl;
+                RESTError << "TRestMetadata::ReplaceForLoopVars. Old for-loop construction identified"
+                          << RESTendl;
+                RESTError << "Please, replace [] variable nomenclature by ${}." << RESTendl;
                 exit(1);
             }
 
@@ -1005,8 +1005,8 @@ void TRestMetadata::ReplaceForLoopVars(TiXmlElement* e, map<string, string> forL
                     outputBuffer.replace(replacePos, replaceLen, proenv);
                     endPosition = 0;
                 } else {
-                    RESTFerr << this->ClassName() << ", replace for loop env : cannot find \"{" << expression
-                             << "}\"" << RESTendl;
+                    RESTError << this->ClassName() << ", replace for loop env : cannot find \"{" << expression
+                              << "}\"" << RESTendl;
                     exit(1);
                 }
             }
@@ -1129,8 +1129,8 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
     }
 
     if (filename == "") {
-        RESTFerr << "TRestMetadata::ExpandIncludeFile. Include file \"" << _filename << "\" does not exist!"
-                 << RESTendl;
+        RESTError << "TRestMetadata::ExpandIncludeFile. Include file \"" << _filename << "\" does not exist!"
+                  << RESTendl;
         exit(1);
         return;
     }
@@ -1166,7 +1166,7 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
 
             TiXmlElement* ele = GetElementFromFile(filename);
             if (ele == nullptr) {
-                RESTFerr
+                RESTError
                     << "TRestMetadata::ExpandIncludeFile. No xml elements contained in the include file \""
                     << filename << "\"" << RESTendl;
                 exit(1);
@@ -1206,8 +1206,8 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
             // get the root element
             TiXmlElement* rootele = GetElementFromFile(filename);
             if (rootele == nullptr) {
-                RESTFerr << "TRestMetaddata::ExpandIncludeFile. Include file " << filename
-                         << " is of wrong xml format!" << RESTendl;
+                RESTError << "TRestMetaddata::ExpandIncludeFile. Include file " << filename
+                          << " is of wrong xml format!" << RESTendl;
                 exit(1);
                 return;
             }
@@ -1545,19 +1545,19 @@ TiXmlElement* TRestMetadata::GetElementFromFile(std::string configFilename, std:
         filename = TRestMetadata_UpdatedConfigFile[filename];
 
     if (!TRestTools::fileExists(filename)) {
-        RESTFerr << "Config file does not exist. The file is: " << filename << RESTendl;
+        RESTError << "Config file does not exist. The file is: " << filename << RESTendl;
         exit(1);
     }
 
     if (!doc.LoadFile(filename.c_str())) {
-        RESTFerr << "Failed to load xml file, syntax maybe wrong. The file is: " << filename << RESTendl;
+        RESTError << "Failed to load xml file, syntax maybe wrong. The file is: " << filename << RESTendl;
         exit(1);
     }
 
     rootele = doc.RootElement();
     if (rootele == nullptr) {
-        RESTFerr << "The rml file \"" << configFilename << "\" does not contain any valid elements!"
-                 << RESTendl;
+        RESTError << "The rml file \"" << configFilename << "\" does not contain any valid elements!"
+                  << RESTendl;
         exit(1);
     }
     if (NameOrDecalre == "") {
@@ -1968,8 +1968,8 @@ string TRestMetadata::ReplaceVariables(const string buffer) {
             outputBuffer.replace(replacePos, replaceLen, proenv);
             endPosition = 0;
         } else {
-            RESTFerr << this->ClassName() << ", replace env : cannot find \"${" << expression
-                     << "}\" in either system or program env, exiting..." << RESTendl;
+            RESTError << this->ClassName() << ", replace env : cannot find \"${" << expression
+                      << "}\" in either system or program env, exiting..." << RESTendl;
             exit(1);
         }
     }
@@ -2079,7 +2079,7 @@ void TRestMetadata::WriteConfigBuffer(string fname) {
         return;
     }
 
-    RESTFerr << "Something missing here. Call the police" << RESTendl;
+    RESTError << "Something missing here. Call the police" << RESTendl;
 }
 
 void TRestMetadata::PrintMessageBuffer() { cout << messageBuffer << endl; }
@@ -2130,9 +2130,9 @@ TString TRestMetadata::GetLibraryVersion() { return fLibraryVersion; }
 /// allowed to update version.
 void TRestMetadata::ReSetVersion() {
     if (!this->InheritsFrom("TRestRun"))
-        RESTFerr << "version is a static value, you cannot set version "
-                    "for a class!"
-                 << RESTendl;
+        RESTError << "version is a static value, you cannot set version "
+                     "for a class!"
+                  << RESTendl;
     else {
         fVersion = REST_RELEASE;
     }
@@ -2143,9 +2143,9 @@ void TRestMetadata::ReSetVersion() {
 /// Only TRestRun is allowed to update version.
 void TRestMetadata::UnSetVersion() {
     if (!this->InheritsFrom("TRestRun"))
-        RESTFerr << "version is a static value, you cannot set version "
-                    "for a class!"
-                 << RESTendl;
+        RESTError << "version is a static value, you cannot set version "
+                     "for a class!"
+                  << RESTendl;
     else {
         fVersion = -1;
         fCommit = -1;

--- a/source/framework/core/src/TRestMetadataPlot.cxx
+++ b/source/framework/core/src/TRestMetadataPlot.cxx
@@ -401,8 +401,9 @@ void TRestMetadataPlot::InitFromConfigFile() {
         if (ToUpper(active) == "ON") {
             int N = fPlots.size();
             if (N >= maxPlots) {
-                RESTFerr << "Your canvas divisions (" << fCanvasDivisions.X() << " , " << fCanvasDivisions.Y()
-                         << ") are not enough to show " << N + 1 << " plots" << RESTendl;
+                RESTError << "Your canvas divisions (" << fCanvasDivisions.X() << " , "
+                          << fCanvasDivisions.Y() << ") are not enough to show " << N + 1 << " plots"
+                          << RESTendl;
                 exit(1);
             }
 
@@ -467,9 +468,9 @@ void TRestMetadataPlot::InitFromConfigFile() {
         if (ToUpper(active) == "ON") {
             int N = fPanels.size();
             if (N >= maxPlots) {
-                RESTFerr << "Your canvas divisions (" << fCanvasDivisions.X() << " , " << fCanvasDivisions.Y()
-                         << ") are not enough to show " << fPlots.size() << " plots, and " << N + 1
-                         << " info panels" << RESTendl;
+                RESTError << "Your canvas divisions (" << fCanvasDivisions.X() << " , "
+                          << fCanvasDivisions.Y() << ") are not enough to show " << fPlots.size()
+                          << " plots, and " << N + 1 << " info panels" << RESTendl;
                 exit(1);
             }
 
@@ -515,15 +516,15 @@ TRestMetadataPlot::Graph_Info_Set TRestMetadataPlot::SetupGraphFromConfigFile(Ti
 
     for (int n = 0; n < fPlotNamesCheck.size(); n++)
         if (graph.name == fPlotNamesCheck[n]) {
-            RESTFerr
+            RESTError
                 << "Repeated plot/graph names were found! Please, use different names for different plots!"
                 << RESTendl;
-            RESTFerr << "<plot/graph name=\"" << graph.name << "\" already defined!" << RESTendl;
+            RESTError << "<plot/graph name=\"" << graph.name << "\" already defined!" << RESTendl;
             exit(1);
         }
 
     if (graph.yVariable == "") {
-        RESTFerr << "Problem reading yVariable from graph with name : " << graph.name << RESTendl;
+        RESTError << "Problem reading yVariable from graph with name : " << graph.name << RESTendl;
         exit(2);
     }
 
@@ -618,7 +619,7 @@ void TRestMetadataPlot::GenerateCanvas() {
     if (fNFiles == 0) AddFileFromEnv();
 
     if (fNFiles == 0) {
-        RESTFerr << "TRestMetadataPlot: No input files are added!" << RESTendl;
+        RESTError << "TRestMetadataPlot: No input files are added!" << RESTendl;
         exit(1);
     }
 

--- a/source/framework/core/src/TRestMetadataPlot.cxx
+++ b/source/framework/core/src/TRestMetadataPlot.cxx
@@ -304,11 +304,11 @@ void TRestMetadataPlot::InitFromConfigFile() {
     }
 
 #pragma region ReadLabels
-    debug << "TRestMetadataPlot: Reading canvas settings" << endl;
+    RESTDebug << "TRestMetadataPlot: Reading canvas settings" << RESTendl;
     position = 0;
     TiXmlElement* formatDefinition = GetElement("labels");
     if (formatDefinition != nullptr) {
-        if (GetVerboseLevel() >= REST_Debug) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             cout << formatDefinition << endl;
             cout << "Reading format definition : " << endl;
             cout << "---------------------------" << endl;
@@ -332,7 +332,7 @@ void TRestMetadataPlot::InitFromConfigFile() {
         if (fLabelScaleX == -1) fLabelScaleX = 1.3;
         if (fLabelScaleY == -1) fLabelScaleY = 1.3;
 
-        if (GetVerboseLevel() >= REST_Debug) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             cout << "ticks scale X : " << fTicksScaleX << endl;
             cout << "ticks scale Y : " << fTicksScaleY << endl;
             cout << "label scale X : " << fLabelScaleX << endl;
@@ -340,7 +340,7 @@ void TRestMetadataPlot::InitFromConfigFile() {
             cout << "label offset X : " << fLabelOffsetX << endl;
             cout << "label offset Y : " << fLabelOffsetY << endl;
 
-            if (GetVerboseLevel() >= REST_Extreme) GetChar();
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
         }
     }
 #pragma endregion
@@ -349,7 +349,7 @@ void TRestMetadataPlot::InitFromConfigFile() {
     position = 0;
     TiXmlElement* legendDefinition = GetElement("legendPosition");
     if (legendDefinition != nullptr) {
-        if (GetVerboseLevel() >= REST_Debug) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             cout << legendDefinition << endl;
             cout << "Reading legend definition : " << endl;
             cout << "---------------------------" << endl;
@@ -367,11 +367,11 @@ void TRestMetadataPlot::InitFromConfigFile() {
         if (fLegendX2 == -1) fLegendX2 = 0.88;
         if (fLegendY2 == -1) fLegendY2 = 0.88;
 
-        if (GetVerboseLevel() >= REST_Debug) {
+        if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             cout << "x1 : " << fLegendX1 << " y1 : " << fLegendY1 << endl;
             cout << "x2 : " << fLegendX2 << " y2 : " << fLegendY2 << endl;
 
-            if (GetVerboseLevel() >= REST_Extreme) GetChar();
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Extreme) GetChar();
         }
 
         fLegendOption = GetFieldValue("option", legendDefinition);
@@ -393,7 +393,7 @@ void TRestMetadataPlot::InitFromConfigFile() {
 #pragma endregion
 
 #pragma region ReadPlot
-    debug << "TRestMetadataPlot: Reading plot sections" << endl;
+    RESTDebug << "TRestMetadataPlot: Reading plot sections" << RESTendl;
     Int_t maxPlots = (Int_t)fCanvasDivisions.X() * (Int_t)fCanvasDivisions.Y();
     TiXmlElement* plotele = fElement->FirstChildElement("plot");
     while (plotele != nullptr) {
@@ -401,8 +401,8 @@ void TRestMetadataPlot::InitFromConfigFile() {
         if (ToUpper(active) == "ON") {
             int N = fPlots.size();
             if (N >= maxPlots) {
-                ferr << "Your canvas divisions (" << fCanvasDivisions.X() << " , " << fCanvasDivisions.Y()
-                     << ") are not enough to show " << N + 1 << " plots" << endl;
+                RESTFerr << "Your canvas divisions (" << fCanvasDivisions.X() << " , " << fCanvasDivisions.Y()
+                         << ") are not enough to show " << N + 1 << " plots" << RESTendl;
                 exit(1);
             }
 
@@ -422,18 +422,18 @@ void TRestMetadataPlot::InitFromConfigFile() {
             plot.yRange = StringTo2DVector(GetParameter("yRange", plotele, "(-1,-1)"));
             plot.xRange = StringTo2DVector(GetParameter("xRange", plotele, "(-1,-1)"));
 
-            debug << " Plot parameters read from <plot section " << endl;
-            debug << " --------------------------------------- " << endl;
-            debug << "- name: " << plot.name << endl;
-            debug << "- title: " << plot.title << endl;
-            debug << "- xVariable: " << plot.xVariable << endl;
-            debug << "- logX: " << plot.logX << endl;
-            debug << "- logY: " << plot.logY << endl;
-            debug << "- X-label : " << plot.labelX << endl;
-            debug << "- Y-label : " << plot.labelY << endl;
-            debug << "- legendOn: " << plot.legendOn << endl;
-            debug << "- timeDisplay: " << plot.timeDisplay << endl;
-            debug << "- save : " << plot.save << endl;
+            RESTDebug << " Plot parameters read from <plot section " << RESTendl;
+            RESTDebug << " --------------------------------------- " << RESTendl;
+            RESTDebug << "- name: " << plot.name << RESTendl;
+            RESTDebug << "- title: " << plot.title << RESTendl;
+            RESTDebug << "- xVariable: " << plot.xVariable << RESTendl;
+            RESTDebug << "- logX: " << plot.logX << RESTendl;
+            RESTDebug << "- logY: " << plot.logY << RESTendl;
+            RESTDebug << "- X-label : " << plot.labelX << RESTendl;
+            RESTDebug << "- Y-label : " << plot.labelY << RESTendl;
+            RESTDebug << "- legendOn: " << plot.legendOn << RESTendl;
+            RESTDebug << "- timeDisplay: " << plot.timeDisplay << RESTendl;
+            RESTDebug << "- save : " << plot.save << RESTendl;
 
             TiXmlElement* graphele = plotele->FirstChildElement("graph");
             if (graphele == nullptr) {
@@ -444,8 +444,8 @@ void TRestMetadataPlot::InitFromConfigFile() {
             while (graphele != nullptr) {
                 Graph_Info_Set graph = SetupGraphFromConfigFile(graphele, plot);
 
-                debug << "Graph name : " << graph.name << endl;
-                debug << "Graph variable : " << graph.yVariable << endl;
+                RESTDebug << "Graph name : " << graph.name << RESTendl;
+                RESTDebug << "Graph variable : " << graph.yVariable << RESTendl;
 
                 plot.graphs.push_back(graph);
 
@@ -459,7 +459,7 @@ void TRestMetadataPlot::InitFromConfigFile() {
 #pragma endregion
 
 #pragma region ReadPanel
-    debug << "TRestMetadataPlot: Reading panel sections" << endl;
+    RESTDebug << "TRestMetadataPlot: Reading panel sections" << RESTendl;
     maxPlots -= fPlots.size();  // remaining spaces on canvas
     TiXmlElement* panelele = fElement->FirstChildElement("panel");
     while (panelele != nullptr) {
@@ -467,9 +467,9 @@ void TRestMetadataPlot::InitFromConfigFile() {
         if (ToUpper(active) == "ON") {
             int N = fPanels.size();
             if (N >= maxPlots) {
-                ferr << "Your canvas divisions (" << fCanvasDivisions.X() << " , " << fCanvasDivisions.Y()
-                     << ") are not enough to show " << fPlots.size() << " plots, and " << N + 1
-                     << " info panels" << endl;
+                RESTFerr << "Your canvas divisions (" << fCanvasDivisions.X() << " , " << fCanvasDivisions.Y()
+                         << ") are not enough to show " << fPlots.size() << " plots, and " << N + 1
+                         << " info panels" << RESTendl;
                 exit(1);
             }
 
@@ -491,11 +491,11 @@ void TRestMetadataPlot::InitFromConfigFile() {
     }
 
     for (int n = 0; n < fPanels.size(); n++) {
-        extreme << "Panel " << n << " with font size : " << fPanels[n].font_size << endl;
+        RESTExtreme << "Panel " << n << " with font size : " << fPanels[n].font_size << RESTendl;
         for (int m = 0; m < fPanels[n].posX.size(); m++) {
-            extreme << "Label : " << fPanels[n].label[m] << endl;
-            extreme << "Pos X : " << fPanels[n].posX[m] << endl;
-            extreme << "Pos Y : " << fPanels[n].posY[m] << endl;
+            RESTExtreme << "Label : " << fPanels[n].label[m] << RESTendl;
+            RESTExtreme << "Pos X : " << fPanels[n].posX[m] << RESTendl;
+            RESTExtreme << "Pos Y : " << fPanels[n].posY[m] << RESTendl;
         }
     }
 #pragma endregion
@@ -515,14 +515,15 @@ TRestMetadataPlot::Graph_Info_Set TRestMetadataPlot::SetupGraphFromConfigFile(Ti
 
     for (int n = 0; n < fPlotNamesCheck.size(); n++)
         if (graph.name == fPlotNamesCheck[n]) {
-            ferr << "Repeated plot/graph names were found! Please, use different names for different plots!"
-                 << endl;
-            ferr << "<plot/graph name=\"" << graph.name << "\" already defined!" << endl;
+            RESTFerr
+                << "Repeated plot/graph names were found! Please, use different names for different plots!"
+                << RESTendl;
+            RESTFerr << "<plot/graph name=\"" << graph.name << "\" already defined!" << RESTendl;
             exit(1);
         }
 
     if (graph.yVariable == "") {
-        ferr << "Problem reading yVariable from graph with name : " << graph.name << endl;
+        RESTFerr << "Problem reading yVariable from graph with name : " << graph.name << RESTendl;
         exit(2);
     }
 
@@ -544,8 +545,8 @@ TRestMetadataPlot::Graph_Info_Set TRestMetadataPlot::SetupGraphFromConfigFile(Ti
 /// adds it to the list of input files beloning to this class.
 ///
 void TRestMetadataPlot::AddFile(TString fileName) {
-    debug << "TRestMetadataPlot::AddFile. Adding file. " << endl;
-    debug << "File name: " << fileName << endl;
+    RESTDebug << "TRestMetadataPlot::AddFile. Adding file. " << RESTendl;
+    RESTDebug << "File name: " << fileName << RESTendl;
 
     // TODO: How do we check here that the run is valid?
     fRunInputFileName.push_back((string)fileName);
@@ -580,7 +581,7 @@ void TRestMetadataPlot::AddFileFromEnv() {
     auto files = TRestTools::GetFilesMatchingPattern(filepattern);
 
     for (unsigned int n = 0; n < files.size(); n++) {
-        essential << "Adding file : " << files[n] << endl;
+        RESTEssential << "Adding file : " << files[n] << RESTendl;
         AddFile(files[n]);
     }
 }
@@ -592,7 +593,7 @@ Int_t TRestMetadataPlot::GetPlotIndex(TString plotName) {
     for (unsigned int n = 0; n < fPlots.size(); n++)
         if (fPlots[n].name == plotName) return n;
 
-    warning << "TRestMetadataPlot::GetPlotIndex. Plot name " << plotName << " not found" << endl;
+    RESTWarning << "TRestMetadataPlot::GetPlotIndex. Plot name " << plotName << " not found" << RESTendl;
     return -1;
 }
 
@@ -601,9 +602,9 @@ Int_t TRestMetadataPlot::GetPlotIndex(TString plotName) {
 /// and generating the plots inside the main canvas.
 ///
 void TRestMetadataPlot::GenerateCanvas() {
-    info << "--------------------------" << endl;
-    info << "Starting to GenerateCanvas" << endl;
-    info << "--------------------------" << endl;
+    RESTInfo << "--------------------------" << RESTendl;
+    RESTInfo << "Starting to GenerateCanvas" << RESTendl;
+    RESTInfo << "--------------------------" << RESTendl;
     // Add files, first use <addFile section definition
     TiXmlElement* ele = fElement->FirstChildElement("addFile");
     while (ele != nullptr) {
@@ -617,7 +618,7 @@ void TRestMetadataPlot::GenerateCanvas() {
     if (fNFiles == 0) AddFileFromEnv();
 
     if (fNFiles == 0) {
-        ferr << "TRestMetadataPlot: No input files are added!" << endl;
+        RESTFerr << "TRestMetadataPlot: No input files are added!" << RESTendl;
         exit(1);
     }
 
@@ -653,7 +654,7 @@ void TRestMetadataPlot::GenerateCanvas() {
             run->SetHistoricMetadataSaving(false);
             run->OpenInputFile(fRunInputFileName[n]);
 
-            info << "Loading timestamps from file : " << fRunInputFileName[n] << endl;
+            RESTInfo << "Loading timestamps from file : " << fRunInputFileName[n] << RESTendl;
 
             Double_t endTimeStamp = run->GetEndTimestamp();
             Double_t startTimeStamp = run->GetStartTimestamp();
@@ -731,7 +732,7 @@ void TRestMetadataPlot::GenerateCanvas() {
             TString graphName = graph.name;
             TString graphVariable = graph.yVariable;
 
-            if (GetVerboseLevel() >= REST_Debug) {
+            if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 cout << endl;
                 cout << "--------------------------------------" << endl;
                 cout << "Graph name : " << graphName << endl;
@@ -754,7 +755,7 @@ void TRestMetadataPlot::GenerateCanvas() {
 
             // We build the corresponding TGraph extracting the points from each file
             for (unsigned int j = 0; j < fRunInputFileName.size(); j++) {
-                info << "Loading file : " << fRunInputFileName[j] << endl;
+                RESTInfo << "Loading file : " << fRunInputFileName[j] << RESTendl;
 
                 TRestRun* run = new TRestRun();
                 run->SetHistoricMetadataSaving(false);
@@ -803,20 +804,20 @@ void TRestMetadataPlot::GenerateCanvas() {
 
             // In case of problems we output this
             if (xData.size() == 0) {
-                warning << "TRestMetadataPlot: no input file matches condition for graph: " << graph.name
-                        << endl;
-                warning << "This graph is empty and it will not be plotted" << endl;
+                RESTWarning << "TRestMetadataPlot: no input file matches condition for graph: " << graph.name
+                            << RESTendl;
+                RESTWarning << "This graph is empty and it will not be plotted" << RESTendl;
                 plot.graphs.erase(plot.graphs.begin() + i);
                 i--;
             }
 
             if (xData.size() == 1) {
-                warning << "TRestMetadataPlot: Only 1-point for graph: " << graph.name << endl;
-                warning << "X: " << xData[0] << " Y: " << yData[0] << endl;
+                RESTWarning << "TRestMetadataPlot: Only 1-point for graph: " << graph.name << RESTendl;
+                RESTWarning << "X: " << xData[0] << " Y: " << yData[0] << RESTendl;
             }
 
             for (int nn = 0; nn < xData.size(); nn++)
-                debug << "X: " << xData[nn] << " Y: " << yData[nn] << endl;
+                RESTDebug << "X: " << xData[nn] << " Y: " << yData[nn] << RESTendl;
 
             // adjust the graph
             TGraph* gr_temp = new TGraph(xData.size(), &xData[0], &yData[0]);
@@ -855,7 +856,7 @@ void TRestMetadataPlot::GenerateCanvas() {
         }
 
         if (graphCollectionPlot.size() == 0) {
-            warning << "TRestMetadataPlot: pad empty for the plot: " << plot.name << endl;
+            RESTWarning << "TRestMetadataPlot: pad empty for the plot: " << plot.name << RESTendl;
             continue;
         }
 

--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -364,15 +364,15 @@ void TRestProcessRunner::RunProcess() {
         }
     } else {
         if (fRunInfo->GetFileProcess() != nullptr) {
-            RESTFout << "(external) " << fRunInfo->GetFileProcess()->ClassName() << " : "
+            RESTcout << "(external) " << fRunInfo->GetFileProcess()->ClassName() << " : "
                      << fRunInfo->GetFileProcess()->GetName() << RESTendl;
         }
         for (int i = 0; i < fProcessNumber; i++) {
-            RESTFout << "++ " << fThreads[0]->GetProcess(i)->ClassName() << " : "
+            RESTcout << "++ " << fThreads[0]->GetProcess(i)->ClassName() << " : "
                      << fThreads[0]->GetProcess(i)->GetName() << RESTendl;
         }
     }
-    RESTFout << "=" << RESTendl;
+    RESTcout << "=" << RESTendl;
 
     // copy thread's event tree to local
     fOutputDataFile->cd();
@@ -426,7 +426,7 @@ void TRestProcessRunner::RunProcess() {
 #endif
 
     // start the thread!
-    RESTFout << this->ClassName() << ": Starting the Process.." << RESTendl;
+    RESTcout << this->ClassName() << ": Starting the Process.." << RESTendl;
     for (int i = 0; i < fThreadNumber; i++) {
         fThreads[i]->StartThread();
     }
@@ -442,15 +442,14 @@ void TRestProcessRunner::RunProcess() {
             if (a == 'p') {
                 fProcStatus = kPause;
                 usleep(100000);  // wait 0.1s for the processes to finish;
-                TRestStringOutput RESTcout(TRestStringOutput::REST_Verbose_Level::REST_Silent,
-                                           COLOR_BOLDWHITE, "| |",
-                                           TRestStringOutput::REST_Display_Orientation::kMiddle);
+                TRestStringOutput RESTLog(TRestStringOutput::REST_Verbose_Level::REST_Silent, COLOR_BOLDWHITE,
+                                          "| |", TRestStringOutput::REST_Display_Orientation::kMiddle);
                 Console::ClearLinesAfterCursor();
-                RESTcout << RESTendl;
-                RESTcout << "-" << RESTendl;
-                RESTcout << "PROCESS PAUSED!" << RESTendl;
-                RESTcout << "-" << RESTendl;
-                RESTcout << " " << RESTendl;
+                RESTLog << RESTendl;
+                RESTLog << "-" << RESTendl;
+                RESTLog << "PROCESS PAUSED!" << RESTendl;
+                RESTLog << "-" << RESTendl;
+                RESTLog << " " << RESTendl;
             }
         }
 
@@ -513,7 +512,7 @@ void TRestProcessRunner::RunProcess() {
     gROOTMutex = nullptr;
     gInterpreterMutex = nullptr;
 
-    RESTFout << this->ClassName() << ": " << fProcessedEvents << " processed events" << RESTendl;
+    RESTcout << this->ClassName() << ": " << fProcessedEvents << " processed events" << RESTendl;
 
 #ifdef TIME_MEASUREMENT
     RESTInfo << "Total processing time : " << ((Double_t)deltaTime) / 1000. << " ms" << RESTendl;
@@ -543,20 +542,20 @@ void TRestProcessRunner::RunProcess() {
 /// 4. Print the latest processed event
 /// 5. Quit the process directly with file saved
 void TRestProcessRunner::PauseMenu() {
-    TRestStringOutput RESTcout(TRestStringOutput::REST_Verbose_Level::REST_Silent, COLOR_BOLDWHITE, "| |",
-                               TRestStringOutput::REST_Display_Orientation::kMiddle);
+    TRestStringOutput RESTLog(TRestStringOutput::REST_Verbose_Level::REST_Silent, COLOR_BOLDWHITE, "| |",
+                              TRestStringOutput::REST_Display_Orientation::kMiddle);
     Console::ClearLinesAfterCursor();
 
-    RESTcout << "--------------MENU--------------" << RESTendl;
-    RESTcout << "\"v\" : change the verbose level" << RESTendl;
-    RESTcout << "\"n\" : push foward one event, then pause" << RESTendl;
-    RESTcout << "\"l\" : print the latest processed event" << RESTendl;
-    RESTcout << "\"d\" : detach the current process" << RESTendl;
-    RESTcout << "\"q\" : stop and quit the process" << RESTendl;
-    RESTcout << "press \"p\" to continue process..." << RESTendl;
-    RESTcout << "-" << RESTendl;
-    RESTcout << RESTendl;
-    RESTcout << RESTendl;
+    RESTLog << "--------------MENU--------------" << RESTendl;
+    RESTLog << "\"v\" : change the verbose level" << RESTendl;
+    RESTLog << "\"n\" : push foward one event, then pause" << RESTendl;
+    RESTLog << "\"l\" : print the latest processed event" << RESTendl;
+    RESTLog << "\"d\" : detach the current process" << RESTendl;
+    RESTLog << "\"q\" : stop and quit the process" << RESTendl;
+    RESTLog << "press \"p\" to continue process..." << RESTendl;
+    RESTLog << "-" << RESTendl;
+    RESTLog << RESTendl;
+    RESTLog << RESTendl;
     int menuupper = 15;
     int infobar = 11;
     while (1) {
@@ -566,20 +565,20 @@ void TRestProcessRunner::PauseMenu() {
 
         if (b == 'v') {
             Console::CursorUp(infobar);
-            RESTcout.setcolor(COLOR_BOLDGREEN);
-            RESTcout << "Changing verbose level for all the processes..." << RESTendl;
-            RESTcout.setcolor(COLOR_BOLDWHITE);
+            RESTLog.setcolor(COLOR_BOLDGREEN);
+            RESTLog << "Changing verbose level for all the processes..." << RESTendl;
+            RESTLog.setcolor(COLOR_BOLDWHITE);
             Console::CursorDown(1);
             Console::ClearLinesAfterCursor();
-            RESTcout << "type \"0\"/\"s\" to set level silent" << RESTendl;
-            RESTcout << "type \"1\"/\"e\" to set level essential" << RESTendl;
-            RESTcout << "type \"2\"/\"i\" to set level info" << RESTendl;
-            RESTcout << "type \"3\"/\"d\" to set level debug" << RESTendl;
-            RESTcout << "type \"4\"/\"x\" to set level extreme" << RESTendl;
-            RESTcout << "type other to return the pause menu" << RESTendl;
-            RESTcout << "-" << RESTendl;
-            RESTcout << RESTendl;
-            RESTcout << RESTendl;
+            RESTLog << "type \"0\"/\"s\" to set level silent" << RESTendl;
+            RESTLog << "type \"1\"/\"e\" to set level essential" << RESTendl;
+            RESTLog << "type \"2\"/\"i\" to set level info" << RESTendl;
+            RESTLog << "type \"3\"/\"d\" to set level debug" << RESTendl;
+            RESTLog << "type \"4\"/\"x\" to set level extreme" << RESTendl;
+            RESTLog << "type other to return the pause menu" << RESTendl;
+            RESTLog << "-" << RESTendl;
+            RESTLog << RESTendl;
+            RESTLog << RESTendl;
             while (1) {
                 Console::CursorUp(1);
                 int c = Console::Read();
@@ -599,9 +598,9 @@ void TRestProcessRunner::PauseMenu() {
                     l = TRestStringOutput::REST_Verbose_Level::REST_Extreme;
                 } else {
                     Console::CursorUp(infobar);
-                    RESTcout.setcolor(COLOR_BOLDYELLOW);
-                    RESTcout << "Verbose level not set!" << RESTendl;
-                    RESTcout.setcolor(COLOR_BOLDWHITE);
+                    RESTLog.setcolor(COLOR_BOLDYELLOW);
+                    RESTLog << "Verbose level not set!" << RESTendl;
+                    RESTLog.setcolor(COLOR_BOLDWHITE);
                     break;
                 }
 
@@ -614,30 +613,30 @@ void TRestProcessRunner::PauseMenu() {
                     }
                 }
                 Console::CursorUp(infobar);
-                RESTcout.setcolor(COLOR_BOLDGREEN);
-                RESTcout << "Verbose level has been set to " << ToString(static_cast<int>(l)) << "!"
-                         << RESTendl;
-                RESTcout.setcolor(COLOR_BOLDWHITE);
+                RESTLog.setcolor(COLOR_BOLDGREEN);
+                RESTLog << "Verbose level has been set to " << ToString(static_cast<int>(l)) << "!"
+                        << RESTendl;
+                RESTLog.setcolor(COLOR_BOLDWHITE);
                 break;
             }
             Console::ClearLinesAfterCursor();
             break;
         } else if (b == 'd') {
             Console::CursorUp(infobar);
-            RESTcout.setcolor(COLOR_BOLDGREEN);
-            RESTcout << "Detaching restManager to backend" << RESTendl;
-            RESTcout.setcolor(COLOR_BOLDWHITE);
+            RESTLog.setcolor(COLOR_BOLDGREEN);
+            RESTLog << "Detaching restManager to backend" << RESTendl;
+            RESTLog.setcolor(COLOR_BOLDWHITE);
             Console::CursorDown(1);
             Console::ClearLinesAfterCursor();
-            RESTcout << "type filename for output redirect" << RESTendl;
-            RESTcout << "leave blank to redirect to /dev/null" << RESTendl;
-            RESTcout << " " << RESTendl;
-            RESTcout << " " << RESTendl;
-            RESTcout << " " << RESTendl;
-            RESTcout << " " << RESTendl;
-            RESTcout << "-" << RESTendl;
-            RESTcout << RESTendl;
-            RESTcout << RESTendl;
+            RESTLog << "type filename for output redirect" << RESTendl;
+            RESTLog << "leave blank to redirect to /dev/null" << RESTendl;
+            RESTLog << " " << RESTendl;
+            RESTLog << " " << RESTendl;
+            RESTLog << " " << RESTendl;
+            RESTLog << " " << RESTendl;
+            RESTLog << "-" << RESTendl;
+            RESTLog << RESTendl;
+            RESTLog << RESTendl;
 
             string file;
 
@@ -647,17 +646,17 @@ void TRestProcessRunner::PauseMenu() {
             if (TRestTools::fileExists(file)) {
                 if (!TRestTools::isPathWritable(file)) {
                     Console::CursorUp(infobar);
-                    RESTcout.setcolor(COLOR_BOLDYELLOW);
-                    RESTcout << "file not writeable!" << RESTendl;
-                    RESTcout.setcolor(COLOR_BOLDWHITE);
+                    RESTLog.setcolor(COLOR_BOLDYELLOW);
+                    RESTLog << "file not writeable!" << RESTendl;
+                    RESTLog.setcolor(COLOR_BOLDWHITE);
                     break;
                 }
             } else {
                 if (!TRestTools::isPathWritable(TRestTools::SeparatePathAndName(file).first)) {
                     Console::CursorUp(infobar);
-                    RESTcout.setcolor(COLOR_BOLDYELLOW);
-                    RESTcout << "path not writeable!" << RESTendl;
-                    RESTcout.setcolor(COLOR_BOLDWHITE);
+                    RESTLog.setcolor(COLOR_BOLDYELLOW);
+                    RESTLog << "path not writeable!" << RESTendl;
+                    RESTLog.setcolor(COLOR_BOLDWHITE);
                     break;
                 }
             }
@@ -670,7 +669,7 @@ void TRestProcessRunner::PauseMenu() {
             }
             // child process
             if (pid == 0) {
-                RESTFout << "Child process created! pid: " << getpid() << RESTendl;
+                RESTcout << "Child process created! pid: " << getpid() << RESTendl;
                 RESTInfo << "Restarting threads" << RESTendl;
                 mutex_write.unlock();
                 for (int i = 0; i < fThreadNumber; i++) {
@@ -710,9 +709,9 @@ void TRestProcessRunner::PauseMenu() {
             // CursorUp(1);
         } else {
             Console::CursorUp(infobar);
-            RESTcout.setcolor(COLOR_BOLDYELLOW);
-            RESTcout << "Invailed option \"" << (char)b << "\" (key value: " << b << ") !" << RESTendl;
-            RESTcout.setcolor(COLOR_BOLDWHITE);
+            RESTLog.setcolor(COLOR_BOLDYELLOW);
+            RESTLog << "Invailed option \"" << (char)b << "\" (key value: " << b << ") !" << RESTendl;
+            RESTLog.setcolor(COLOR_BOLDWHITE);
             Console::CursorDown(infobar - 1);
         }
     }

--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -108,14 +108,14 @@ void TRestProcessRunner::BeginOfInit() {
     if (fHostmgr != nullptr) {
         fRunInfo = fHostmgr->GetRunInfo();
         if (fRunInfo == nullptr) {
-            RESTFerr << "File IO has not been specified, " << RESTendl;
-            RESTFerr << "please make sure the \"TRestFiles\" section is ahead of the "
-                        "\"TRestProcessRunner\" section"
-                     << RESTendl;
+            RESTError << "File IO has not been specified, " << RESTendl;
+            RESTError << "please make sure the \"TRestFiles\" section is ahead of the "
+                         "\"TRestProcessRunner\" section"
+                      << RESTendl;
             exit(0);
         }
     } else {
-        RESTFerr << "manager not initialized!" << RESTendl;
+        RESTError << "manager not initialized!" << RESTendl;
         exit(0);
     }
 
@@ -125,8 +125,8 @@ void TRestProcessRunner::BeginOfInit() {
     // I believe it is risky to exit() at TRestThread without closing threads.
     // It is a guess (J.G.)
     if (!fRunInfo->GetFileProcess() && fRunInfo->GetEntries() == 0) {
-        RESTFerr << "TRestProcessRunner::BeginOfInit. The input file is a valid REST file but entries are 0!"
-                 << RESTendl;
+        RESTError << "TRestProcessRunner::BeginOfInit. The input file is a valid REST file but entries are 0!"
+                  << RESTendl;
         exit(1);
     }
 
@@ -164,7 +164,7 @@ void TRestProcessRunner::BeginOfInit() {
     if (!fUsePauseMenu || fVerboseLevel >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
         fProcStatus = kIgnore;
     if (fOutputAnalysisStorage == false) {
-        RESTFerr << "output analysis must be turned on to process data!" << RESTendl;
+        RESTError << "output analysis must be turned on to process data!" << RESTendl;
         exit(1);
     }
     // fValidateObservables = StringToBool(GetParameter("validateObservables", "OFF"));
@@ -283,7 +283,7 @@ void TRestProcessRunner::EndOfInit() {
         fInputEvent = fRunInfo->GetInputEvent();
     }
     if (fInputEvent == nullptr) {
-        RESTFerr << "Cannot determine input event, validating process chain failed!" << RESTendl;
+        RESTError << "Cannot determine input event, validating process chain failed!" << RESTendl;
         exit(1);
     }
 
@@ -337,7 +337,7 @@ void TRestProcessRunner::RunProcess() {
     // we must set in each threadCompression
     // fOutputDataFile->SetCompressionLevel(fFile);
     if (!fOutputDataFile->IsOpen()) {
-        RESTFerr << "Failed to create output file: " << fOutputDataFile->GetName() << RESTendl;
+        RESTError << "Failed to create output file: " << fOutputDataFile->GetName() << RESTendl;
         exit(1);
     }
     RESTInfo << RESTendl;
@@ -398,7 +398,7 @@ void TRestProcessRunner::RunProcess() {
     if (tree != nullptr) {
         fNBranches = tree->GetNbranches();
     } else {
-        RESTFerr << "Threads are not initialized! No AnalysisTree!" << RESTendl;
+        RESTError << "Threads are not initialized! No AnalysisTree!" << RESTendl;
         exit(1);
     }
 
@@ -915,7 +915,7 @@ void TRestProcessRunner::FillThreadEventFunc(TRestThread* t) {
                 delete fOutputDataFile;
                 fOutputDataFile = newfile;
             } else {
-                RESTFerr << "internal error!" << RESTendl;
+                RESTError << "internal error!" << RESTendl;
             }
         }
 

--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -104,18 +104,18 @@ void TRestProcessRunner::Initialize() {
 /// 2. Tree branch list. can be inputAnalysis, inputEvent, outputEvent.
 /// 3. Number of thread needed. A list TRestThread will then be instantiated.
 void TRestProcessRunner::BeginOfInit() {
-    info << endl;
+    RESTInfo << RESTendl;
     if (fHostmgr != nullptr) {
         fRunInfo = fHostmgr->GetRunInfo();
         if (fRunInfo == nullptr) {
-            ferr << "File IO has not been specified, " << endl;
-            ferr << "please make sure the \"TRestFiles\" section is ahead of the "
-                    "\"TRestProcessRunner\" section"
-                 << endl;
+            RESTFerr << "File IO has not been specified, " << RESTendl;
+            RESTFerr << "please make sure the \"TRestFiles\" section is ahead of the "
+                        "\"TRestProcessRunner\" section"
+                     << RESTendl;
             exit(0);
         }
     } else {
-        ferr << "manager not initialized!" << endl;
+        RESTFerr << "manager not initialized!" << RESTendl;
         exit(0);
     }
 
@@ -125,8 +125,8 @@ void TRestProcessRunner::BeginOfInit() {
     // I believe it is risky to exit() at TRestThread without closing threads.
     // It is a guess (J.G.)
     if (!fRunInfo->GetFileProcess() && fRunInfo->GetEntries() == 0) {
-        ferr << "TRestProcessRunner::BeginOfInit. The input file is a valid REST file but entries are 0!"
-             << endl;
+        RESTFerr << "TRestProcessRunner::BeginOfInit. The input file is a valid REST file but entries are 0!"
+                 << RESTendl;
         exit(1);
     }
 
@@ -139,14 +139,14 @@ void TRestProcessRunner::BeginOfInit() {
         fEventsToProcess = lastEntry - fFirstEntry;
     } else if (fEventsToProcess > 0 && lastEntry - fFirstEntry > 0 &&
                lastEntry - fFirstEntry != fEventsToProcess) {
-        warning << "Conflict number of events to process!" << endl;
+        RESTWarning << "Conflict number of events to process!" << RESTendl;
     } else if (fEventsToProcess > 0 && lastEntry - fFirstEntry == 0) {
         lastEntry = fFirstEntry + fEventsToProcess;
     } else if (fEventsToProcess == 0 && fFirstEntry == 0 && lastEntry == 0) {
         fEventsToProcess = REST_MAXIMUM_EVENTS;
         lastEntry = REST_MAXIMUM_EVENTS;
     } else {
-        warning << "error setting of event number" << endl;
+        RESTWarning << "error setting of event number" << RESTendl;
         fEventsToProcess = fEventsToProcess > 0 ? fEventsToProcess : REST_MAXIMUM_EVENTS;
         fFirstEntry = fFirstEntry > 0 ? fFirstEntry : 0;
         lastEntry = lastEntry == fFirstEntry + fEventsToProcess ? lastEntry : REST_MAXIMUM_EVENTS;
@@ -154,16 +154,17 @@ void TRestProcessRunner::BeginOfInit() {
     fRunInfo->SetCurrentEntry(fFirstEntry);
 
     if (fFileSplitSize < 50000000LL || fFileSplitSize > 100000000000LL) {
-        warning << "automatic file splitting size cannot < 10MB or > 100GB, setting to default (10GB)."
-                << endl;
+        RESTWarning << "automatic file splitting size cannot < 10MB or > 100GB, setting to default (10GB)."
+                    << RESTendl;
         fFileSplitSize = 10000000000LL;
     }
 
     // fUseTestRun = StringToBool(GetParameter("useTestRun", "ON"));
     // fUsePauseMenu = StringToBool(GetParameter("usePauseMenu", "OFF"));
-    if (!fUsePauseMenu || fVerboseLevel >= REST_Debug) fProcStatus = kIgnore;
+    if (!fUsePauseMenu || fVerboseLevel >= TRestStringOutput::REST_Verbose_Level::REST_Debug)
+        fProcStatus = kIgnore;
     if (fOutputAnalysisStorage == false) {
-        ferr << "output analysis must be turned on to process data!" << endl;
+        RESTFerr << "output analysis must be turned on to process data!" << RESTendl;
         exit(1);
     }
     // fValidateObservables = StringToBool(GetParameter("validateObservables", "OFF"));
@@ -207,14 +208,14 @@ Int_t TRestProcessRunner::ReadConfig(string keydeclare, TiXmlElement* e) {
         string processType = GetParameter("type", e, "");
 
         if (processType == "") {
-            warning << "Bad expression of addProcess" << endl;
+            RESTWarning << "Bad expression of addProcess" << RESTendl;
             return 0;
         } else if (processName == "") {
-            warning << "Event process " << processType << " has no name, it will be skipped" << endl;
+            RESTWarning << "Event process " << processType << " has no name, it will be skipped" << RESTendl;
             return 0;
         }
 
-        info << "adding process " << processType << " \"" << processName << "\"" << endl;
+        RESTInfo << "adding process " << processType << " \"" << processName << "\"" << RESTendl;
         vector<TRestEventProcess*> processes;
         for (int i = 0; i < fThreadNumber; i++) {
             TRestEventProcess* p = InstantiateProcess(processType, e);
@@ -223,13 +224,14 @@ Int_t TRestProcessRunner::ReadConfig(string keydeclare, TiXmlElement* e) {
                     fRunInfo->SetExtProcess(p);
                     return 0;
                 }
-                if ((p->GetVerboseLevel() >= REST_Debug || p->singleThreadOnly())) {
+                if ((p->GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug ||
+                     p->singleThreadOnly())) {
                     fUsePauseMenu = false;
                     fProcStatus = kIgnore;
                     if (fThreadNumber > 1) {
-                        info << "multi-threading is disabled due to process \"" << p->GetName() << "\""
-                             << endl;
-                        info << "This process is in debug mode or is single thread only" << endl;
+                        RESTInfo << "multi-threading is disabled due to process \"" << p->GetName() << "\""
+                                 << RESTendl;
+                        RESTInfo << "This process is in debug mode or is single thread only" << RESTendl;
                         for (i = fThreadNumber; i > 1; i--) {
                             // delete (*fThreads.end());
                             fThreads.erase(fThreads.end() - 1);
@@ -252,7 +254,7 @@ Int_t TRestProcessRunner::ReadConfig(string keydeclare, TiXmlElement* e) {
         }
 
         fProcessNumber++;
-        debug << "process \"" << processType << "\" has been added!" << endl;
+        RESTDebug << "process \"" << processType << "\" has been added!" << RESTendl;
         return 0;
     }
 
@@ -266,7 +268,7 @@ Int_t TRestProcessRunner::ReadConfig(string keydeclare, TiXmlElement* e) {
 /// Validation of the process chain. Finally it calls ReadProcInfo() and create
 /// a process info list
 void TRestProcessRunner::EndOfInit() {
-    debug << "Validating process chain..." << endl;
+    RESTDebug << "Validating process chain..." << RESTendl;
 
     if (fRunInfo->GetFileProcess() != nullptr) {
         fInputEvent = fRunInfo->GetFileProcess()->GetOutputEvent();
@@ -281,7 +283,7 @@ void TRestProcessRunner::EndOfInit() {
         fInputEvent = fRunInfo->GetInputEvent();
     }
     if (fInputEvent == nullptr) {
-        ferr << "Cannot determine input event, validating process chain failed!" << endl;
+        RESTFerr << "Cannot determine input event, validating process chain failed!" << RESTendl;
         exit(1);
     }
 
@@ -326,7 +328,7 @@ void TRestProcessRunner::ReadProcInfo() {
 /// 8. Call ConfigOutputFile() method to save the output file
 ///
 void TRestProcessRunner::RunProcess() {
-    debug << "Creating output File " << fRunInfo->GetOutputFileName() << endl;
+    RESTDebug << "Creating output File " << fRunInfo->GetOutputFileName() << RESTendl;
 
     TString filename = fRunInfo->FormFormat(fRunInfo->GetOutputFileName());
     fOutputDataFileName = filename;
@@ -335,11 +337,11 @@ void TRestProcessRunner::RunProcess() {
     // we must set in each threadCompression
     // fOutputDataFile->SetCompressionLevel(fFile);
     if (!fOutputDataFile->IsOpen()) {
-        ferr << "Failed to create output file: " << fOutputDataFile->GetName() << endl;
+        RESTFerr << "Failed to create output file: " << fOutputDataFile->GetName() << RESTendl;
         exit(1);
     }
-    info << endl;
-    info << "TRestProcessRunner : preparing threads..." << endl;
+    RESTInfo << RESTendl;
+    RESTInfo << "TRestProcessRunner : preparing threads..." << RESTendl;
     fRunInfo->ResetEntry();
     fRunInfo->SetCurrentEntry(fFirstEntry);
     for (int i = 0; i < fThreadNumber; i++) {
@@ -348,13 +350,13 @@ void TRestProcessRunner::RunProcess() {
 
     // print metadata
     if (fRunInfo->GetFileProcess() != nullptr) {
-        essential << this->ClassName() << ": 1 + " << fProcessNumber << " processes loaded, " << fThreadNumber
-                  << " threads prepared!" << endl;
+        RESTEssential << this->ClassName() << ": 1 + " << fProcessNumber << " processes loaded, "
+                      << fThreadNumber << " threads prepared!" << RESTendl;
     } else {
-        essential << this->ClassName() << ": " << fProcessNumber << " processes loaded, " << fThreadNumber
-                  << " threads prepared!" << endl;
+        RESTEssential << this->ClassName() << ": " << fProcessNumber << " processes loaded, " << fThreadNumber
+                      << " threads prepared!" << RESTendl;
     }
-    if (fVerboseLevel >= REST_Essential) {
+    if (fVerboseLevel >= TRestStringOutput::REST_Verbose_Level::REST_Essential) {
         if (fRunInfo->GetFileProcess() != nullptr) fRunInfo->GetFileProcess()->PrintMetadata();
 
         for (int i = 0; i < fProcessNumber; i++) {
@@ -362,15 +364,15 @@ void TRestProcessRunner::RunProcess() {
         }
     } else {
         if (fRunInfo->GetFileProcess() != nullptr) {
-            fout << "(external) " << fRunInfo->GetFileProcess()->ClassName() << " : "
-                 << fRunInfo->GetFileProcess()->GetName() << endl;
+            RESTFout << "(external) " << fRunInfo->GetFileProcess()->ClassName() << " : "
+                     << fRunInfo->GetFileProcess()->GetName() << RESTendl;
         }
         for (int i = 0; i < fProcessNumber; i++) {
-            fout << "++ " << fThreads[0]->GetProcess(i)->ClassName() << " : "
-                 << fThreads[0]->GetProcess(i)->GetName() << endl;
+            RESTFout << "++ " << fThreads[0]->GetProcess(i)->ClassName() << " : "
+                     << fThreads[0]->GetProcess(i)->GetName() << RESTendl;
         }
     }
-    fout << "=" << endl;
+    RESTFout << "=" << RESTendl;
 
     // copy thread's event tree to local
     fOutputDataFile->cd();
@@ -396,7 +398,7 @@ void TRestProcessRunner::RunProcess() {
     if (tree != nullptr) {
         fNBranches = tree->GetNbranches();
     } else {
-        ferr << "Threads are not initialized! No AnalysisTree!" << endl;
+        RESTFerr << "Threads are not initialized! No AnalysisTree!" << RESTendl;
         exit(1);
     }
 
@@ -424,7 +426,7 @@ void TRestProcessRunner::RunProcess() {
 #endif
 
     // start the thread!
-    fout << this->ClassName() << ": Starting the Process.." << endl;
+    RESTFout << this->ClassName() << ": Starting the Process.." << RESTendl;
     for (int i = 0; i < fThreadNumber; i++) {
         fThreads[i]->StartThread();
     }
@@ -440,13 +442,15 @@ void TRestProcessRunner::RunProcess() {
             if (a == 'p') {
                 fProcStatus = kPause;
                 usleep(100000);  // wait 0.1s for the processes to finish;
-                TRestStringOutput cout(REST_Silent, COLOR_BOLDWHITE, "| |", kMiddle);
+                TRestStringOutput RESTcout(TRestStringOutput::REST_Verbose_Level::REST_Silent,
+                                           COLOR_BOLDWHITE, "| |",
+                                           TRestStringOutput::REST_Display_Orientation::kMiddle);
                 Console::ClearLinesAfterCursor();
-                cout << endl;
-                cout << "-" << endl;
-                cout << "PROCESS PAUSED!" << endl;
-                cout << "-" << endl;
-                cout << " " << endl;
+                RESTcout << RESTendl;
+                RESTcout << "-" << RESTendl;
+                RESTcout << "PROCESS PAUSED!" << RESTendl;
+                RESTcout << "-" << RESTendl;
+                RESTcout << " " << RESTendl;
             }
         }
 
@@ -472,7 +476,8 @@ void TRestProcessRunner::RunProcess() {
         while (getchar() != '\n')
             ;  // clear buffer
 
-    essential << "Waiting for processes to finish ..." << endl;
+    RESTEssential << "Waiting for processes to finish ..." << RESTendl;
+
     while (1) {
 #ifdef WIN32
         _sleep(50);
@@ -508,17 +513,18 @@ void TRestProcessRunner::RunProcess() {
     gROOTMutex = nullptr;
     gInterpreterMutex = nullptr;
 
-    fout << this->ClassName() << ": " << fProcessedEvents << " processed events" << endl;
+    RESTFout << this->ClassName() << ": " << fProcessedEvents << " processed events" << RESTendl;
 
 #ifdef TIME_MEASUREMENT
-    info << "Total processing time : " << ((Double_t)deltaTime) / 1000. << " ms" << endl;
-    info << "Average read time from disk (per event) : " << ((Double_t)readTime) / fProcessedEvents / 1000.
-         << " ms" << endl;
-    info << "Average process time (per event) : "
-         << ((Double_t)(deltaTime - readTime - writeTime)) / fProcessedEvents / 1000. << " ms" << endl;
-    info << "Average write time to disk (per event) : " << ((Double_t)writeTime) / fProcessedEvents / 1000.
-         << " ms" << endl;
-    info << "=" << endl;
+    RESTInfo << "Total processing time : " << ((Double_t)deltaTime) / 1000. << " ms" << RESTendl;
+    RESTInfo << "Average read time from disk (per event) : "
+             << ((Double_t)readTime) / fProcessedEvents / 1000. << " ms" << RESTendl;
+    RESTInfo << "Average process time (per event) : "
+             << ((Double_t)(deltaTime - readTime - writeTime)) / fProcessedEvents / 1000. << " ms"
+             << RESTendl;
+    RESTInfo << "Average write time to disk (per event) : "
+             << ((Double_t)writeTime) / fProcessedEvents / 1000. << " ms" << RESTendl;
+    RESTInfo << "=" << RESTendl;
 #endif
 
     if (fRunInfo->GetOutputFileName() != "/dev/null") {
@@ -537,19 +543,20 @@ void TRestProcessRunner::RunProcess() {
 /// 4. Print the latest processed event
 /// 5. Quit the process directly with file saved
 void TRestProcessRunner::PauseMenu() {
-    TRestStringOutput cout(REST_Silent, COLOR_BOLDWHITE, "| |", kMiddle);
+    TRestStringOutput RESTcout(TRestStringOutput::REST_Verbose_Level::REST_Silent, COLOR_BOLDWHITE, "| |",
+                               TRestStringOutput::REST_Display_Orientation::kMiddle);
     Console::ClearLinesAfterCursor();
 
-    cout << "--------------MENU--------------" << endl;
-    cout << "\"v\" : change the verbose level" << endl;
-    cout << "\"n\" : push foward one event, then pause" << endl;
-    cout << "\"l\" : print the latest processed event" << endl;
-    cout << "\"d\" : detach the current process" << endl;
-    cout << "\"q\" : stop and quit the process" << endl;
-    cout << "press \"p\" to continue process..." << endl;
-    cout << "-" << endl;
-    cout << endl;
-    cout << endl;
+    RESTcout << "--------------MENU--------------" << RESTendl;
+    RESTcout << "\"v\" : change the verbose level" << RESTendl;
+    RESTcout << "\"n\" : push foward one event, then pause" << RESTendl;
+    RESTcout << "\"l\" : print the latest processed event" << RESTendl;
+    RESTcout << "\"d\" : detach the current process" << RESTendl;
+    RESTcout << "\"q\" : stop and quit the process" << RESTendl;
+    RESTcout << "press \"p\" to continue process..." << RESTendl;
+    RESTcout << "-" << RESTendl;
+    RESTcout << RESTendl;
+    RESTcout << RESTendl;
     int menuupper = 15;
     int infobar = 11;
     while (1) {
@@ -559,42 +566,42 @@ void TRestProcessRunner::PauseMenu() {
 
         if (b == 'v') {
             Console::CursorUp(infobar);
-            cout.setcolor(COLOR_BOLDGREEN);
-            cout << "Changing verbose level for all the processes..." << endl;
-            cout.setcolor(COLOR_BOLDWHITE);
+            RESTcout.setcolor(COLOR_BOLDGREEN);
+            RESTcout << "Changing verbose level for all the processes..." << RESTendl;
+            RESTcout.setcolor(COLOR_BOLDWHITE);
             Console::CursorDown(1);
             Console::ClearLinesAfterCursor();
-            cout << "type \"0\"/\"s\" to set level silent" << endl;
-            cout << "type \"1\"/\"e\" to set level essential" << endl;
-            cout << "type \"2\"/\"i\" to set level info" << endl;
-            cout << "type \"3\"/\"d\" to set level debug" << endl;
-            cout << "type \"4\"/\"x\" to set level extreme" << endl;
-            cout << "type other to return the pause menu" << endl;
-            cout << "-" << endl;
-            cout << endl;
-            cout << endl;
+            RESTcout << "type \"0\"/\"s\" to set level silent" << RESTendl;
+            RESTcout << "type \"1\"/\"e\" to set level essential" << RESTendl;
+            RESTcout << "type \"2\"/\"i\" to set level info" << RESTendl;
+            RESTcout << "type \"3\"/\"d\" to set level debug" << RESTendl;
+            RESTcout << "type \"4\"/\"x\" to set level extreme" << RESTendl;
+            RESTcout << "type other to return the pause menu" << RESTendl;
+            RESTcout << "-" << RESTendl;
+            RESTcout << RESTendl;
+            RESTcout << RESTendl;
             while (1) {
                 Console::CursorUp(1);
                 int c = Console::Read();
                 if (c != '\n')
                     while (Console::Read() != '\n')
                         ;
-                REST_Verbose_Level l;
+                TRestStringOutput::REST_Verbose_Level l;
                 if (c == '0' || c == 's') {
-                    l = REST_Silent;
+                    l = TRestStringOutput::REST_Verbose_Level::REST_Silent;
                 } else if (c == '1' || c == 'e') {
-                    l = REST_Essential;
+                    l = TRestStringOutput::REST_Verbose_Level::REST_Essential;
                 } else if (c == '2' || c == 'i') {
-                    l = REST_Info;
+                    l = TRestStringOutput::REST_Verbose_Level::REST_Info;
                 } else if (c == '3' || c == 'd') {
-                    l = REST_Debug;
+                    l = TRestStringOutput::REST_Verbose_Level::REST_Debug;
                 } else if (c == '4' || c == 'x') {
-                    l = REST_Extreme;
+                    l = TRestStringOutput::REST_Verbose_Level::REST_Extreme;
                 } else {
                     Console::CursorUp(infobar);
-                    cout.setcolor(COLOR_BOLDYELLOW);
-                    cout << "Verbose level not set!" << endl;
-                    cout.setcolor(COLOR_BOLDWHITE);
+                    RESTcout.setcolor(COLOR_BOLDYELLOW);
+                    RESTcout << "Verbose level not set!" << RESTendl;
+                    RESTcout.setcolor(COLOR_BOLDWHITE);
                     break;
                 }
 
@@ -607,29 +614,30 @@ void TRestProcessRunner::PauseMenu() {
                     }
                 }
                 Console::CursorUp(infobar);
-                cout.setcolor(COLOR_BOLDGREEN);
-                cout << "Verbose level has been set to " << ToString(l) << "!" << endl;
-                cout.setcolor(COLOR_BOLDWHITE);
+                RESTcout.setcolor(COLOR_BOLDGREEN);
+                RESTcout << "Verbose level has been set to " << ToString(static_cast<int>(l)) << "!"
+                         << RESTendl;
+                RESTcout.setcolor(COLOR_BOLDWHITE);
                 break;
             }
             Console::ClearLinesAfterCursor();
             break;
         } else if (b == 'd') {
             Console::CursorUp(infobar);
-            cout.setcolor(COLOR_BOLDGREEN);
-            cout << "Detaching restManager to backend" << endl;
-            cout.setcolor(COLOR_BOLDWHITE);
+            RESTcout.setcolor(COLOR_BOLDGREEN);
+            RESTcout << "Detaching restManager to backend" << RESTendl;
+            RESTcout.setcolor(COLOR_BOLDWHITE);
             Console::CursorDown(1);
             Console::ClearLinesAfterCursor();
-            cout << "type filename for output redirect" << endl;
-            cout << "leave blank to redirect to /dev/null" << endl;
-            cout << " " << endl;
-            cout << " " << endl;
-            cout << " " << endl;
-            cout << " " << endl;
-            cout << "-" << endl;
-            cout << endl;
-            cout << endl;
+            RESTcout << "type filename for output redirect" << RESTendl;
+            RESTcout << "leave blank to redirect to /dev/null" << RESTendl;
+            RESTcout << " " << RESTendl;
+            RESTcout << " " << RESTendl;
+            RESTcout << " " << RESTendl;
+            RESTcout << " " << RESTendl;
+            RESTcout << "-" << RESTendl;
+            RESTcout << RESTendl;
+            RESTcout << RESTendl;
 
             string file;
 
@@ -639,17 +647,17 @@ void TRestProcessRunner::PauseMenu() {
             if (TRestTools::fileExists(file)) {
                 if (!TRestTools::isPathWritable(file)) {
                     Console::CursorUp(infobar);
-                    cout.setcolor(COLOR_BOLDYELLOW);
-                    cout << "file not writeable!" << endl;
-                    cout.setcolor(COLOR_BOLDWHITE);
+                    RESTcout.setcolor(COLOR_BOLDYELLOW);
+                    RESTcout << "file not writeable!" << RESTendl;
+                    RESTcout.setcolor(COLOR_BOLDWHITE);
                     break;
                 }
             } else {
                 if (!TRestTools::isPathWritable(TRestTools::SeparatePathAndName(file).first)) {
                     Console::CursorUp(infobar);
-                    cout.setcolor(COLOR_BOLDYELLOW);
-                    cout << "path not writeable!" << endl;
-                    cout.setcolor(COLOR_BOLDWHITE);
+                    RESTcout.setcolor(COLOR_BOLDYELLOW);
+                    RESTcout << "path not writeable!" << RESTendl;
+                    RESTcout.setcolor(COLOR_BOLDWHITE);
                     break;
                 }
             }
@@ -662,13 +670,13 @@ void TRestProcessRunner::PauseMenu() {
             }
             // child process
             if (pid == 0) {
-                fout << "Child process created! pid: " << getpid() << endl;
-                info << "Restarting threads" << endl;
+                RESTFout << "Child process created! pid: " << getpid() << RESTendl;
+                RESTInfo << "Restarting threads" << RESTendl;
                 mutex_write.unlock();
                 for (int i = 0; i < fThreadNumber; i++) {
                     fThreads[i]->StartThread();
                 }
-                info << "Re-directing output to " << file << endl;
+                RESTInfo << "Re-directing output to " << file << RESTendl;
                 freopen(file.c_str(), "w", stdout);
                 Console::CompatibilityMode = true;
             }
@@ -677,7 +685,7 @@ void TRestProcessRunner::PauseMenu() {
                 exit(0);
             }
             fProcStatus = kNormal;
-            info << "Continue processing..." << endl;
+            RESTInfo << "Continue processing..." << RESTendl;
             break;
         } else if (b == 'n') {
             fProcStatus = kStep;
@@ -692,7 +700,7 @@ void TRestProcessRunner::PauseMenu() {
         } else if (b == 'p') {
             Console::CursorUp(menuupper);
             Console::ClearLinesAfterCursor();
-            if (fVerboseLevel >= REST_Debug) {
+            if (fVerboseLevel >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
                 fProcStatus = kIgnore;
             } else {
                 fProcStatus = kNormal;
@@ -702,9 +710,9 @@ void TRestProcessRunner::PauseMenu() {
             // CursorUp(1);
         } else {
             Console::CursorUp(infobar);
-            cout.setcolor(COLOR_BOLDYELLOW);
-            cout << "Invailed option \"" << (char)b << "\" (key value: " << b << ") !" << endl;
-            cout.setcolor(COLOR_BOLDWHITE);
+            RESTcout.setcolor(COLOR_BOLDYELLOW);
+            RESTcout << "Invailed option \"" << (char)b << "\" (key value: " << b << ") !" << RESTendl;
+            RESTcout.setcolor(COLOR_BOLDWHITE);
             Console::CursorDown(infobar - 1);
         }
     }
@@ -907,7 +915,7 @@ void TRestProcessRunner::FillThreadEventFunc(TRestThread* t) {
                 delete fOutputDataFile;
                 fOutputDataFile = newfile;
             } else {
-                ferr << "internal error!" << endl;
+                RESTFerr << "internal error!" << RESTendl;
             }
         }
 
@@ -930,7 +938,7 @@ void TRestProcessRunner::FillThreadEventFunc(TRestThread* t) {
 /// It first saves process metadata in to the main output file, then calls
 /// TRestRun::FormOutputFile() to merge the main file with process's tmp file.
 void TRestProcessRunner::ConfigOutputFile() {
-    essential << "Configuring output file, writing metadata and tree objects" << endl;
+    RESTEssential << "Configuring output file, writing metadata and tree objects" << RESTendl;
 #ifdef TIME_MEASUREMENT
     fProcessInfo["ProcessTime"] = ToString(deltaTime) + "ms";
 #endif
@@ -969,7 +977,7 @@ void TRestProcessRunner::WriteMetadata() {
 /// It first saves process metadata in to the main output file, then calls
 /// TRestRun::FormOutputFile() to merge the main file with process's tmp file.
 void TRestProcessRunner::MergeOutputFile() {
-    essential << "Merging thread files together" << endl;
+    RESTEssential << "Merging thread files together" << RESTendl;
     // add threads file
     // processes may have their own TObject output. They are stored in the threads
     // file these files are mush smaller that data file, so they are merged to the
@@ -1095,7 +1103,7 @@ void TRestProcessRunner::PrintProcessedEvents(Int_t rateE) {
                 cout << s1 << s2 << s3 << endl;
                 prog_last_printed = (int)prog;
             }
-        } else if (fThreads[0]->GetVerboseLevel() < REST_Debug) {
+        } else if (fThreads[0]->GetVerboseLevel() < TRestStringOutput::REST_Verbose_Level::REST_Debug) {
             printf("%s", (s1 + s2 + s3 + "\r").c_str());
             fflush(stdout);
         }
@@ -1150,18 +1158,18 @@ void TRestProcessRunner::PrintMetadata() {
     else
         status = "Unknown";
 
-    metadata << "Status : " << status << endl;
-    metadata << "Processesed events : " << fProcessedEvents << endl;
-    metadata << "Analysis tree branches : " << fNBranches << endl;
-    metadata << "Thread number : " << fThreadNumber << endl;
-    metadata << "Processes in each thread : " << fProcessNumber << endl;
-    metadata << "File auto split size: " << fFileSplitSize << endl;
-    metadata << "File compression level: " << fFileCompression << endl;
+    RESTMetadata << "Status : " << status << RESTendl;
+    RESTMetadata << "Processesed events : " << fProcessedEvents << RESTendl;
+    RESTMetadata << "Analysis tree branches : " << fNBranches << RESTendl;
+    RESTMetadata << "Thread number : " << fThreadNumber << RESTendl;
+    RESTMetadata << "Processes in each thread : " << fProcessNumber << RESTendl;
+    RESTMetadata << "File auto split size: " << fFileSplitSize << RESTendl;
+    RESTMetadata << "File compression level: " << fFileCompression << RESTendl;
     // cout << "Input filename : " << fInputFilename << endl;
     // cout << "Output filename : " << fOutputFilename << endl;
     // cout << "Number of initial events : " << GetNumberOfEvents() << endl;
     // cout << "Number of processed events : " << fProcessedEvents << endl;
-    metadata << "******************************************" << endl;
-    metadata << endl;
-    metadata << endl;
+    RESTMetadata << "******************************************" << RESTendl;
+    RESTMetadata << RESTendl;
+    RESTMetadata << RESTendl;
 }

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -992,9 +992,9 @@ TFile* TRestRun::MergeToOutputFile(vector<string> filenames, string outputfilena
     RESTDebug << "TRestRun::FormOutputFile. Calling WriteWithDataBase()" << RESTendl;
     this->WriteWithDataBase();
 
-    RESTFout << this->ClassName() << " Created ..." << RESTendl;
-    RESTFout << "- Path : " << TRestTools::SeparatePathAndName((string)fOutputFileName).first << RESTendl;
-    RESTFout << "- Filename : " << TRestTools::SeparatePathAndName((string)fOutputFileName).second
+    RESTcout << this->ClassName() << " Created ..." << RESTendl;
+    RESTcout << "- Path : " << TRestTools::SeparatePathAndName((string)fOutputFileName).first << RESTendl;
+    RESTcout << "- Filename : " << TRestTools::SeparatePathAndName((string)fOutputFileName).second
              << RESTendl;
     return fOutputFile;
 }
@@ -1015,9 +1015,9 @@ TFile* TRestRun::FormOutputFile() {
     fEventTree->Write();
     this->WriteWithDataBase();
 
-    RESTFout << "TRestRun: Output File Created." << RESTendl;
-    RESTFout << "- Path : " << TRestTools::SeparatePathAndName((string)fOutputFileName).first << RESTendl;
-    RESTFout << "- Filename : " << TRestTools::SeparatePathAndName((string)fOutputFileName).second
+    RESTcout << "TRestRun: Output File Created." << RESTendl;
+    RESTcout << "- Path : " << TRestTools::SeparatePathAndName((string)fOutputFileName).first << RESTendl;
+    RESTcout << "- Filename : " << TRestTools::SeparatePathAndName((string)fOutputFileName).second
              << RESTendl;
     return fOutputFile;
 }
@@ -1033,9 +1033,9 @@ TFile* TRestRun::UpdateOutputFile() {
         fEventTree->Write(0, kWriteDelete);
         this->WriteWithDataBase();
 
-        RESTFout << "TRestRun: Output File Updated." << RESTendl;
-        RESTFout << "- Path : " << TRestTools::SeparatePathAndName((string)fOutputFileName).first << RESTendl;
-        RESTFout << "- Filename : " << TRestTools::SeparatePathAndName((string)fOutputFileName).second
+        RESTcout << "TRestRun: Output File Updated." << RESTendl;
+        RESTcout << "- Path : " << TRestTools::SeparatePathAndName((string)fOutputFileName).first << RESTendl;
+        RESTcout << "- Filename : " << TRestTools::SeparatePathAndName((string)fOutputFileName).second
                  << RESTendl;
         return fOutputFile;
 
@@ -1108,7 +1108,7 @@ void TRestRun::WriteWithDataBase() {
     RESTDebug << "TResRun::WriteWithDataBase. Run number is : " << fRunNumber << RESTendl;
     if (fRunNumber != -1) {
         int fileid = gDataBase->set_runfile(fRunNumber, (string)fOutputFileName);
-        RESTFout << "DataBase Entry Added! Run Number: " << fRunNumber << ", File ID: " << fileid << RESTendl;
+        RESTcout << "DataBase Entry Added! Run Number: " << fRunNumber << ", File ID: " << fileid << RESTendl;
     }
 }
 

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -48,7 +48,7 @@ TRestRun::TRestRun(const string& filename) {
         Initialize();
         LoadConfigFromFile(filename);
     } else {
-        RESTFerr << "TRestRun::TRestRun(): input file error!" << RESTendl;
+        RESTError << "TRestRun::TRestRun(): input file error!" << RESTendl;
     }
 }
 
@@ -150,9 +150,9 @@ void TRestRun::InitFromConfigFile() {
         }
     }
     if (ToUpper(runNstr) == "AUTO" && ToUpper(inputname) == "AUTO") {
-        RESTFerr << "TRestRun: run number and input file name cannot both be "
-                    "\"AUTO\""
-                 << RESTendl;
+        RESTError << "TRestRun: run number and input file name cannot both be "
+                     "\"AUTO\""
+                  << RESTendl;
         exit(1);
     }
 
@@ -208,7 +208,7 @@ void TRestRun::InitFromConfigFile() {
 
     if (fInputFileNames.size() == 0) {
         if (fInputFileName != "") {
-            RESTFerr << "cannot find the input file!" << RESTendl;
+            RESTError << "cannot find the input file!" << RESTendl;
             exit(1);
         } else {
             RESTWarning << "no input file added" << RESTendl;
@@ -262,8 +262,8 @@ void TRestRun::InitFromConfigFile() {
         system((TString) "mkdir -p " + outputdir);
     }
     if (!TRestTools::isPathWritable(outputdir)) {
-        RESTFerr << "TRestRun: Output path does not exist or it is not writable." << RESTendl;
-        RESTFerr << "Path : " << outputdir << RESTendl;
+        RESTError << "TRestRun: Output path does not exist or it is not writable." << RESTendl;
+        RESTError << "Path : " << outputdir << RESTendl;
         exit(1);
     }
 
@@ -364,7 +364,7 @@ void TRestRun::OpenInputFile(int i) {
 void TRestRun::OpenInputFile(const TString& filename, const string& mode) {
     CloseFile();
     if (!filename.Contains("http") && !TRestTools::fileExists((string)filename)) {
-        RESTFerr << "input file \"" << filename << "\" does not exist!" << RESTendl;
+        RESTError << "input file \"" << filename << "\" does not exist!" << RESTendl;
         exit(1);
     }
 
@@ -481,7 +481,7 @@ void TRestRun::AddInputFileExternal(const string& file) {
     if (fFileProcess != nullptr) {
         bool add = fFileProcess->AddInputFile(file);
         if (!add) {
-            RESTFerr << "failed to add input file!" << RESTendl;
+            RESTError << "failed to add input file!" << RESTendl;
         }
         fInputFileNames.push_back(file);
     }
@@ -503,9 +503,9 @@ void TRestRun::ReadInputFileMetadata() {
 
             TRestMetadata* a = (TRestMetadata*)f->Get(key->GetName());
             if (!a) {
-                RESTFerr << "TRestRun::ReadInputFileMetadata." << RESTendl;
-                RESTFerr << "Key name : " << key->GetName() << RESTendl;
-                RESTFerr << "Hidden key? Please, report this problem." << RESTendl;
+                RESTError << "TRestRun::ReadInputFileMetadata." << RESTendl;
+                RESTError << "Key name : " << key->GetName() << RESTendl;
+                RESTError << "Hidden key? Please, report this problem." << RESTendl;
             } else if (a->InheritsFrom("TRestMetadata") && a->ClassName() != (TString) "TRestRun") {
                 /*
                 //we make sure there is no repeated class added
@@ -555,8 +555,8 @@ void TRestRun::ReadInputFileTrees() {
                 }
                 if (fAnalysisTree->GetChain() == nullptr ||
                     fAnalysisTree->GetChain()->GetNtrees() != fNFilesSplit + 1) {
-                    RESTFerr << "Error adding split files, files missing?" << RESTendl;
-                    RESTFerr << "Your data could be incomplete!" << RESTendl;
+                    RESTError << "Error adding split files, files missing?" << RESTendl;
+                    RESTError << "Your data could be incomplete!" << RESTendl;
                 }
             }
 
@@ -593,9 +593,9 @@ void TRestRun::ReadInputFileTrees() {
             //	fAnalysisTree->SetEntries(Tree2->GetEntries());
             RESTDebug << "Old REST file successfully recovered!" << RESTendl;
         } else {
-            RESTFerr << "(OpenInputFile) : AnalysisTree was not found" << RESTendl;
-            RESTFerr << "Inside file : " << filename << RESTendl;
-            RESTFerr << "This may be not REST output file!" << RESTendl;
+            RESTError << "(OpenInputFile) : AnalysisTree was not found" << RESTendl;
+            RESTError << "Inside file : " << filename << RESTendl;
+            RESTError << "This may be not REST output file!" << RESTendl;
             exit(1);
         }
 
@@ -672,8 +672,8 @@ void TRestRun::ReadFileInfo(const string& filename) {
     struct stat buf;
     FILE* fp = fopen(filename.c_str(), "rb");
     if (!fp) {
-        RESTFerr << "TRestRun::ReadFileInfo. Something went wrong with fopen()!" << strerror(errno)
-                 << RESTendl;
+        RESTError << "TRestRun::ReadFileInfo. Something went wrong with fopen()!" << strerror(errno)
+                  << RESTendl;
         exit(1);
     }
     int fd = fileno(fp);
@@ -977,7 +977,7 @@ TFile* TRestRun::MergeToOutputFile(vector<string> filenames, string outputfilena
         }
     } else {
         fOutputFileName = "";
-        RESTFerr << "(Merge files) failed to merge process files." << RESTendl;
+        RESTError << "(Merge files) failed to merge process files." << RESTendl;
         exit(1);
     }
 
@@ -1040,7 +1040,7 @@ TFile* TRestRun::UpdateOutputFile() {
         return fOutputFile;
 
     } else {
-        RESTFerr << "TRestRun::UpdateOutputFile(): output file is closed" << RESTendl;
+        RESTError << "TRestRun::UpdateOutputFile(): output file is closed" << RESTendl;
     }
     return nullptr;
 }
@@ -1169,8 +1169,8 @@ void TRestRun::SetExtProcess(TRestEventProcess* p) {
         fFileProcess->InitProcess();
         fInputEvent = fFileProcess->GetOutputEvent();
         if (fInputEvent == nullptr) {
-            RESTFerr << "The external process \"" << p->GetName() << "\" doesn't yield any output event!"
-                     << RESTendl;
+            RESTError << "The external process \"" << p->GetName() << "\" doesn't yield any output event!"
+                      << RESTendl;
             exit(1);
         } else {
             fInputEvent->SetRunOrigin(fRunNumber);
@@ -1188,7 +1188,7 @@ void TRestRun::SetExtProcess(TRestEventProcess* p) {
         RESTInfo << "The external file process has been set! Name : " << fFileProcess->GetName() << RESTendl;
     } else {
         if (fFileProcess != nullptr) {
-            RESTFerr << "There can only be one file process!" << RESTendl;
+            RESTError << "There can only be one file process!" << RESTendl;
             exit(1);
         }
         if (p == nullptr) {
@@ -1266,22 +1266,22 @@ void TRestRun::AddEventBranch(TRestEvent* eve) {
 void TRestRun::ImportMetadata(const TString& File, const TString& name, const TString& type, Bool_t store) {
     const TString thisFile = SearchFile(File.Data());
     if (thisFile == "") {
-        RESTFerr << "(ImportMetadata): The file " << thisFile << " does not exist!" << RESTendl;
-        RESTFerr << RESTendl;
+        RESTError << "(ImportMetadata): The file " << thisFile << " does not exist!" << RESTendl;
+        RESTError << RESTendl;
         return;
     }
     if (!TRestTools::isRootFile(thisFile.Data())) {
-        RESTFerr << "(ImportMetadata) : The file " << thisFile << " is not root file!" << RESTendl;
-        RESTFerr << "If you want to initialize metadata from rml file, use <TRest section!" << RESTendl;
+        RESTError << "(ImportMetadata) : The file " << thisFile << " is not root file!" << RESTendl;
+        RESTError << "If you want to initialize metadata from rml file, use <TRest section!" << RESTendl;
         return;
     }
 
     TFile* f = new TFile(thisFile);
     // TODO give error in case we try to obtain a class that is not TRestMetadata
     if (type == "" && name == "") {
-        RESTFerr << "(ImportMetadata) : metadata type and name is not "
-                    "specified!"
-                 << RESTendl;
+        RESTError << "(ImportMetadata) : metadata type and name is not "
+                     "specified!"
+                  << RESTendl;
         return;
     }
 
@@ -1621,7 +1621,7 @@ string TRestRun::ReplaceMetadataMembers(const string& instr) {
         string s = outstring.substr(startPosition + 1, endPosition - startPosition - 1);
         int cont = count(s.begin(), s.end(), '[') - count(s.begin(), s.end(), ']');
 
-        if (cont < 0) RESTFerr << "This is a coding error at ReplaceMetadataMembers!" << RESTendl;
+        if (cont < 0) RESTError << "This is a coding error at ReplaceMetadataMembers!" << RESTendl;
 
         // We search for the enclosing ]. Since we might find a vector index inside.
         while (cont > 0) {
@@ -1700,7 +1700,7 @@ string TRestRun::ReplaceMetadataMember(const string& instr) {
         }
 
     } else
-        RESTFerr << "TRestRun::ReplaceMetadataMember. Wrong number of elements found" << RESTendl;
+        RESTError << "TRestRun::ReplaceMetadataMember. Wrong number of elements found" << RESTendl;
 
     RESTWarning << "TRestRun::ReplaceMetadataMember. " << instr << " not found!" << RESTendl;
     return "";
@@ -1866,14 +1866,14 @@ void TRestRun::PrintErrors() {
 
     if (nErrors) {
         cout << endl;
-        RESTFerr << "Found a total of " << nErrors << " metadata errors" << RESTendl;
+        RESTError << "Found a total of " << nErrors << " metadata errors" << RESTendl;
         for (int n = 0; n < fMetadata.size(); n++)
             if (fMetadata[n]->GetError()) {
                 cout << endl;
-                RESTFerr << "Class: " << fMetadata[n]->ClassName() << " Name: " << fMetadata[n]->GetName()
-                         << RESTendl;
-                RESTFerr << "Number of errors: " << fMetadata[n]->GetNumberOfErrors() << RESTendl;
-                RESTFerr << "Message: " << fMetadata[n]->GetErrorMessage() << RESTendl;
+                RESTError << "Class: " << fMetadata[n]->ClassName() << " Name: " << fMetadata[n]->GetName()
+                          << RESTendl;
+                RESTError << "Number of errors: " << fMetadata[n]->GetNumberOfErrors() << RESTendl;
+                RESTError << "Message: " << fMetadata[n]->GetErrorMessage() << RESTendl;
             }
         cout << endl;
     } else {

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -48,7 +48,7 @@ TRestRun::TRestRun(const string& filename) {
         Initialize();
         LoadConfigFromFile(filename);
     } else {
-        ferr << "TRestRun::TRestRun(): input file error!" << endl;
+        RESTFerr << "TRestRun::TRestRun(): input file error!" << RESTendl;
     }
 }
 
@@ -123,7 +123,7 @@ void TRestRun::Initialize() {
 /// pattern to TRestDetector metadata.
 ///
 void TRestRun::InitFromConfigFile() {
-    debug << "Initializing TRestRun from config file, version: " << REST_RELEASE << endl;
+    RESTDebug << "Initializing TRestRun from config file, version: " << REST_RELEASE << RESTendl;
     fFromRML = true;
     ReSetVersion();
 
@@ -143,16 +143,16 @@ void TRestRun::InitFromConfigFile() {
     inputname = TRestTools::RemoveMultipleSlash(inputname);
     string inputnameold = GetParameter("inputFile", "default");
     if (inputnameold != "default") {
-        warning << "Parameter \"inputFile\" in rml is obsolete! Please update it to \"inputFileName\""
-                << endl;
+        RESTWarning << "Parameter \"inputFile\" in rml is obsolete! Please update it to \"inputFileName\""
+                    << RESTendl;
         if (inputname == "") {
             inputname = inputnameold;
         }
     }
     if (ToUpper(runNstr) == "AUTO" && ToUpper(inputname) == "AUTO") {
-        ferr << "TRestRun: run number and input file name cannot both be "
-                "\"AUTO\""
-             << endl;
+        RESTFerr << "TRestRun: run number and input file name cannot both be "
+                    "\"AUTO\""
+                 << RESTendl;
         exit(1);
     }
 
@@ -208,10 +208,10 @@ void TRestRun::InitFromConfigFile() {
 
     if (fInputFileNames.size() == 0) {
         if (fInputFileName != "") {
-            ferr << "cannot find the input file!" << endl;
+            RESTFerr << "cannot find the input file!" << RESTendl;
             exit(1);
         } else {
-            warning << "no input file added" << endl;
+            RESTWarning << "no input file added" << RESTendl;
         }
         // throw;
     }
@@ -221,8 +221,8 @@ void TRestRun::InitFromConfigFile() {
     string outputname = GetParameter("outputFileName", "default");
     string outputnameold = GetParameter("outputFile", "default");
     if (outputnameold != "default") {
-        warning << "Parameter \"outputFile\" in rml is obsolete! Please update it to \"outputFileName\""
-                << endl;
+        RESTWarning << "Parameter \"outputFile\" in rml is obsolete! Please update it to \"outputFileName\""
+                    << RESTendl;
         if (outputname == "default") {
             outputname = outputnameold;
         }
@@ -262,8 +262,8 @@ void TRestRun::InitFromConfigFile() {
         system((TString) "mkdir -p " + outputdir);
     }
     if (!TRestTools::isPathWritable(outputdir)) {
-        ferr << "TRestRun: Output path does not exist or it is not writable." << endl;
-        ferr << "Path : " << outputdir << endl;
+        RESTFerr << "TRestRun: Output path does not exist or it is not writable." << RESTendl;
+        RESTFerr << "Path : " << outputdir << RESTendl;
         exit(1);
     }
 
@@ -275,9 +275,9 @@ void TRestRun::InitFromConfigFile() {
             if (e->Attribute("file") != nullptr) {
                 ImportMetadata(e->Attribute("file"), e->Attribute("name"), e->Attribute("type"), true);
             } else {
-                warning << "Wrong definition of addMetadata! Metadata name or file name "
-                           "is not given!"
-                        << endl;
+                RESTWarning << "Wrong definition of addMetadata! Metadata name or file name "
+                               "is not given!"
+                            << RESTendl;
             }
         } else if (keydeclare == "addProcess") {
             bool active = StringToBool(GetParameter("value", e, ""));
@@ -288,13 +288,14 @@ void TRestRun::InitFromConfigFile() {
             string processName = GetParameter("name", e, "");
             string processType = GetParameter("type", e, "");
             if (processType == "") {
-                warning << "Bad expression of addProcess" << endl;
+                RESTWarning << "Bad expression of addProcess" << RESTendl;
             } else if (processName == "") {
-                warning << "Event process " << processType << " has no name, it will be skipped" << endl;
+                RESTWarning << "Event process " << processType << " has no name, it will be skipped"
+                            << RESTendl;
             }
             TRestEventProcess* pc = REST_Reflection::Assembly(processType);
             if (!pc->isExternal()) {
-                warning << "This is not an external file process!" << endl;
+                RESTWarning << "This is not an external file process!" << RESTendl;
             } else {
                 pc->LoadConfigFromElement(e, fElementGlobal);
                 pc->SetRunInfo(this);
@@ -304,9 +305,9 @@ void TRestRun::InitFromConfigFile() {
             }
         } else if (Count(keydeclare, "TRest") > 0) {
             if (e->Attribute("file") != nullptr && TRestTools::isRootFile(e->Attribute("file"))) {
-                warning << "TRestRun: A root file is being included in section <" << keydeclare
-                        << " ! To import metadata from this file, use <addMetadata" << endl;
-                warning << "Skipping..." << endl;
+                RESTWarning << "TRestRun: A root file is being included in section <" << keydeclare
+                            << " ! To import metadata from this file, use <addMetadata" << RESTendl;
+                RESTWarning << "Skipping..." << RESTendl;
             }
             // if (e->Attribute("file") != nullptr && (string)e->Attribute("file") == "server") {
             //    // read meta-sections from database
@@ -318,7 +319,7 @@ void TRestRun::InitFromConfigFile() {
 
             TRestMetadata* meta = REST_Reflection::Assembly(keydeclare);
             if (meta == nullptr) {
-                warning << "failed to add metadata \"" << keydeclare << "\"" << endl;
+                RESTWarning << "failed to add metadata \"" << keydeclare << "\"" << RESTendl;
                 e = e->NextSiblingElement();
                 continue;
             }
@@ -332,12 +333,12 @@ void TRestRun::InitFromConfigFile() {
     // 5. Open input file(s). We open input file at the last stage in case the file name pattern
     // reading requires TRestDetector
     OpenInputFile(0);
-    debug << "TRestRun::EndOfInit. InputFile pattern: \"" << fInputFileName << "\"" << endl;
-    info << "which matches :" << endl;
+    RESTDebug << "TRestRun::EndOfInit. InputFile pattern: \"" << fInputFileName << "\"" << RESTendl;
+    RESTInfo << "which matches :" << RESTendl;
     for (int i = 0; i < fInputFileNames.size(); i++) {
-        info << fInputFileNames[i] << endl;
+        RESTInfo << fInputFileNames[i] << RESTendl;
     }
-    essential << "(" << fInputFileNames.size() << " added files)" << endl;
+    RESTEssential << "(" << fInputFileNames.size() << " added files)" << RESTendl;
 }
 
 ///////////////////////////////////////////////
@@ -346,7 +347,7 @@ void TRestRun::InitFromConfigFile() {
 void TRestRun::OpenInputFile(int i) {
     if (fInputFileNames.size() > i) {
         TString Filename = fInputFileNames[i];
-        info << "opening... " << Filename << endl;
+        RESTInfo << "opening... " << Filename << RESTendl;
         OpenInputFile((string)Filename);
     }
 }
@@ -363,7 +364,7 @@ void TRestRun::OpenInputFile(int i) {
 void TRestRun::OpenInputFile(const TString& filename, const string& mode) {
     CloseFile();
     if (!filename.Contains("http") && !TRestTools::fileExists((string)filename)) {
-        ferr << "input file \"" << filename << "\" does not exist!" << endl;
+        RESTFerr << "input file \"" << filename << "\" does not exist!" << RESTendl;
         exit(1);
     }
 
@@ -435,19 +436,19 @@ void TRestRun::OpenInputFile(const TString& filename, const string& mode) {
                     this->GetVersionCode() <= REST_VERSION(2, 1, 8)) {
                     ReadInputFileMetadata();
                 } else {
-                    warning << "-- W : The metadata version found on input file is lower "
-                               "than 2.2.1!"
-                            << endl;
-                    warning << "-- W : metadata from input file will not be read" << endl;
+                    RESTWarning << "-- W : The metadata version found on input file is lower "
+                                   "than 2.2.1!"
+                                << RESTendl;
+                    RESTWarning << "-- W : metadata from input file will not be read" << RESTendl;
                 }
             }
 
-            debug << "Initializing input file : version code : " << this->GetVersionCode() << endl;
-            debug << "Input file version : " << this->GetVersion() << endl;
+            RESTDebug << "Initializing input file : version code : " << this->GetVersionCode() << RESTendl;
+            RESTDebug << "Input file version : " << this->GetVersion() << RESTendl;
             ReadInputFileTrees();
             fCurrentEvent = 0;
         } else {
-            warning << "TRestRun object not found in file! The input file is problematic!" << endl;
+            RESTWarning << "TRestRun object not found in file! The input file is problematic!" << RESTendl;
 
             ReadInputFileTrees();
             // fAnalysisTree = nullptr;
@@ -472,7 +473,7 @@ void TRestRun::OpenInputFile(const TString& filename, const string& mode) {
     }
 
     if (fAnalysisTree == nullptr && fFileProcess == nullptr)
-        info << "Input file is not REST root file, an external process is needed!" << endl;
+        RESTInfo << "Input file is not REST root file, an external process is needed!" << RESTendl;
 }
 
 void TRestRun::AddInputFileExternal(const string& file) {
@@ -480,7 +481,7 @@ void TRestRun::AddInputFileExternal(const string& file) {
     if (fFileProcess != nullptr) {
         bool add = fFileProcess->AddInputFile(file);
         if (!add) {
-            ferr << "failed to add input file!" << endl;
+            RESTFerr << "failed to add input file!" << RESTendl;
         }
         fInputFileNames.push_back(file);
     }
@@ -497,14 +498,14 @@ void TRestRun::ReadInputFileMetadata() {
         // we should make sure the input metadata has unique names
         set<string> addednames;
         while ((key = (TKey*)nextkey())) {
-            debug << "Reading key with name : " << key->GetName() << endl;
+            RESTDebug << "Reading key with name : " << key->GetName() << RESTendl;
             if (addednames.count(key->GetName()) != 0) continue;
 
             TRestMetadata* a = (TRestMetadata*)f->Get(key->GetName());
             if (!a) {
-                ferr << "TRestRun::ReadInputFileMetadata." << endl;
-                ferr << "Key name : " << key->GetName() << endl;
-                ferr << "Hidden key? Please, report this problem." << endl;
+                RESTFerr << "TRestRun::ReadInputFileMetadata." << RESTendl;
+                RESTFerr << "Key name : " << key->GetName() << RESTendl;
+                RESTFerr << "Hidden key? Please, report this problem." << RESTendl;
             } else if (a->InheritsFrom("TRestMetadata") && a->ClassName() != (TString) "TRestRun") {
                 /*
                 //we make sure there is no repeated class added
@@ -535,7 +536,7 @@ void TRestRun::ReadInputFileMetadata() {
 
 void TRestRun::ReadInputFileTrees() {
     if (fInputFile != nullptr) {
-        debug << "Finding TRestAnalysisTree.." << endl;
+        RESTDebug << "Finding TRestAnalysisTree.." << RESTendl;
         TTree* _eventTree = nullptr;
         string filename = fInputFile->GetName();
 
@@ -543,19 +544,19 @@ void TRestRun::ReadInputFileTrees() {
             fAnalysisTree = (TRestAnalysisTree*)fInputFile->Get("AnalysisTree");
 
             if (fNFilesSplit > 0) {  // fNFilesSplit=1: split to 1 additional file
-                essential << "Linking analysis tree from split data files" << endl;
+                RESTEssential << "Linking analysis tree from split data files" << RESTendl;
                 fAnalysisTree =
                     (TRestAnalysisTree*)
                         fAnalysisTree->Clone();  // we must make a copy to have TBrowser correctly browsed.
                 for (int i = 1; i <= fNFilesSplit; i++) {
                     string filename = fInputFile->GetName() + (string) "." + ToString(i);
-                    info << filename << " --> ";
-                    info << (fAnalysisTree->AddChainFile(filename) ? "success" : "failed") << endl;
+                    RESTInfo << filename << " --> ";
+                    RESTInfo << (fAnalysisTree->AddChainFile(filename) ? "success" : "failed") << RESTendl;
                 }
                 if (fAnalysisTree->GetChain() == nullptr ||
                     fAnalysisTree->GetChain()->GetNtrees() != fNFilesSplit + 1) {
-                    ferr << "Error adding split files, files missing?" << endl;
-                    ferr << "Your data could be incomplete!" << endl;
+                    RESTFerr << "Error adding split files, files missing?" << RESTendl;
+                    RESTFerr << "Your data could be incomplete!" << RESTendl;
                 }
             }
 
@@ -571,7 +572,7 @@ void TRestRun::ReadInputFileTrees() {
             // This is v2.1.6- version of input file, we directly find EventTree and
             // AnalysisTree. The old name pattern is "TRestXXXEventTree-eventBranch"
             // and "TRestAnalysisTree"
-            warning << "Loading root file from old version REST!" << endl;
+            RESTWarning << "Loading root file from old version REST!" << RESTendl;
             fAnalysisTree = (TRestAnalysisTree*)fInputFile->Get("TRestAnalysisTree");
             fAnalysisTree->GetEntry(0);
 
@@ -590,11 +591,11 @@ void TRestRun::ReadInputFileTrees() {
             }
             // if(Tree2!=nullptr)
             //	fAnalysisTree->SetEntries(Tree2->GetEntries());
-            debug << "Old REST file successfully recovered!" << endl;
+            RESTDebug << "Old REST file successfully recovered!" << RESTendl;
         } else {
-            ferr << "(OpenInputFile) : AnalysisTree was not found" << endl;
-            ferr << "Inside file : " << filename << endl;
-            ferr << "This may be not REST output file!" << endl;
+            RESTFerr << "(OpenInputFile) : AnalysisTree was not found" << RESTendl;
+            RESTFerr << "Inside file : " << filename << RESTendl;
+            RESTFerr << "This may be not REST output file!" << RESTendl;
             exit(1);
         }
 
@@ -602,22 +603,22 @@ void TRestRun::ReadInputFileTrees() {
             if (fNFilesSplit > 0) {
                 // eventTree shall be initailized as TChain
                 delete _eventTree;
-                essential << "Linking event tree from split data files" << endl;
+                RESTEssential << "Linking event tree from split data files" << RESTendl;
                 TChain* _fEventTree = new TChain("EventTree");
-                info << fInputFile->GetName() << " --> ";
-                info << (_fEventTree->Add(fInputFile->GetName()) ? "success" : "failed") << endl;
+                RESTInfo << fInputFile->GetName() << " --> ";
+                RESTInfo << (_fEventTree->Add(fInputFile->GetName()) ? "success" : "failed") << RESTendl;
 
                 for (int i = 1; i <= fNFilesSplit; i++) {
                     string filename = fInputFile->GetName() + (string) "." + ToString(i);
-                    info << filename << " --> ";
-                    info << (_fEventTree->Add(filename.c_str()) ? "success" : "failed") << endl;
+                    RESTInfo << filename << " --> ";
+                    RESTInfo << (_fEventTree->Add(filename.c_str()) ? "success" : "failed") << RESTendl;
                 }
                 fEventTree = _fEventTree;
             } else {
                 fEventTree = _eventTree;
             }
 
-            debug << "Finding event branch.." << endl;
+            RESTDebug << "Finding event branch.." << RESTendl;
             if (fInputEvent == nullptr) {
                 TObjArray* branches = fEventTree->GetListOfBranches();
                 // get the last event branch as input event branch
@@ -625,32 +626,33 @@ void TRestRun::ReadInputFileTrees() {
                     TBranch* br = (TBranch*)branches->At(branches->GetLast());
 
                     if (br == nullptr || Count(br->GetName(), "EventBranch") == 0) {
-                        info << "No event branch inside file : " << filename << endl;
-                        info << "This file may be a pure analysis file" << endl;
+                        RESTInfo << "No event branch inside file : " << filename << RESTendl;
+                        RESTInfo << "This file may be a pure analysis file" << RESTendl;
                     } else {
                         string type = Replace(br->GetName(), "Branch", "", 0);
                         fInputEvent = REST_Reflection::Assembly(type);
                         fInputEvent->InitializeWithMetadata(this);
                         fEventTree->SetBranchAddress(br->GetName(), &fInputEvent);
                         fEventBranchLoc = branches->GetLast();
-                        debug << "found event branch of event type: " << fInputEvent->ClassName() << endl;
+                        RESTDebug << "found event branch of event type: " << fInputEvent->ClassName()
+                                  << RESTendl;
                     }
                 }
             } else {
                 string brname = (string)fInputEvent->ClassName() + "Branch";
                 if (fEventTree->GetBranch(brname.c_str()) == nullptr) {
-                    warning << "REST WARNING (OpenInputFile) : No matched event branch "
-                               "inside file : "
-                            << filename << endl;
-                    warning << "Branch required: " << brname << endl;
+                    RESTWarning << "REST WARNING (OpenInputFile) : No matched event branch "
+                                   "inside file : "
+                                << filename << RESTendl;
+                    RESTWarning << "Branch required: " << brname << RESTendl;
                 } else {
                     fEventTree->SetBranchAddress(brname.c_str(), &fInputEvent);
-                    debug << brname << " is found and set!" << endl;
+                    RESTDebug << brname << " is found and set!" << RESTendl;
                 }
             }
         } else {
-            debug << "TRestRun:OpenInputFile. EventTree was not found" << endl;
-            debug << "This is a pure analysis file!" << endl;
+            RESTDebug << "TRestRun:OpenInputFile. EventTree was not found" << RESTendl;
+            RESTDebug << "This is a pure analysis file!" << RESTendl;
             fInputEvent = nullptr;
         }
     }
@@ -664,13 +666,14 @@ void TRestRun::ReadInputFileTrees() {
 /// 2. Created time and date
 /// 3. File size and entries
 void TRestRun::ReadFileInfo(const string& filename) {
-    debug << "begin collecting basic file info..." << filename << endl;
+    RESTDebug << "begin collecting basic file info..." << filename << RESTendl;
 
     // basic file info: modify time, total bytes, etc.
     struct stat buf;
     FILE* fp = fopen(filename.c_str(), "rb");
     if (!fp) {
-        ferr << "TRestRun::ReadFileInfo. Something went wrong with fopen()!" << strerror(errno) << endl;
+        RESTFerr << "TRestRun::ReadFileInfo. Something went wrong with fopen()!" << strerror(errno)
+                 << RESTendl;
         exit(1);
     }
     int fd = fileno(fp);
@@ -684,7 +687,7 @@ void TRestRun::ReadFileInfo(const string& filename) {
         fTotalBytes = buf.st_size;
     }
 
-    debug << "begin matching file name pattern for more file info..." << endl;
+    RESTDebug << "begin matching file name pattern for more file info..." << RESTendl;
     // format example:
     // run[fRunNumber]_cobo[aaa]_frag[bbb]_Vm[TRestDetector::fAmplificationVoltage].graw
     // we are going to match it with inputfile:
@@ -715,7 +718,7 @@ void TRestRun::ReadFileInfo(const string& filename) {
     pos = -1;
     for (int i = 0; i < formatsectionlist.size() && i < formatprefixlist.size() - 1; i++) {
         if (i != 0 && formatprefixlist[i] == "") {
-            warning << "file format reference contains error!" << endl;
+            RESTWarning << "file format reference contains error!" << RESTendl;
             return;
         }
         int pos1 = name.find(formatprefixlist[i], pos + 1) + formatprefixlist[i].size();
@@ -723,15 +726,15 @@ void TRestRun::ReadFileInfo(const string& filename) {
         int pos2 = name.find(formatprefixlist[i + 1], pos1);
         if (formatprefixlist[i + 1] == "") pos2 = name.length();
         if (pos1 == -1 || pos2 == -1) {
-            warning << "File pattern matching: file format mismatch!" << endl;
+            RESTWarning << "File pattern matching: file format mismatch!" << RESTendl;
             return;
         }
 
         string infoFromFileName = name.substr(pos1, pos2 - pos1);
 
-        debug << "File pattern matching. key: " << formatsectionlist[i] << " (between the mark \""
-              << formatprefixlist[i] << "\" and \"" << formatprefixlist[i + 1]
-              << "\"), value: " << infoFromFileName << endl;
+        RESTDebug << "File pattern matching. key: " << formatsectionlist[i] << " (between the mark \""
+                  << formatprefixlist[i] << "\" and \"" << formatprefixlist[i + 1]
+                  << "\"), value: " << infoFromFileName << RESTendl;
 
         // run[fRunNumber]_cobo[aaa]_frag[bbb]_Vm[TRestDetector::fAmplificationVoltage].graw
         bool inforead = false;
@@ -743,9 +746,9 @@ void TRestRun::ReadFileInfo(const string& filename) {
                     member.ParseString(infoFromFileName);
                     inforead = true;
                 } else {
-                    warning << "TRestRun: file name format field \"" << formatsectionlist[i]
-                            << "\"(value = " << infoFromFileName
-                            << ") not registered, data member does not exist in TRestRun!" << endl;
+                    RESTWarning << "TRestRun: file name format field \"" << formatsectionlist[i]
+                                << "\"(value = " << infoFromFileName
+                                << ") not registered, data member does not exist in TRestRun!" << RESTendl;
                 }
             }
         }
@@ -763,15 +766,15 @@ void TRestRun::ReadFileInfo(const string& filename) {
                         meta->UpdateMetadataMembers();
                         inforead = true;
                     } else {
-                        warning << "TRestRun: file name format field \"" << formatsectionlist[i]
-                                << "\"(value = " << infoFromFileName
-                                << ") not registered, metadata exist but without such datamember field!"
-                                << endl;
+                        RESTWarning << "TRestRun: file name format field \"" << formatsectionlist[i]
+                                    << "\"(value = " << infoFromFileName
+                                    << ") not registered, metadata exist but without such datamember field!"
+                                    << RESTendl;
                     }
                 } else {
-                    warning << "TRestRun: file name format field \"" << formatsectionlist[i]
-                            << "\"(value = " << infoFromFileName
-                            << ") not registered, metadata does not exist!" << endl;
+                    RESTWarning << "TRestRun: file name format field \"" << formatsectionlist[i]
+                                << "\"(value = " << infoFromFileName
+                                << ") not registered, metadata does not exist!" << RESTendl;
                 }
             }
         }
@@ -811,7 +814,7 @@ Int_t TRestRun::GetNextEvent(TRestEvent* targetevt, TRestAnalysisTree* targettre
     TRestEvent* eve = fInputEvent;
 
     if (fFileProcess != nullptr) {
-        debug << "TRestRun: getting next event from external process" << endl;
+        RESTDebug << "TRestRun: getting next event from external process" << RESTendl;
     GetEventExt:
         mutex_read.lock();
         fFileProcess->BeginOfEventProcess();
@@ -825,9 +828,10 @@ Int_t TRestRun::GetNextEvent(TRestEvent* targetevt, TRestAnalysisTree* targettre
         //}
         fCurrentEvent++;
     } else {
-        debug << "TRestRun: getting next event from root file" << endl;
+        RESTDebug << "TRestRun: getting next event from root file" << RESTendl;
         if (fAnalysisTree == nullptr) {
-            warning << "error to get event from input file, missing analysis tree from input file" << endl;
+            RESTWarning << "error to get event from input file, missing analysis tree from input file"
+                        << RESTendl;
             eve = nullptr;
         } else {
             if (fCurrentEvent >= fAnalysisTree->GetTree()->GetEntriesFast()) {
@@ -845,8 +849,8 @@ Int_t TRestRun::GetNextEvent(TRestEvent* targetevt, TRestAnalysisTree* targettre
                     if (fEventTree->IsA() == TChain::Class()) {
                         Long64_t entry = fEventTree->LoadTree(fCurrentEvent);
                         fBytesRead += ((TBranch*)fEventTree->GetTree()->GetListOfBranches()->UncheckedAt(
-                                             fEventBranchLoc))
-                                            ->GetEntry(entry);
+                                           fEventBranchLoc))
+                                          ->GetEntry(entry);
                     } else {
                         fBytesRead +=
                             ((TBranch*)fEventTree->GetListOfBranches()->UncheckedAt(fEventBranchLoc))
@@ -865,7 +869,8 @@ Int_t TRestRun::GetNextEvent(TRestEvent* targetevt, TRestAnalysisTree* targettre
             // if hangup is set, we continue calling ProcessEvent() of the
             // external process, until there is non-null event yielded
             if (!messageShown) {
-                essential << "external process file reading reaches end, waiting for more files" << endl;
+                RESTEssential << "external process file reading reaches end, waiting for more files"
+                              << RESTendl;
             }
             sleep(1);
             messageShown = true;
@@ -905,7 +910,7 @@ TString TRestRun::FormFormat(const TString& FilenameFormat) {
     string inString = (string)FilenameFormat;
     string outString = (string)FilenameFormat;
 
-    debug << "TRestRun::FormFormat. In string : " << inString << endl;
+    RESTDebug << "TRestRun::FormFormat. In string : " << inString << RESTendl;
 
     int pos = 0;
     while (1) {
@@ -917,8 +922,8 @@ TString TRestRun::FormFormat(const TString& FilenameFormat) {
         string target = inString.substr(pos1 + 1, pos2 - pos1 - 1);  // without []
         string replacestr = GetRunInformation(target);
 
-        debug << "TRestRun::FormFormat. target : " << target << endl;
-        debug << "TRestRun::FormFormat. replacestr : " << replacestr << endl;
+        RESTDebug << "TRestRun::FormFormat. target : " << target << RESTendl;
+        RESTDebug << "TRestRun::FormFormat. replacestr : " << replacestr << RESTendl;
 
         // If we form an output file we are willing to form the output filename
         // using the latest version. But the version is set just before we
@@ -947,20 +952,20 @@ TString TRestRun::FormFormat(const TString& FilenameFormat) {
 /// This method is used to create output file after TRestProcessRunner is finished.
 /// The metadata objects will also be written into the file.
 TFile* TRestRun::MergeToOutputFile(vector<string> filenames, string outputfilename) {
-    debug << "TRestRun::FormOutputFile. target : " << outputfilename << endl;
+    RESTDebug << "TRestRun::FormOutputFile. target : " << outputfilename << RESTendl;
     string filename;
     TFileMerger* m = new TFileMerger(false);
     if (outputfilename == "") {
         filename = fOutputFileName;
-        info << "Creating file : " << filename << endl;
+        RESTInfo << "Creating file : " << filename << RESTendl;
         m->OutputFile(filename.c_str(), "RECREATE");
     } else {
         filename = outputfilename;
-        info << "Creating file : " << filename << endl;
+        RESTInfo << "Creating file : " << filename << RESTendl;
         m->OutputFile(filename.c_str(), "UPDATE");
     }
 
-    debug << "TRestRun::FormOutputFile. Starting to add files" << endl;
+    RESTDebug << "TRestRun::FormOutputFile. Starting to add files" << RESTendl;
 
     for (int i = 0; i < filenames.size(); i++) {
         m->AddFile(filenames[i].c_str(), false);
@@ -972,7 +977,7 @@ TFile* TRestRun::MergeToOutputFile(vector<string> filenames, string outputfilena
         }
     } else {
         fOutputFileName = "";
-        ferr << "(Merge files) failed to merge process files." << endl;
+        RESTFerr << "(Merge files) failed to merge process files." << RESTendl;
         exit(1);
     }
 
@@ -984,12 +989,13 @@ TFile* TRestRun::MergeToOutputFile(vector<string> filenames, string outputfilena
 
     // write metadata into the output file
     fOutputFile = new TFile(fOutputFileName, "update");
-    debug << "TRestRun::FormOutputFile. Calling WriteWithDataBase()" << endl;
+    RESTDebug << "TRestRun::FormOutputFile. Calling WriteWithDataBase()" << RESTendl;
     this->WriteWithDataBase();
 
-    fout << this->ClassName() << " Created ..." << endl;
-    fout << "- Path : " << TRestTools::SeparatePathAndName((string)fOutputFileName).first << endl;
-    fout << "- Filename : " << TRestTools::SeparatePathAndName((string)fOutputFileName).second << endl;
+    RESTFout << this->ClassName() << " Created ..." << RESTendl;
+    RESTFout << "- Path : " << TRestTools::SeparatePathAndName((string)fOutputFileName).first << RESTendl;
+    RESTFout << "- Filename : " << TRestTools::SeparatePathAndName((string)fOutputFileName).second
+             << RESTendl;
     return fOutputFile;
 }
 
@@ -1009,9 +1015,10 @@ TFile* TRestRun::FormOutputFile() {
     fEventTree->Write();
     this->WriteWithDataBase();
 
-    fout << "TRestRun: Output File Created." << endl;
-    fout << "- Path : " << TRestTools::SeparatePathAndName((string)fOutputFileName).first << endl;
-    fout << "- Filename : " << TRestTools::SeparatePathAndName((string)fOutputFileName).second << endl;
+    RESTFout << "TRestRun: Output File Created." << RESTendl;
+    RESTFout << "- Path : " << TRestTools::SeparatePathAndName((string)fOutputFileName).first << RESTendl;
+    RESTFout << "- Filename : " << TRestTools::SeparatePathAndName((string)fOutputFileName).second
+             << RESTendl;
     return fOutputFile;
 }
 
@@ -1026,13 +1033,14 @@ TFile* TRestRun::UpdateOutputFile() {
         fEventTree->Write(0, kWriteDelete);
         this->WriteWithDataBase();
 
-        fout << "TRestRun: Output File Updated." << endl;
-        fout << "- Path : " << TRestTools::SeparatePathAndName((string)fOutputFileName).first << endl;
-        fout << "- Filename : " << TRestTools::SeparatePathAndName((string)fOutputFileName).second << endl;
+        RESTFout << "TRestRun: Output File Updated." << RESTendl;
+        RESTFout << "- Path : " << TRestTools::SeparatePathAndName((string)fOutputFileName).first << RESTendl;
+        RESTFout << "- Filename : " << TRestTools::SeparatePathAndName((string)fOutputFileName).second
+                 << RESTendl;
         return fOutputFile;
 
     } else {
-        ferr << "TRestRun::UpdateOutputFile(): output file is closed" << endl;
+        RESTFerr << "TRestRun::UpdateOutputFile(): output file is closed" << RESTendl;
     }
     return nullptr;
 }
@@ -1049,7 +1057,7 @@ TFile* TRestRun::UpdateOutputFile() {
 void TRestRun::WriteWithDataBase() {
     TRestAnalysisTree* tree = nullptr;
 
-    debug << "TRestRun::WriteWithDataBase. Getting entries in analysisTree" << endl;
+    RESTDebug << "TRestRun::WriteWithDataBase. Getting entries in analysisTree" << RESTendl;
 
     // record the entries saved
     fEntriesSaved = -1;
@@ -1059,7 +1067,7 @@ void TRestRun::WriteWithDataBase() {
             fEntriesSaved = tree->GetEntries();
         }
     }
-    debug << "TRestRun::WriteWithDataBase. Entries found : " << fEntriesSaved << endl;
+    RESTDebug << "TRestRun::WriteWithDataBase. Entries found : " << fEntriesSaved << RESTendl;
 
     // If time was not written by any other process we record the current time
     if (fEndTime == 0) {
@@ -1071,15 +1079,16 @@ void TRestRun::WriteWithDataBase() {
     fRunUser = REST_USER;
 
     // save metadata objects in file
-    debug << "TRestRun::WriteWithDataBase. Calling this->Write(0,kWriteDelete)" << endl;
+    RESTDebug << "TRestRun::WriteWithDataBase. Calling this->Write(0,kWriteDelete)" << RESTendl;
     this->Write(0, kWriteDelete);
-    debug << "TRestRun::WriteWithDataBase. Succeed" << endl;
-    debug << "TRestRun::WriteWithDataBase. fMetadata.size() == " << fMetadata.size() << endl;
+    RESTDebug << "TRestRun::WriteWithDataBase. Succeed" << RESTendl;
+    RESTDebug << "TRestRun::WriteWithDataBase. fMetadata.size() == " << fMetadata.size() << RESTendl;
     for (int i = 0; i < fMetadata.size(); i++) {
         bool historic = false;
-        debug << "TRestRun::WriteWithDataBase. fInputMetadata.size() == " << fInputMetadata.size() << endl;
+        RESTDebug << "TRestRun::WriteWithDataBase. fInputMetadata.size() == " << fInputMetadata.size()
+                  << RESTendl;
         for (int j = 0; j < fInputMetadata.size(); j++) {
-            debug << fMetadata[i]->GetName() << " == " << fInputMetadata[j]->GetName() << endl;
+            RESTDebug << fMetadata[i]->GetName() << " == " << fInputMetadata[j]->GetName() << RESTendl;
             if (fMetadata[i] == fInputMetadata[j]) {
                 historic = true;
                 break;
@@ -1087,19 +1096,19 @@ void TRestRun::WriteWithDataBase() {
         }
 
         if (!historic) {
-            debug << "NO historic" << endl;
+            RESTDebug << "NO historic" << RESTendl;
             fMetadata[i]->Write(fMetadata[i]->GetName(), kWriteDelete);
         } else {
-            debug << "IS historic" << endl;
+            RESTDebug << "IS historic" << RESTendl;
             if (fSaveHistoricData) fMetadata[i]->Write(fMetadata[i]->GetName(), kWriteDelete);
         }
     }
 
     // write to database
-    debug << "TResRun::WriteWithDataBase. Run number is : " << fRunNumber << endl;
+    RESTDebug << "TResRun::WriteWithDataBase. Run number is : " << fRunNumber << RESTendl;
     if (fRunNumber != -1) {
         int fileid = gDataBase->set_runfile(fRunNumber, (string)fOutputFileName);
-        fout << "DataBase Entry Added! Run Number: " << fRunNumber << ", File ID: " << fileid << endl;
+        RESTFout << "DataBase Entry Added! Run Number: " << fRunNumber << ", File ID: " << fileid << RESTendl;
     }
 }
 
@@ -1160,7 +1169,8 @@ void TRestRun::SetExtProcess(TRestEventProcess* p) {
         fFileProcess->InitProcess();
         fInputEvent = fFileProcess->GetOutputEvent();
         if (fInputEvent == nullptr) {
-            ferr << "The external process \"" << p->GetName() << "\" doesn't yield any output event!" << endl;
+            RESTFerr << "The external process \"" << p->GetName() << "\" doesn't yield any output event!"
+                     << RESTendl;
             exit(1);
         } else {
             fInputEvent->SetRunOrigin(fRunNumber);
@@ -1175,14 +1185,14 @@ void TRestRun::SetExtProcess(TRestEventProcess* p) {
 
         GetNextEvent(fInputEvent, 0);
         // fAnalysisTree->CreateBranches();
-        info << "The external file process has been set! Name : " << fFileProcess->GetName() << endl;
+        RESTInfo << "The external file process has been set! Name : " << fFileProcess->GetName() << RESTendl;
     } else {
         if (fFileProcess != nullptr) {
-            ferr << "There can only be one file process!" << endl;
+            RESTFerr << "There can only be one file process!" << RESTendl;
             exit(1);
         }
         if (p == nullptr) {
-            warning << "Given file process is null, skipping..." << endl;
+            RESTWarning << "Given file process is null, skipping..." << RESTendl;
         }
     }
 }
@@ -1209,8 +1219,8 @@ void TRestRun::SetInputEvent(TRestEvent* event) {
             for (int i = 0; i <= branches->GetLast(); i++) {
                 TBranch* br = (TBranch*)branches->At(i);
                 if ((string)br->GetName() == branchName) {
-                    debug << "Setting input event.. Type: " << event->ClassName() << " Address: " << event
-                          << endl;
+                    RESTDebug << "Setting input event.. Type: " << event->ClassName() << " Address: " << event
+                              << RESTendl;
                     // if (fInputEvent != nullptr && (char*)fInputEvent != (char*)eve) {
                     //    delete fInputEvent;
                     //}
@@ -1221,11 +1231,11 @@ void TRestRun::SetInputEvent(TRestEvent* event) {
                     fEventBranchLoc = i;
                     break;
                 } else if (i == branches->GetLast()) {
-                    warning << "REST Warning : (TRestRun) cannot find corresponding "
-                               "branch in event tree!"
-                            << endl;
-                    warning << "Event Type : " << event->ClassName() << endl;
-                    warning << "Input event not set!" << endl;
+                    RESTWarning << "REST Warning : (TRestRun) cannot find corresponding "
+                                   "branch in event tree!"
+                                << RESTendl;
+                    RESTWarning << "Event Type : " << event->ClassName() << RESTendl;
+                    RESTWarning << "Input event not set!" << RESTendl;
                 }
             }
         } else {
@@ -1256,22 +1266,22 @@ void TRestRun::AddEventBranch(TRestEvent* eve) {
 void TRestRun::ImportMetadata(const TString& File, const TString& name, const TString& type, Bool_t store) {
     const TString thisFile = SearchFile(File.Data());
     if (thisFile == "") {
-        ferr << "(ImportMetadata): The file " << thisFile << " does not exist!" << endl;
-        ferr << endl;
+        RESTFerr << "(ImportMetadata): The file " << thisFile << " does not exist!" << RESTendl;
+        RESTFerr << RESTendl;
         return;
     }
     if (!TRestTools::isRootFile(thisFile.Data())) {
-        ferr << "(ImportMetadata) : The file " << thisFile << " is not root file!" << endl;
-        ferr << "If you want to initialize metadata from rml file, use <TRest section!" << endl;
+        RESTFerr << "(ImportMetadata) : The file " << thisFile << " is not root file!" << RESTendl;
+        RESTFerr << "If you want to initialize metadata from rml file, use <TRest section!" << RESTendl;
         return;
     }
 
     TFile* f = new TFile(thisFile);
     // TODO give error in case we try to obtain a class that is not TRestMetadata
     if (type == "" && name == "") {
-        ferr << "(ImportMetadata) : metadata type and name is not "
-                "specified!"
-             << endl;
+        RESTFerr << "(ImportMetadata) : metadata type and name is not "
+                    "specified!"
+                 << RESTendl;
         return;
     }
 
@@ -1529,9 +1539,9 @@ TRestMetadata* TRestRun::GetMetadataClass(const TString& type, TFile* f) {
                 if (a != nullptr && a->InheritsFrom("TRestMetadata")) {
                     return a;
                 } else {
-                    warning << "TRestRun::GetMetadataClass() : The object to import is "
-                               "not inherited from TRestMetadata"
-                            << endl;
+                    RESTWarning << "TRestRun::GetMetadataClass() : The object to import is "
+                                   "not inherited from TRestMetadata"
+                                << RESTendl;
                 }
             }
         }
@@ -1560,9 +1570,9 @@ TRestMetadata* TRestRun::GetMetadata(const TString& name, TFile* f) {
                 if (a->InheritsFrom("TRestMetadata")) {
                     return a;
                 } else {
-                    warning << "TRestRun::GetMetadata() : The object to import is not "
-                               "inherited from TRestMetadata"
-                            << endl;
+                    RESTWarning << "TRestRun::GetMetadata() : The object to import is not "
+                                   "inherited from TRestMetadata"
+                                << RESTendl;
                 }
             }
         }
@@ -1611,7 +1621,7 @@ string TRestRun::ReplaceMetadataMembers(const string& instr) {
         string s = outstring.substr(startPosition + 1, endPosition - startPosition - 1);
         int cont = count(s.begin(), s.end(), '[') - count(s.begin(), s.end(), ']');
 
-        if (cont < 0) ferr << "This is a coding error at ReplaceMetadataMembers!" << endl;
+        if (cont < 0) RESTFerr << "This is a coding error at ReplaceMetadataMembers!" << RESTendl;
 
         // We search for the enclosing ]. Since we might find a vector index inside.
         while (cont > 0) {
@@ -1673,8 +1683,8 @@ string TRestRun::ReplaceMetadataMember(const string& instr) {
 
         if (GetMetadata(results[0])) {
             if (index >= this->GetMetadata(results[0])->GetDataMemberValues(results[1]).size()) {
-                warning << "TRestRun::ReplaceMetadataMember. Index out of range!" << endl;
-                warning << "Returning the first element" << endl;
+                RESTWarning << "TRestRun::ReplaceMetadataMember. Index out of range!" << RESTendl;
+                RESTWarning << "Returning the first element" << RESTendl;
                 index = 0;
             }
             return this->GetMetadata(results[0])->GetDataMemberValues(results[1])[index];
@@ -1682,17 +1692,17 @@ string TRestRun::ReplaceMetadataMember(const string& instr) {
 
         if (GetMetadataClass(results[0])) {
             if (index >= this->GetMetadataClass(results[0])->GetDataMemberValues(results[1]).size()) {
-                warning << "TRestRun::ReplaceMetadataMember. Index out of range!" << endl;
-                warning << "Returning the first element" << endl;
+                RESTWarning << "TRestRun::ReplaceMetadataMember. Index out of range!" << RESTendl;
+                RESTWarning << "Returning the first element" << RESTendl;
                 index = 0;
             }
             return this->GetMetadataClass(results[0])->GetDataMemberValues(results[1])[index];
         }
 
     } else
-        ferr << "TRestRun::ReplaceMetadataMember. Wrong number of elements found" << endl;
+        RESTFerr << "TRestRun::ReplaceMetadataMember. Wrong number of elements found" << RESTendl;
 
-    warning << "TRestRun::ReplaceMetadataMember. " << instr << " not found!" << endl;
+    RESTWarning << "TRestRun::ReplaceMetadataMember. " << instr << " not found!" << RESTendl;
     return "";
 }
 
@@ -1734,13 +1744,13 @@ Bool_t TRestRun::EvaluateMetadataMember(const string& instr) {
     }
 
     if (expOp == "") {
-        warning << "TRestRun::EvaluateMetadataMember. Not valid operator found in expression : " << instr
-                << endl;
+        RESTWarning << "TRestRun::EvaluateMetadataMember. Not valid operator found in expression : " << instr
+                    << RESTendl;
         return false;
     }
 
     if (results.size() != 2) {
-        warning << "TRestRun::EvaluateMetadataMember. Not valid expression : " << instr << endl;
+        RESTWarning << "TRestRun::EvaluateMetadataMember. Not valid expression : " << instr << RESTendl;
         return false;
     }
 
@@ -1772,35 +1782,36 @@ void TRestRun::PrintMetadata() {
     // cout.precision(10);
     TRestMetadata::PrintMetadata();
 
-    metadata << "Version : " << this->GetVersion() << endl;
-    metadata << "Parent run number : " << GetParentRunNumber() << endl;
-    metadata << "Run number : " << GetRunNumber() << endl;
-    metadata << "Experiment/project : " << GetExperimentName() << endl;
-    metadata << "Run type : " << GetRunType() << endl;
-    metadata << "Run tag : " << GetRunTag() << endl;
-    metadata << "Run user : " << GetRunUser() << endl;
-    metadata << "Run description : " << GetRunDescription() << endl;
-    metadata << "Start Date/Time : " << ToDateTimeString(GetStartTimestamp()) << " (" << GetStartTimestamp()
-             << ")" << endl;
-    metadata << "End Date/Time : " << ToDateTimeString(GetEndTimestamp()) << " (" << GetEndTimestamp() << ")"
-             << endl;
-    metadata << "Input file : " << TRestTools::GetPureFileName((string)GetInputFileNamePattern()) << endl;
-    metadata << "Output file : " << TRestTools::GetPureFileName((string)GetOutputFileName()) << endl;
+    RESTMetadata << "Version : " << this->GetVersion() << RESTendl;
+    RESTMetadata << "Parent run number : " << GetParentRunNumber() << RESTendl;
+    RESTMetadata << "Run number : " << GetRunNumber() << RESTendl;
+    RESTMetadata << "Experiment/project : " << GetExperimentName() << RESTendl;
+    RESTMetadata << "Run type : " << GetRunType() << RESTendl;
+    RESTMetadata << "Run tag : " << GetRunTag() << RESTendl;
+    RESTMetadata << "Run user : " << GetRunUser() << RESTendl;
+    RESTMetadata << "Run description : " << GetRunDescription() << RESTendl;
+    RESTMetadata << "Start Date/Time : " << ToDateTimeString(GetStartTimestamp()) << " ("
+                 << GetStartTimestamp() << ")" << RESTendl;
+    RESTMetadata << "End Date/Time : " << ToDateTimeString(GetEndTimestamp()) << " (" << GetEndTimestamp()
+                 << ")" << RESTendl;
+    RESTMetadata << "Input file : " << TRestTools::GetPureFileName((string)GetInputFileNamePattern())
+                 << RESTendl;
+    RESTMetadata << "Output file : " << TRestTools::GetPureFileName((string)GetOutputFileName()) << RESTendl;
     if (fInputFile != nullptr) {
-        metadata << "Data file : " << fInputFile->GetName();
+        RESTMetadata << "Data file : " << fInputFile->GetName();
         if (fNFilesSplit > 0) {
-            metadata << " (Splitted into " << fNFilesSplit + 1 << " files)" << endl;
+            RESTMetadata << " (Splitted into " << fNFilesSplit + 1 << " files)" << RESTendl;
         } else {
-            metadata << endl;
+            RESTMetadata << RESTendl;
         }
     }
-    metadata << "Number of events : " << fEntriesSaved << endl;
+    RESTMetadata << "Number of events : " << fEntriesSaved << RESTendl;
     // metadata << "Input filename : " << fInputFilename << endl;
     // metadata << "Output filename : " << fOutputFilename << endl;
     // metadata << "Number of initial events : " << GetNumberOfEvents() << endl;
     // metadata << "Number of processed events : " << fProcessedEvents << endl;
-    metadata << "---------------------------------------" << endl;
-    metadata << endl;
+    RESTMetadata << "---------------------------------------" << RESTendl;
+    RESTMetadata << RESTendl;
 }
 
 ///////////////////////////////////////////////
@@ -1855,14 +1866,14 @@ void TRestRun::PrintErrors() {
 
     if (nErrors) {
         cout << endl;
-        ferr << "Found a total of " << nErrors << " metadata errors" << endl;
+        RESTFerr << "Found a total of " << nErrors << " metadata errors" << RESTendl;
         for (int n = 0; n < fMetadata.size(); n++)
             if (fMetadata[n]->GetError()) {
                 cout << endl;
-                ferr << "Class: " << fMetadata[n]->ClassName() << " Name: " << fMetadata[n]->GetName()
-                     << endl;
-                ferr << "Number of errors: " << fMetadata[n]->GetNumberOfErrors() << endl;
-                ferr << "Message: " << fMetadata[n]->GetErrorMessage() << endl;
+                RESTFerr << "Class: " << fMetadata[n]->ClassName() << " Name: " << fMetadata[n]->GetName()
+                         << RESTendl;
+                RESTFerr << "Number of errors: " << fMetadata[n]->GetNumberOfErrors() << RESTendl;
+                RESTFerr << "Message: " << fMetadata[n]->GetErrorMessage() << RESTendl;
             }
         cout << endl;
     } else {
@@ -1881,14 +1892,14 @@ void TRestRun::PrintWarnings() {
 
     if (nWarnings) {
         cout << endl;
-        warning << "Found a total of " << nWarnings << " metadata warnings" << endl;
+        RESTWarning << "Found a total of " << nWarnings << " metadata warnings" << RESTendl;
         for (int n = 0; n < fMetadata.size(); n++)
             if (fMetadata[n]->GetWarning()) {
                 cout << endl;
-                warning << "Class: " << fMetadata[n]->ClassName() << " Name: " << fMetadata[n]->GetName()
-                        << endl;
-                warning << "Number of warnings: " << fMetadata[n]->GetNumberOfWarnings() << endl;
-                warning << "Message: " << fMetadata[n]->GetWarningMessage() << endl;
+                RESTWarning << "Class: " << fMetadata[n]->ClassName() << " Name: " << fMetadata[n]->GetName()
+                            << RESTendl;
+                RESTWarning << "Number of warnings: " << fMetadata[n]->GetNumberOfWarnings() << RESTendl;
+                RESTWarning << "Message: " << fMetadata[n]->GetWarningMessage() << RESTendl;
             }
         cout << endl;
     } else {

--- a/source/framework/core/src/TRestTask.cxx
+++ b/source/framework/core/src/TRestTask.cxx
@@ -96,9 +96,9 @@ TRestTask::TRestTask(TString TaskString, REST_TASKMODE mode) {
         string name;
         string call;
         if (Split(cmd, "->").size() != 2) {
-            warning << "command"
-                    << " \"" << cmd << "\" "
-                    << "is illegal!" << endl;
+            RESTWarning << "command"
+                        << " \"" << cmd << "\" "
+                        << "is illegal!" << RESTendl;
             fMode = TASK_ERROR;
             return;
         } else {
@@ -109,9 +109,9 @@ TRestTask::TRestTask(TString TaskString, REST_TASKMODE mode) {
         int p1 = call.find_first_of("(");
         int p2 = call.find_last_of(")");
         if (p1 == -1 || p2 == -1 || p1 >= p2) {
-            warning << "command"
-                    << " \"" << cmd << "\" "
-                    << "is illegal!" << endl;
+            RESTWarning << "command"
+                        << " \"" << cmd << "\" "
+                        << "is illegal!" << RESTendl;
             fMode = TASK_ERROR;
             return;
         }
@@ -153,14 +153,14 @@ void TRestTask::SetArgumentValue(vector<string> arg) {
 ///
 void TRestTask::RunTask(TRestManager* mgr) {
     if (fInvokeMethod == "") {
-        ferr << "no task specified for TRestTask!!!" << endl;
+        RESTFerr << "no task specified for TRestTask!!!" << RESTendl;
         exit(-1);
     } else {
         if (fMode == TASK_MACRO) {
             // call gInterpreter to run a command
             for (int i = 0; i < fArgumentValues.size(); i++) {
                 if (fArgumentValues[i] == "NOT SET") {
-                    ferr << "TRestTask : argument " << i << " not set! Task will not run!" << endl;
+                    RESTFerr << "TRestTask : argument " << i << " not set! Task will not run!" << RESTendl;
                 }
             }
 
@@ -183,14 +183,14 @@ void TRestTask::RunTask(TRestManager* mgr) {
         } else if (fMode == TASK_CPPCMD) {
             //
             if (mgr == nullptr) {
-                ferr << "no target specified for the command:" << endl;
-                ferr << fConstructedCommand << endl;
+                RESTFerr << "no target specified for the command:" << RESTendl;
+                RESTFerr << fConstructedCommand << RESTendl;
                 exit(-1);
             } else {
                 TRestMetadata* meta = mgr->GetMetadata(fInvokeObject);
                 if (meta == nullptr) {
-                    ferr << "cannot file metadata: " << fInvokeObject << " in TRestManager" << endl;
-                    ferr << "command: " << fConstructedCommand << endl;
+                    RESTFerr << "cannot file metadata: " << fInvokeObject << " in TRestManager" << RESTendl;
+                    RESTFerr << "command: " << fConstructedCommand << RESTendl;
                     exit(-1);
                 } else {
                     string type = meta->ClassName();
@@ -200,15 +200,16 @@ void TRestTask::RunTask(TRestManager* mgr) {
                     TInterpreter::EErrorCode err;
                     gInterpreter->ProcessLine(cmd.c_str(), &err);
                     if (err != TInterpreter::kNoError) {
-                        ferr << "TRestTask::RunTask(): unknown error" << endl;
-                        ferr << "code: " << err << endl;
+                        RESTFerr << "TRestTask::RunTask(): unknown error" << RESTendl;
+                        RESTFerr << "code: " << err << RESTendl;
                         exit(-1);
                     }
                     gInterpreter->ProcessLine(fConstructedCommand.c_str(), &err);
                     if (err != TInterpreter::kNoError) {
-                        ferr << "TRestTask: failed to execute cpp command, error code: " << err << endl;
-                        ferr << fConstructedCommand << endl;
-                        ferr << "Check your <AddTask section!" << endl;
+                        RESTFerr << "TRestTask: failed to execute cpp command, error code: " << err
+                                 << RESTendl;
+                        RESTFerr << fConstructedCommand << RESTendl;
+                        RESTFerr << "Check your <AddTask section!" << RESTendl;
                         exit(-1);
                     }
                 }
@@ -225,7 +226,7 @@ void TRestTask::RunTask(TRestManager* mgr) {
 ///
 void TRestTask::PrintArgumentHelp() {
     if (fMode == 0) {
-        ferr << fInvokeMethod << "() Gets invalided input!" << endl;
+        RESTFerr << fInvokeMethod << "() Gets invalided input!" << RESTendl;
         cout << "You should give the following arguments (* is mandatory input):" << endl;
         int n = fArgumentNames.size();
         for (int i = 0; i < n; i++) {
@@ -233,12 +234,12 @@ void TRestTask::PrintArgumentHelp() {
         }
     } else if (fMode == 1) {
     } else if (fMode == 2) {
-        ferr << "Macro class \"" << this->ClassName() << "\" gets invalided input!" << endl;
-        ferr << "You should give the following arguments ( * : necessary input):" << endl;
+        RESTFerr << "Macro class \"" << this->ClassName() << "\" gets invalided input!" << RESTendl;
+        RESTFerr << "You should give the following arguments ( * : necessary input):" << RESTendl;
         int n = any(this).GetNumberOfDataMembers();
         for (int i = 1; i < n; i++) {
-            if (i < fNRequiredArgument + 1) ferr << "*";
-            ferr << any(this).GetDataMember(i).name << endl;
+            if (i < fNRequiredArgument + 1) RESTFerr << "*";
+            RESTFerr << any(this).GetDataMember(i).name << RESTendl;
         }
     }
 }
@@ -262,21 +263,22 @@ TRestTask* TRestTask::GetTaskFromMacro(TString taskName) {
     auto macfiles = Split(macfilelists, "\n");
 
     if (macfiles.size() != 0 && macfiles[0] != "") {
-        info << "Found MacroFile " << macfiles[0] << noClass::endl;
+        RESTInfo << "Found MacroFile " << macfiles[0] << TRestStringOutput::RESTendl;
         // system("echo \"#define REST_MANAGER\" > /tmp/tmpMacro.c");
         // system(("cat " + macfiles[0] + " >> /tmp/tmpMacro.c").c_str());
         if (gInterpreter->LoadFile(macfiles[0].c_str()) == 0) {
             TRestTask* tsk = new TRestTask(macfiles[0].c_str(), TASK_MACRO);
             if (tsk->GetMode() == TASK_ERROR) {
-                ferr << "Task file: " << macfiles[0]
-                     << " loaded but method not found. Make sure it contains the method with same name as "
-                        "file name"
-                     << noClass::endl;
+                RESTFerr
+                    << "Task file: " << macfiles[0]
+                    << " loaded but method not found. Make sure it contains the method with same name as "
+                       "file name"
+                    << TRestStringOutput::RESTendl;
                 return nullptr;
             }
             return tsk;
         } else {
-            ferr << "Task file: " << macfiles[0] << " contains error" << noClass::endl;
+            RESTFerr << "Task file: " << macfiles[0] << " contains error" << TRestStringOutput::RESTendl;
             return nullptr;
         }
 
@@ -288,7 +290,7 @@ TRestTask* TRestTask::GetTaskFromMacro(TString taskName) {
             return tsk;
         }
     }
-    ferr << "REST ERROR. Task : " << taskName << " not found!!" << noClass::endl;
+    RESTFerr << "REST ERROR. Task : " << taskName << " not found!!" << TRestStringOutput::RESTendl;
     return nullptr;
 }
 

--- a/source/framework/core/src/TRestTask.cxx
+++ b/source/framework/core/src/TRestTask.cxx
@@ -153,14 +153,14 @@ void TRestTask::SetArgumentValue(vector<string> arg) {
 ///
 void TRestTask::RunTask(TRestManager* mgr) {
     if (fInvokeMethod == "") {
-        RESTFerr << "no task specified for TRestTask!!!" << RESTendl;
+        RESTError << "no task specified for TRestTask!!!" << RESTendl;
         exit(-1);
     } else {
         if (fMode == TASK_MACRO) {
             // call gInterpreter to run a command
             for (int i = 0; i < fArgumentValues.size(); i++) {
                 if (fArgumentValues[i] == "NOT SET") {
-                    RESTFerr << "TRestTask : argument " << i << " not set! Task will not run!" << RESTendl;
+                    RESTError << "TRestTask : argument " << i << " not set! Task will not run!" << RESTendl;
                 }
             }
 
@@ -183,14 +183,14 @@ void TRestTask::RunTask(TRestManager* mgr) {
         } else if (fMode == TASK_CPPCMD) {
             //
             if (mgr == nullptr) {
-                RESTFerr << "no target specified for the command:" << RESTendl;
-                RESTFerr << fConstructedCommand << RESTendl;
+                RESTError << "no target specified for the command:" << RESTendl;
+                RESTError << fConstructedCommand << RESTendl;
                 exit(-1);
             } else {
                 TRestMetadata* meta = mgr->GetMetadata(fInvokeObject);
                 if (meta == nullptr) {
-                    RESTFerr << "cannot file metadata: " << fInvokeObject << " in TRestManager" << RESTendl;
-                    RESTFerr << "command: " << fConstructedCommand << RESTendl;
+                    RESTError << "cannot file metadata: " << fInvokeObject << " in TRestManager" << RESTendl;
+                    RESTError << "command: " << fConstructedCommand << RESTendl;
                     exit(-1);
                 } else {
                     string type = meta->ClassName();
@@ -200,16 +200,16 @@ void TRestTask::RunTask(TRestManager* mgr) {
                     TInterpreter::EErrorCode err;
                     gInterpreter->ProcessLine(cmd.c_str(), &err);
                     if (err != TInterpreter::kNoError) {
-                        RESTFerr << "TRestTask::RunTask(): unknown error" << RESTendl;
-                        RESTFerr << "code: " << err << RESTendl;
+                        RESTError << "TRestTask::RunTask(): unknown error" << RESTendl;
+                        RESTError << "code: " << err << RESTendl;
                         exit(-1);
                     }
                     gInterpreter->ProcessLine(fConstructedCommand.c_str(), &err);
                     if (err != TInterpreter::kNoError) {
-                        RESTFerr << "TRestTask: failed to execute cpp command, error code: " << err
-                                 << RESTendl;
-                        RESTFerr << fConstructedCommand << RESTendl;
-                        RESTFerr << "Check your <AddTask section!" << RESTendl;
+                        RESTError << "TRestTask: failed to execute cpp command, error code: " << err
+                                  << RESTendl;
+                        RESTError << fConstructedCommand << RESTendl;
+                        RESTError << "Check your <AddTask section!" << RESTendl;
                         exit(-1);
                     }
                 }
@@ -226,7 +226,7 @@ void TRestTask::RunTask(TRestManager* mgr) {
 ///
 void TRestTask::PrintArgumentHelp() {
     if (fMode == 0) {
-        RESTFerr << fInvokeMethod << "() Gets invalided input!" << RESTendl;
+        RESTError << fInvokeMethod << "() Gets invalided input!" << RESTendl;
         cout << "You should give the following arguments (* is mandatory input):" << endl;
         int n = fArgumentNames.size();
         for (int i = 0; i < n; i++) {
@@ -234,12 +234,12 @@ void TRestTask::PrintArgumentHelp() {
         }
     } else if (fMode == 1) {
     } else if (fMode == 2) {
-        RESTFerr << "Macro class \"" << this->ClassName() << "\" gets invalided input!" << RESTendl;
-        RESTFerr << "You should give the following arguments ( * : necessary input):" << RESTendl;
+        RESTError << "Macro class \"" << this->ClassName() << "\" gets invalided input!" << RESTendl;
+        RESTError << "You should give the following arguments ( * : necessary input):" << RESTendl;
         int n = any(this).GetNumberOfDataMembers();
         for (int i = 1; i < n; i++) {
-            if (i < fNRequiredArgument + 1) RESTFerr << "*";
-            RESTFerr << any(this).GetDataMember(i).name << RESTendl;
+            if (i < fNRequiredArgument + 1) RESTError << "*";
+            RESTError << any(this).GetDataMember(i).name << RESTendl;
         }
     }
 }
@@ -269,7 +269,7 @@ TRestTask* TRestTask::GetTaskFromMacro(TString taskName) {
         if (gInterpreter->LoadFile(macfiles[0].c_str()) == 0) {
             TRestTask* tsk = new TRestTask(macfiles[0].c_str(), TASK_MACRO);
             if (tsk->GetMode() == TASK_ERROR) {
-                RESTFerr
+                RESTError
                     << "Task file: " << macfiles[0]
                     << " loaded but method not found. Make sure it contains the method with same name as "
                        "file name"
@@ -278,7 +278,7 @@ TRestTask* TRestTask::GetTaskFromMacro(TString taskName) {
             }
             return tsk;
         } else {
-            RESTFerr << "Task file: " << macfiles[0] << " contains error" << TRestStringOutput::RESTendl;
+            RESTError << "Task file: " << macfiles[0] << " contains error" << TRestStringOutput::RESTendl;
             return nullptr;
         }
 
@@ -290,7 +290,7 @@ TRestTask* TRestTask::GetTaskFromMacro(TString taskName) {
             return tsk;
         }
     }
-    RESTFerr << "REST ERROR. Task : " << taskName << " not found!!" << TRestStringOutput::RESTendl;
+    RESTError << "REST ERROR. Task : " << taskName << " not found!!" << TRestStringOutput::RESTendl;
     return nullptr;
 }
 

--- a/source/framework/core/src/TRestThread.cxx
+++ b/source/framework/core/src/TRestThread.cxx
@@ -80,9 +80,9 @@ Int_t TRestThread::ValidateChain(TRestEvent* input) {
                    inEvent.cl->InheritsFrom("TRestEvent")) {
             processes.push_back(fProcessChain[i]);
         } else {
-            RESTFerr << "Process: " << fProcessChain[i]->ClassName()
-                     << " not properly written, the input/output event is illegal!" << RESTendl;
-            RESTFerr << "Hint: they must be inherited from TRestEvent" << RESTendl;
+            RESTError << "Process: " << fProcessChain[i]->ClassName()
+                      << " not properly written, the input/output event is illegal!" << RESTendl;
+            RESTError << "Hint: they must be inherited from TRestEvent" << RESTendl;
             abort();
         }
     }
@@ -91,7 +91,7 @@ Int_t TRestThread::ValidateChain(TRestEvent* input) {
         // verify that the input event of first process is OK
         if (input != nullptr) {
             if ((string)input->ClassName() != processes[0]->GetInputEvent().type) {
-                RESTFerr << "(ValidateChain): Input event type does not match!" << RESTendl;
+                RESTError << "(ValidateChain): Input event type does not match!" << RESTendl;
                 cout << "Input type of the first non-external process in chain: "
                      << processes[0]->GetInputEvent().type << endl;
                 cout << "The event type from file: " << input->ClassName() << endl;
@@ -107,13 +107,13 @@ Int_t TRestThread::ValidateChain(TRestEvent* input) {
             string nextinEventType = processes[i + 1]->GetInputEvent().type;
             if (outEventType != nextinEventType && outEventType != "TRestEvent" &&
                 nextinEventType != "TRestEvent") {
-                RESTFerr << "(ValidateChain): Event process input/output does not match" << RESTendl;
-                RESTFerr << "The event output for process " << processes[i]->GetName() << " is "
-                         << outEventType << RESTendl;
-                RESTFerr << "The event input for process " << processes[i + 1]->GetName() << " is "
-                         << nextinEventType << RESTendl;
-                RESTFerr << "No events will be processed. Please correctly connect the process chain!"
-                         << RESTendl;
+                RESTError << "(ValidateChain): Event process input/output does not match" << RESTendl;
+                RESTError << "The event output for process " << processes[i]->GetName() << " is "
+                          << outEventType << RESTendl;
+                RESTError << "The event input for process " << processes[i + 1]->GetName() << " is "
+                          << nextinEventType << RESTendl;
+                RESTError << "No events will be processed. Please correctly connect the process chain!"
+                          << RESTendl;
                 GetChar();
                 return -1;
             }
@@ -253,9 +253,10 @@ void TRestThread::PrepareToProcess(bool* outputConfig) {
 
         RESTDebug << "TRestThread: Finding first input event of process chain..." << RESTendl;
         if (fHostRunner->GetInputEvent() == nullptr) {
-            RESTFerr << "Input event is not initialized from TRestRun! Please check your input file and file "
-                        "reading process!"
-                     << RESTendl;
+            RESTError
+                << "Input event is not initialized from TRestRun! Please check your input file and file "
+                   "reading process!"
+                << RESTendl;
             exit(1);
         }
         fInputEvent = (TRestEvent*)fHostRunner->GetInputEvent()->Clone();
@@ -270,8 +271,8 @@ void TRestThread::PrepareToProcess(bool* outputConfig) {
 
         RESTDebug << "TRestThread: Reading input event and input observable..." << RESTendl;
         if (fHostRunner->GetNextevtFunc(fInputEvent, fAnalysisTree) != 0) {
-            RESTFerr << "In thread " << fThreadId << ")::Failed to read input event, process cannot start!"
-                     << RESTendl;
+            RESTError << "In thread " << fThreadId << ")::Failed to read input event, process cannot start!"
+                      << RESTendl;
             exit(1);
         }
 
@@ -289,12 +290,12 @@ void TRestThread::PrepareToProcess(bool* outputConfig) {
         if (fHostRunner->UseTestRun()) {
             RESTDebug << "Test Run..." << RESTendl;
             if (!TestRun()) {
-                RESTFerr << "In thread " << fThreadId << ")::test run failed!" << RESTendl;
-                RESTFerr << "One of the processes has NULL pointer fOutputEvent!" << RESTendl;
+                RESTError << "In thread " << fThreadId << ")::test run failed!" << RESTendl;
+                RESTError << "One of the processes has NULL pointer fOutputEvent!" << RESTendl;
                 if (fVerboseLevel < TRestStringOutput::REST_Verbose_Level::REST_Debug)
-                    RESTFerr << "To see more detail, turn on debug mode for "
-                                "TRestProcessRunner!"
-                             << RESTendl;
+                    RESTError << "To see more detail, turn on debug mode for "
+                                 "TRestProcessRunner!"
+                              << RESTendl;
                 exit(1);
             }
             RESTDebug << "Test Run complete!" << RESTendl;
@@ -592,8 +593,8 @@ void TRestThread::EndProcess() {
                     << " process warnings were found! Use run0->PrintWarnings(); to get additional info."
                     << RESTendl;
     if (nErrors)
-        RESTFerr << nErrors << " process errors were found! Use run0->PrintErrors(); to get additional info."
-                 << RESTendl;
+        RESTError << nErrors << " process errors were found! Use run0->PrintErrors(); to get additional info."
+                  << RESTendl;
 
     delete fAnalysisTree;
 }

--- a/source/framework/core/src/startup.cpp
+++ b/source/framework/core/src/startup.cpp
@@ -92,18 +92,7 @@ const __REST_CONST_INIT REST_CONST_INIT;
 TRestDataBase* gDataBase = nullptr;
 MakeGlobal(TRestDataBase, gDataBase, 1);
 
-// initialize formatted message output tool
-TRestStringOutput fout(REST_Silent, COLOR_BOLDBLUE, "[== ==]", kMiddle);
-TRestStringOutput ferr(REST_Silent, COLOR_BOLDRED, "-- Error : ", kLeft, true);
-TRestStringOutput warning(REST_Warning, COLOR_BOLDYELLOW, "-- Warning : ", kLeft, true);
-TRestStringOutput essential(REST_Essential, COLOR_BOLDGREEN, "", kMiddle);
-TRestStringOutput metadata(REST_Essential, COLOR_BOLDGREEN, "|| ||", kMiddle);
-TRestStringOutput info(REST_Info, COLOR_BLUE, "-- Info : ", kLeft);
-TRestStringOutput success(REST_Info, COLOR_GREEN, "-- Success : ", kLeft);
-TRestStringOutput debug(REST_Debug, COLOR_RESET, "-- Debug : ", kLeft);
-TRestStringOutput extreme(REST_Extreme, COLOR_RESET, "-- Extreme : ", kLeft);
-
-REST_Verbose_Level gVerbose = REST_Warning;
+TRestStringOutput::REST_Verbose_Level gVerbose = TRestStringOutput::REST_Verbose_Level::REST_Warning;
 
 // initialize converter methods
 template <class T>

--- a/source/framework/tools/inc/TRestReflector.h
+++ b/source/framework/tools/inc/TRestReflector.h
@@ -315,8 +315,8 @@ class TRestReflector {
     template <typename T>
     T GetValue() {
         if (typeid(T) != *this->typeinfo) {
-            std::cout << "In TRestReflector::GetValue() : type unmatch! " << endl;
-            std::cout << "Input: " << GetTypeName<T>() << ", this: " << this->type << endl;
+            std::cout << "In TRestReflector::GetValue() : type unmatch! " << std::endl;
+            std::cout << "Input: " << GetTypeName<T>() << ", this: " << this->type << std::endl;
             return T();
         }
         if (address != nullptr) return *(T*)(address);
@@ -326,8 +326,8 @@ class TRestReflector {
     template <class T>
     void SetValue(const T& val) {
         if (typeid(T) != *this->typeinfo) {
-            std::cout << "In TRestReflector::SetValue() : type unmatch! " << endl;
-            std::cout << "Input: " << GetTypeName<T>() << ", this: " << std::string(this->type) << endl;
+            std::cout << "In TRestReflector::SetValue() : type unmatch! " << std::endl;
+            std::cout << "Input: " << GetTypeName<T>() << ", this: " << std::string(this->type) << std::endl;
             return;
         }
         if (address != nullptr) *((T*)(address)) = val;
@@ -383,7 +383,7 @@ class TRestReflector {
         cl = REST_Reflection::GetClassQuick<T>();
         DataType_Info dt = DataType_Info((T*)0);
         if (cl == nullptr && dt.size == 0) {
-            std::cout << "In TRestReflector::TRestReflector() : unrecognized type! " << endl;
+            std::cout << "In TRestReflector::TRestReflector() : unrecognized type! " << std::endl;
             return;
         }
 
@@ -449,7 +449,7 @@ class Converter : RESTVirtualConverter {
         ToStringFunc = _ToStringFunc;
         ParseStringFunc = _ParseStringFunc;
         if (RESTConverterMethodBase.count(type_name) > 0) {
-            std::cout << "Warning! converter for type: " << type_name << " already added!" << endl;
+            std::cout << "Warning! converter for type: " << type_name << " already added!" << std::endl;
         } else {
             RESTConverterMethodBase[type_name] = this;
         }

--- a/source/framework/tools/inc/TRestStringHelper.h
+++ b/source/framework/tools/inc/TRestStringHelper.h
@@ -50,7 +50,7 @@ std::string Replace(std::string in, std::string thisString, std::string byThisSt
 std::string EscapeSpecialLetters(std::string in);
 std::string ToDateTimeString(time_t time);
 time_t StringToTimeStamp(std::string time);
-REST_Verbose_Level StringToVerboseLevel(std::string in);
+TRestStringOutput::REST_Verbose_Level StringToVerboseLevel(std::string in);
 ULong64_t ToHash(std::string str);
 constexpr ULong64_t ToHash(const char* str, ULong64_t last_value = 0xCBF29CE484222325ull) {
     return *str ? ToHash(str + 1, (*str ^ last_value) * 0x100000001B3ull) : last_value;

--- a/source/framework/tools/inc/TRestStringOutput.h
+++ b/source/framework/tools/inc/TRestStringOutput.h
@@ -213,8 +213,8 @@ inline void PrintWelcome() { system("rest-config --welcome"); }
 // initialize formatted message output tool
 static TRestStringOutput RESTFout(TRestStringOutput::REST_Verbose_Level::REST_Silent, COLOR_BOLDBLUE,
                                   "[== ==]", TRestStringOutput::REST_Display_Orientation::kMiddle);
-static TRestStringOutput RESTFerr(TRestStringOutput::REST_Verbose_Level::REST_Silent, COLOR_BOLDRED,
-                                  "-- Error : ", TRestStringOutput::REST_Display_Orientation::kLeft, true);
+static TRestStringOutput RESTError(TRestStringOutput::REST_Verbose_Level::REST_Silent, COLOR_BOLDRED,
+                                   "-- Error : ", TRestStringOutput::REST_Display_Orientation::kLeft, true);
 static TRestStringOutput RESTWarning(TRestStringOutput::REST_Verbose_Level::REST_Warning, COLOR_BOLDYELLOW,
                                      "-- Warning : ", TRestStringOutput::REST_Display_Orientation::kLeft,
                                      true);

--- a/source/framework/tools/inc/TRestStringOutput.h
+++ b/source/framework/tools/inc/TRestStringOutput.h
@@ -23,47 +23,31 @@
 
 //////////////////////////////////////////////////////////////////////////
 /// String identifiers for terminal colors
-#define COLOR_RESET "\033[0m"
-#define COLOR_BLACK "\033[30m"                    /* Black */
-#define COLOR_RED "\033[31m"                      /* Red */
-#define COLOR_GREEN "\033[32m"                    /* Green */
-#define COLOR_YELLOW "\033[33m"                   /* Yellow */
-#define COLOR_BLUE "\033[34m"                     /* Blue */
-#define COLOR_MAGENTA "\033[35m"                  /* Magenta */
-#define COLOR_CYAN "\033[36m"                     /* Cyan */
-#define COLOR_WHITE "\033[37m"                    /* White */
-#define COLOR_BOLDBLACK "\033[1m\033[30m"         /* Bold Black */
-#define COLOR_BOLDRED "\033[1m\033[31m"           /* Bold Red */
-#define COLOR_BOLDGREEN "\033[1m\033[32m"         /* Bold Green */
-#define COLOR_BOLDYELLOW "\033[1m\033[33m"        /* Bold Yellow */
-#define COLOR_BOLDBLUE "\033[1m\033[34m"          /* Bold Blue */
-#define COLOR_BOLDMAGENTA "\033[1m\033[35m"       /* Bold Magenta */
-#define COLOR_BOLDCYAN "\033[1m\033[36m"          /* Bold Cyan */
-#define COLOR_BOLDWHITE "\033[1m\033[37m"         /* Bold White */
-#define COLOR_BACKGROUNDBLACK "\033[1m\033[40m"   /* BACKGROUND Black */
-#define COLOR_BACKGROUNDRED "\033[1m\033[41m"     /* BACKGROUND Red */
-#define COLOR_BACKGROUNDGREEN "\033[1m\033[42m"   /* BACKGROUND Green */
-#define COLOR_BACKGROUNDYELLOW "\033[1m\033[43m"  /* BACKGROUND Yellow */
-#define COLOR_BACKGROUNDBLUE "\033[1m\033[44m"    /* BACKGROUND Blue */
-#define COLOR_BACKGROUNDMAGENTA "\033[1m\033[45m" /* BACKGROUND Magenta */
-#define COLOR_BACKGROUNDCYAN "\033[1m\033[46m"    /* BACKGROUND Cyan */
-#define COLOR_BACKGROUNDWHITE "\033[1m\033[47m"   /* BACKGROUND White */
-
-//////////////////////////////////////////////////////////////////////////
-/// Enumerate of verbose level, containing five levels
-enum REST_Verbose_Level {
-    REST_Silent,     //!< show minimum information of the software, as well as error
-                     //!< messages
-    REST_Essential,  //!< +show some essential information, as well as warnings
-    REST_Info,       //!< +show most of the infomation for each steps
-    REST_Debug,      //!< +show the defined debug messages
-    REST_Extreme     //!< show everything
-};
-#define REST_Warning REST_Essential
-
-//////////////////////////////////////////////////////////////////////////
-/// Enumerate of TRestStringOutput display orientation
-enum REST_Display_Orientation { kLeft = 1, kMiddle = 0 };
+constexpr const char* const COLOR_RESET = "\033[0m";
+constexpr const char* const COLOR_BLACK = "\033[30m";                    /* Black */
+constexpr const char* const COLOR_RED = "\033[31m";                      /* Red */
+constexpr const char* const COLOR_GREEN = "\033[32m";                    /* Green */
+constexpr const char* const COLOR_YELLOW = "\033[33m";                   /* Yellow */
+constexpr const char* const COLOR_BLUE = "\033[34m";                     /* Blue */
+constexpr const char* const COLOR_MAGENTA = "\033[35m";                  /* Magenta */
+constexpr const char* const COLOR_CYAN = "\033[36m";                     /* Cyan */
+constexpr const char* const COLOR_WHITE = "\033[37m";                    /* White */
+constexpr const char* const COLOR_BOLDBLACK = "\033[1m\033[30m";         /* Bold Black */
+constexpr const char* const COLOR_BOLDRED = "\033[1m\033[31m";           /* Bold Red */
+constexpr const char* const COLOR_BOLDGREEN = "\033[1m\033[32m";         /* Bold Green */
+constexpr const char* const COLOR_BOLDYELLOW = "\033[1m\033[33m";        /* Bold Yellow */
+constexpr const char* const COLOR_BOLDBLUE = "\033[1m\033[34m";          /* Bold Blue */
+constexpr const char* const COLOR_BOLDMAGENTA = "\033[1m\033[35m";       /* Bold Magenta */
+constexpr const char* const COLOR_BOLDCYAN = "\033[1m\033[36m";          /* Bold Cyan */
+constexpr const char* const COLOR_BOLDWHITE = "\033[1m\033[37m";         /* Bold White */
+constexpr const char* const COLOR_BACKGROUNDBLACK = "\033[1m\033[40m";   /* BACKGROUND Black */
+constexpr const char* const COLOR_BACKGROUNDRED = "\033[1m\033[41m";     /* BACKGROUND Red */
+constexpr const char* const COLOR_BACKGROUNDGREEN = "\033[1m\033[42m";   /* BACKGROUND Green */
+constexpr const char* const COLOR_BACKGROUNDYELLOW = "\033[1m\033[43m";  /* BACKGROUND Yellow */
+constexpr const char* const COLOR_BACKGROUNDBLUE = "\033[1m\033[44m";    /* BACKGROUND Blue */
+constexpr const char* const COLOR_BACKGROUNDMAGENTA = "\033[1m\033[45m"; /* BACKGROUND Magenta */
+constexpr const char* const COLOR_BACKGROUNDCYAN = "\033[1m\033[46m";    /* BACKGROUND Cyan */
+constexpr const char* const COLOR_BACKGROUNDWHITE = "\033[1m\033[47m";   /* BACKGROUND White */
 
 //////////////////////////////////////////////////////////////////////////
 /// Console helper class, providing several static methods dealing with terminal
@@ -123,7 +107,7 @@ class Console {
 class TRestMetadata;
 struct endl_t {
     endl_t(TRestMetadata* ptr) { TRestMetadataPtr = ptr; }
-    TRestMetadata* TRestMetadataPtr = 0;
+    TRestMetadata* TRestMetadataPtr = nullptr;
     friend std::ostream& operator<<(std::ostream& a, endl_t& et) { return (a << std::endl); }
 };
 
@@ -137,12 +121,29 @@ struct endl_t {
 /// to initialize a local TRestStringOutput object. Then one can costomize output color,
 /// border and orientation on that.
 class TRestStringOutput {
+   public:
+    //////////////////////////////////////////////////////////////////////////
+    /// Enumerate of verbose level, containing five levels
+    enum class REST_Verbose_Level {
+        REST_Silent = 0,     //!< show minimum information of the software, as well as error
+                             //!< messages
+        REST_Essential = 1,  //!< +show some essential information, as well as warnings
+        REST_Warning = REST_Essential,
+        REST_Info = 2,    //!< +show most of the infomation for each steps
+        REST_Debug = 3,   //!< +show the defined debug messages
+        REST_Extreme = 4  //!< show everything
+    };
+
+    //////////////////////////////////////////////////////////////////////////
+    /// Enumerate of TRestStringOutput display orientation
+    enum class REST_Display_Orientation { kLeft = 1, kMiddle = 0 };
+
    protected:
     std::string color;
     std::string formatstring;
     bool useborder;
     bool iserror;
-    int orientation;  // 0->middle, 1->left
+    REST_Display_Orientation orientation;  // 0->middle, 1->left
 
     std::stringstream buf;
     int length;
@@ -153,6 +154,9 @@ class TRestStringOutput {
     void unlock();
 
    public:
+    REST_Verbose_Level GetVerboseLevel() { return verbose; }
+    std::string GetBuffer() { return buf.str(); }
+    bool isError() { return iserror; }
     std::string FormattingPrintString(std::string input);
     void resetstring();
     void flushstring();
@@ -169,61 +173,66 @@ class TRestStringOutput {
     }
     void resetborder() { formatstring = ""; }
     void setlength(int n);
-    void setorientation(int o) { orientation = o; }
-    void resetorientation() { orientation = 0; }
+    void setorientation(REST_Display_Orientation o) { orientation = o; }
+    void resetorientation() { orientation = REST_Display_Orientation::kMiddle; }
+    static void RESTendl(TRestStringOutput& input) { input.flushstring(); }
 
     // If formatter is in mirror form(e.g., "|| ||","< >"), it will use such border
     // to wrap the std::string to be displayed. otherwise the formatter is used as
     // prefix(e.g., "-- Warning: ")
-    TRestStringOutput(std::string color = COLOR_RESET, std::string formatter = "",
-                      REST_Display_Orientation orientation = kLeft);
+    TRestStringOutput(
+        std::string color = COLOR_RESET, std::string formatter = "",
+        REST_Display_Orientation orientation = TRestStringOutput::REST_Display_Orientation::kLeft);
 
-    TRestStringOutput(REST_Verbose_Level v, std::string _color = COLOR_RESET, std::string formatter = "",
-                      REST_Display_Orientation orientation = kLeft, bool _iserror = false)
+    TRestStringOutput(
+        REST_Verbose_Level v, std::string _color = COLOR_RESET, std::string formatter = "",
+        REST_Display_Orientation orientation = TRestStringOutput::REST_Display_Orientation::kLeft,
+        bool _iserror = false)
         : TRestStringOutput(_color, formatter, orientation) {
         verbose = v;
         iserror = _iserror;
     }
 
     template <class T>
-    TRestStringOutput& operator<<(T content) {
+    TRestStringOutput& operator<<(T const& content) {
         buf << content;
         return *this;
     }
 
     TRestStringOutput& operator<<(void (*pfunc)(TRestStringOutput&));
-
+    friend TRestStringOutput& operator<<(TRestMetadata& mt, TRestStringOutput& so);
     TRestStringOutput& operator<<(endl_t et);
 };
-
-namespace noClass {
-//////////////////////////////////////////////////////////////////////////
-/// \relates TRestStringOutput
-/// This method serves as an end-line mark for TRestStringOutput.
-///
-/// Calls TRestStringOutput to flushstring().
-///
-/// When calling `fout<<"hello world"<<endl;` outside metadata class, the pointer of
-/// method is passed to TRestStringOutput, who calls back to this method giving its
-/// reference. This logic is same as endl.
-inline void endl(TRestStringOutput& input) { input.flushstring(); }
-};  // namespace noClass
-using namespace noClass;
 
 /// \relates TRestStringOutput
 /// print a welcome message by calling shell script "rest-config"
 inline void PrintWelcome() { system("rest-config --welcome"); }
 
 /// formatted message output, used for print metadata
-extern TRestStringOutput fout;
-extern TRestStringOutput ferr;
-extern TRestStringOutput warning;
-extern TRestStringOutput essential;
-extern TRestStringOutput metadata;
-extern TRestStringOutput info;
-extern TRestStringOutput success;
-extern TRestStringOutput debug;
-extern TRestStringOutput extreme;
+// initialize formatted message output tool
+// initialize formatted message output tool
+static TRestStringOutput RESTFout(TRestStringOutput::REST_Verbose_Level::REST_Silent, COLOR_BOLDBLUE,
+                                  "[== ==]", TRestStringOutput::REST_Display_Orientation::kMiddle);
+static TRestStringOutput RESTFerr(TRestStringOutput::REST_Verbose_Level::REST_Silent, COLOR_BOLDRED,
+                                  "-- Error : ", TRestStringOutput::REST_Display_Orientation::kLeft, true);
+static TRestStringOutput RESTWarning(TRestStringOutput::REST_Verbose_Level::REST_Warning, COLOR_BOLDYELLOW,
+                                     "-- Warning : ", TRestStringOutput::REST_Display_Orientation::kLeft,
+                                     true);
+static TRestStringOutput RESTEssential(TRestStringOutput::REST_Verbose_Level::REST_Essential, COLOR_BOLDGREEN,
+                                       "", TRestStringOutput::REST_Display_Orientation::kMiddle);
+static TRestStringOutput RESTMetadata(TRestStringOutput::REST_Verbose_Level::REST_Essential, COLOR_BOLDGREEN,
+                                      "|| ||", TRestStringOutput::REST_Display_Orientation::kMiddle);
+static TRestStringOutput RESTInfo(TRestStringOutput::REST_Verbose_Level::REST_Info, COLOR_BLUE,
+                                  "-- Info : ", TRestStringOutput::REST_Display_Orientation::kLeft);
+static TRestStringOutput RESTSuccess(TRestStringOutput::REST_Verbose_Level::REST_Info, COLOR_GREEN,
+                                     "-- Success : ", TRestStringOutput::REST_Display_Orientation::kLeft);
+static TRestStringOutput RESTDebug(TRestStringOutput::REST_Verbose_Level::REST_Debug, COLOR_RESET,
+                                   "-- Debug : ", TRestStringOutput::REST_Display_Orientation::kLeft);
+static TRestStringOutput RESTExtreme(TRestStringOutput::REST_Verbose_Level::REST_Extreme, COLOR_RESET,
+                                     "-- Extreme : ", TRestStringOutput::REST_Display_Orientation::kLeft);
 
-extern REST_Verbose_Level gVerbose;
+static void RESTendl(TRestStringOutput& input) { input.flushstring(); }
+
+extern TRestStringOutput::REST_Verbose_Level gVerbose;
+
 #endif

--- a/source/framework/tools/inc/TRestStringOutput.h
+++ b/source/framework/tools/inc/TRestStringOutput.h
@@ -211,7 +211,7 @@ inline void PrintWelcome() { system("rest-config --welcome"); }
 /// formatted message output, used for print metadata
 // initialize formatted message output tool
 // initialize formatted message output tool
-static TRestStringOutput RESTFout(TRestStringOutput::REST_Verbose_Level::REST_Silent, COLOR_BOLDBLUE,
+static TRestStringOutput RESTcout(TRestStringOutput::REST_Verbose_Level::REST_Silent, COLOR_BOLDBLUE,
                                   "[== ==]", TRestStringOutput::REST_Display_Orientation::kMiddle);
 static TRestStringOutput RESTError(TRestStringOutput::REST_Verbose_Level::REST_Silent, COLOR_BOLDRED,
                                    "-- Error : ", TRestStringOutput::REST_Display_Orientation::kLeft, true);

--- a/source/framework/tools/src/TRestDataBase.cxx
+++ b/source/framework/tools/src/TRestDataBase.cxx
@@ -108,7 +108,7 @@ DBFile DBFile::ParseFile(string _filename) {
     int result = stat(_fullname.c_str(), &buf);
 
     if (result != 0) {
-        ferr << "DBFile::ParseFile: Failed to load file \"" << _fullname << "\"!" << endl;
+        RESTFerr << "DBFile::ParseFile: Failed to load file \"" << _fullname << "\"!" << RESTendl;
     } else {
         file.fileSize = buf.st_size;
         file.evtRate = 0;
@@ -194,9 +194,9 @@ int TRestDataBase::set_run(DBEntry info, bool overwrite) {
     if (TRestTools::isPathWritable(REST_USER_PATH)) {
         TRestTools::Execute("echo " + ToString(newRunNr + 1) + " > " + runFilename);
     } else {
-        warning << "runNumber file not writable. auto run number "
-                   "increment is disabled"
-                << endl;
+        RESTWarning << "runNumber file not writable. auto run number "
+                       "increment is disabled"
+                    << RESTendl;
     }
 
     return newRunNr;
@@ -230,7 +230,7 @@ DBEntry TRestDataBase::query_data(DBEntry _info) {
     if (match.size() == 1) {
         return match[0];
     } else if (match.size() > 1) {
-        warning << "multiple metadata found! returning the first!" << endl;
+        RESTWarning << "multiple metadata found! returning the first!" << RESTendl;
         return match[0];
     } else {
         return DBEntry();

--- a/source/framework/tools/src/TRestDataBase.cxx
+++ b/source/framework/tools/src/TRestDataBase.cxx
@@ -108,7 +108,7 @@ DBFile DBFile::ParseFile(string _filename) {
     int result = stat(_fullname.c_str(), &buf);
 
     if (result != 0) {
-        RESTFerr << "DBFile::ParseFile: Failed to load file \"" << _fullname << "\"!" << RESTendl;
+        RESTError << "DBFile::ParseFile: Failed to load file \"" << _fullname << "\"!" << RESTendl;
     } else {
         file.fileSize = buf.st_size;
         file.evtRate = 0;

--- a/source/framework/tools/src/TRestStringHelper.cxx
+++ b/source/framework/tools/src/TRestStringHelper.cxx
@@ -105,8 +105,8 @@ std::string REST_StringHelper::ReplaceMathematicalExpressions(std::string buffer
         string evaluated = EvaluateExpression(Expressions[i]);
         if (evaluated == "RESTerror") {
             result += Expressions[i] + ",";
-            RESTFerr << "ReplaceMathematicalExpressions. Error on RML syntax!" << RESTendl;
-            if (errorMessage != "") RESTFerr << errorMessage << RESTendl;
+            RESTError << "ReplaceMathematicalExpressions. Error on RML syntax!" << RESTendl;
+            if (errorMessage != "") RESTError << errorMessage << RESTendl;
         } else
             result += evaluated + ",";
     }

--- a/source/framework/tools/src/TRestStringHelper.cxx
+++ b/source/framework/tools/src/TRestStringHelper.cxx
@@ -21,18 +21,16 @@ using namespace std;
 /// \brief Returns 1 only if valid mathematical expression keywords (or numbers)
 /// are found in the string **in**. If not it returns 0.
 ///
-/// By logic, mathematical expressions must have: +-*/e^% in the middle, or % in the end, or math functions in the beginning.
-/// despite those symbols, the string should be purely numeric.
-/// example: 
-/// 1+1 --> expression
+/// By logic, mathematical expressions must have: +-*/e^% in the middle, or % in the end, or math functions in
+/// the beginning. despite those symbols, the string should be purely numeric. example: 1+1 --> expression
 /// sin(1.5) --> expression
 /// 123456789 --> not expression, It is a pure number that can be directly parsed.
 /// ./123 --> not expression, it is a path
 /// 333/555 --> is expression. But it may also be a path. We should avoid using paths like that
 Int_t REST_StringHelper::isAExpression(const string& in) {
     bool symbol = false;
-    
-    if (in.length() < 2) // minimum expression: 3%
+
+    if (in.length() < 2)  // minimum expression: 3%
         return 0;
 
     vector<string> funcs{"sqrt", "log", "exp", "gaus", "cos", "sin", "tan", "atan", "acos", "asin"};
@@ -44,16 +42,16 @@ Int_t REST_StringHelper::isAExpression(const string& in) {
     }
 
     if (!symbol) {
-		int pos = in.find_first_of("+-*/e^%");
-		if (pos > 0 && pos < in.size() - 1) {
-			symbol = true;
-		}
-	}
+        int pos = in.find_first_of("+-*/e^%");
+        if (pos > 0 && pos < in.size() - 1) {
+            symbol = true;
+        }
+    }
 
-	if (!symbol) {
-		int pos = in.find_first_of("%");
-		if (pos == in.size() - 1) {
-			symbol = true;
+    if (!symbol) {
+        int pos = in.find_first_of("%");
+        if (pos == in.size() - 1) {
+            symbol = true;
         }
     }
 
@@ -67,9 +65,7 @@ Int_t REST_StringHelper::isAExpression(const string& in) {
                 return 0;  // identify path
             return 1;
         }
-    }
-    else
-    {
+    } else {
         return 0;
     }
 
@@ -109,8 +105,8 @@ std::string REST_StringHelper::ReplaceMathematicalExpressions(std::string buffer
         string evaluated = EvaluateExpression(Expressions[i]);
         if (evaluated == "RESTerror") {
             result += Expressions[i] + ",";
-            ferr << "ReplaceMathematicalExpressions. Error on RML syntax!" << endl;
-            if (errorMessage != "") ferr << errorMessage << endl;
+            RESTFerr << "ReplaceMathematicalExpressions. Error on RML syntax!" << RESTendl;
+            if (errorMessage != "") RESTFerr << errorMessage << RESTendl;
         } else
             result += evaluated + ",";
     }
@@ -144,7 +140,8 @@ std::string REST_StringHelper::EvaluateExpression(std::string exp) {
     ostringstream sss;
     Double_t number = formula.EvalPar(0);
     if (number > 0 && number < 1.e-300) {
-        warning << "REST_StringHelper::EvaluateExpresssion. Expression not recognized --> " << exp << endl;
+        RESTWarning << "REST_StringHelper::EvaluateExpresssion. Expression not recognized --> " << exp
+                    << RESTendl;
         return (string) "RESTerror";
     }
 
@@ -479,14 +476,15 @@ time_t REST_StringHelper::StringToTimeStamp(string time) {
     return time1;
 }
 
-REST_Verbose_Level REST_StringHelper::StringToVerboseLevel(string in) {
-    if (ToUpper(in) == "SILENT" || in == "0") return REST_Silent;
-    if (ToUpper(in) == "ESSENTIAL" || ToUpper(in) == "WARNING" || in == "1") return REST_Essential;
-    if (ToUpper(in) == "INFO" || in == "2") return REST_Info;
-    if (ToUpper(in) == "DEBUG" || in == "3") return REST_Debug;
-    if (ToUpper(in) == "EXTREME" || in == "4") return REST_Extreme;
+TRestStringOutput::REST_Verbose_Level REST_StringHelper::StringToVerboseLevel(string in) {
+    if (ToUpper(in) == "SILENT" || in == "0") return TRestStringOutput::REST_Verbose_Level::REST_Silent;
+    if (ToUpper(in) == "ESSENTIAL" || ToUpper(in) == "WARNING" || in == "1")
+        return TRestStringOutput::REST_Verbose_Level::REST_Essential;
+    if (ToUpper(in) == "INFO" || in == "2") return TRestStringOutput::REST_Verbose_Level::REST_Info;
+    if (ToUpper(in) == "DEBUG" || in == "3") return TRestStringOutput::REST_Verbose_Level::REST_Debug;
+    if (ToUpper(in) == "EXTREME" || in == "4") return TRestStringOutput::REST_Verbose_Level::REST_Extreme;
 
-    return REST_Essential;
+    return TRestStringOutput::REST_Verbose_Level::REST_Essential;
 }
 
 ///////////////////////////////////////////////

--- a/source/framework/tools/src/TRestStringOutput.cxx
+++ b/source/framework/tools/src/TRestStringOutput.cxx
@@ -214,7 +214,7 @@ TRestStringOutput::TRestStringOutput(string _color, string formatter, REST_Displ
         Console::CompatibilityMode = true;
     }
 
-    verbose = REST_Essential;
+    verbose = REST_Verbose_Level::REST_Essential;
 }
 
 void TRestStringOutput::resetstring() {
@@ -238,7 +238,7 @@ string TRestStringOutput::FormattingPrintString(string input) {
         int Lfmt = formatstring.size();
 
         int startblank;
-        if (useborder || orientation == kMiddle) {
+        if (useborder || orientation == TRestStringOutput::REST_Display_Orientation::kMiddle) {
             startblank = (length - Lstr) / 2;
         } else {
             startblank = Lfmt;
@@ -286,18 +286,18 @@ void TRestStringOutput::setlength(int n) {
 void TRestStringOutput::flushstring() {
     if (Console::CompatibilityMode)  // this means we are using condor
     {
-        std::cout << buf.str() << endl;
+        std::cout << buf.str() << std::endl;
     } else {
         printf("\033[K");
-        if (orientation == kMiddle) {
+        if (orientation == TRestStringOutput::REST_Display_Orientation::kMiddle) {
             // we always reset the length of TRestStringOutput in case the console is resized
             setlength(TRestStringOutput_BestLength);
             int blankwidth = (Console::GetWidth() - 2 - length) / 2;
 
             std::cout << color << string(blankwidth, ' ') << FormattingPrintString(buf.str())
-                      << string(blankwidth, ' ') << COLOR_RESET << endl;
+                      << string(blankwidth, ' ') << COLOR_RESET << std::endl;
         } else {
-            std::cout << color << FormattingPrintString(buf.str()) << COLOR_RESET << endl;
+            std::cout << color << FormattingPrintString(buf.str()) << COLOR_RESET << std::endl;
         }
     }
     resetstring();

--- a/source/framework/tools/src/TRestSystemOfUnits.cxx
+++ b/source/framework/tools/src/TRestSystemOfUnits.cxx
@@ -280,7 +280,7 @@ TRestSystemOfUnits::TRestSystemOfUnits(string unitsStr) {
                         orderprefix = -1;
                     } else if (unitsStr[pos1 - 1] == '-' || unitsStr[pos1 - 1] == '*') {
                     } else {
-                        warning << "illegeal unit combiner \"" << unitsStr[pos1 - 1] << "\"" << endl;
+                        RESTWarning << "illegeal unit combiner \"" << unitsStr[pos1 - 1] << "\"" << RESTendl;
                     }
                 }
 
@@ -315,8 +315,8 @@ TRestSystemOfUnits::TRestSystemOfUnits(string unitsStr) {
             //            << endl;
             //}
             if (pos == unitsStr.size() - 1) {
-                warning << "last character inside \"" << unitsStr << "\" \"" << unitsStr[pos]
-                        << "\" unrecognized in unit definition!" << endl;
+                RESTWarning << "last character inside \"" << unitsStr << "\" \"" << unitsStr[pos]
+                            << "\" unrecognized in unit definition!" << RESTendl;
             }
 
             pos++;

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -142,7 +142,7 @@ template <typename T>
 int TRestTools::ExportASCIITable(std::string fname, std::vector<std::vector<T>>& data) {
     ofstream file(fname);
     if (!file.is_open()) {
-        ferr << "Unable to open file for writing : " << fname << endl;
+        RESTFerr << "Unable to open file for writing : " << fname << RESTendl;
         return 1;
     }
 
@@ -171,7 +171,7 @@ template <typename T>
 int TRestTools::ExportBinaryTable(std::string fname, std::vector<std::vector<T>>& data) {
     ofstream file(fname, ios::out | ios::binary);
     if (!file.is_open()) {
-        ferr << "Unable to open file for writing : " << fname << endl;
+        RESTFerr << "Unable to open file for writing : " << fname << RESTendl;
         return 1;
     }
 
@@ -209,16 +209,16 @@ template int TRestTools::ExportBinaryTable<Double_t>(std::string fname,
 template <typename T>
 int TRestTools::ReadBinaryTable(string fName, std::vector<std::vector<T>>& data, Int_t columns) {
     if (!TRestTools::isValidFile((string)fName)) {
-        ferr << "TRestTools::ReadBinaryTable. Error." << endl;
-        ferr << "Cannot open file : " << fName << endl;
+        RESTFerr << "TRestTools::ReadBinaryTable. Error." << RESTendl;
+        RESTFerr << "Cannot open file : " << fName << RESTendl;
         return 0;
     }
 
     if (columns == -1) {
         columns = GetBinaryFileColumns(fName);
         if (columns == -1) {
-            ferr << "TRestTools::ReadBinaryTable. Format extension error." << endl;
-            ferr << "Please, specify the number of columns at the method 3rd argument" << endl;
+            RESTFerr << "TRestTools::ReadBinaryTable. Format extension error." << RESTendl;
+            RESTFerr << "Please, specify the number of columns at the method 3rd argument" << RESTendl;
             return 0;
         }
     }
@@ -290,7 +290,7 @@ int TRestTools::GetBinaryFileColumns(string fname) {
         return StringToInteger(extension.substr(1, pos - 1));
     }
 
-    ferr << "Format " << ToUpper(extension) << " not recognized" << endl;
+    RESTFerr << "Format " << ToUpper(extension) << " not recognized" << RESTendl;
     return -1;
 }
 
@@ -948,10 +948,10 @@ std::string TRestTools::DownloadRemoteFile(string url) {
         do {
             out = TRestTools::DownloadRemoteFile(url, fullpath);
             if (out == 1024) {
-                warning << "Retrying download in 5 seconds" << endl;
+                RESTWarning << "Retrying download in 5 seconds" << RESTendl;
                 std::this_thread::sleep_for(std::chrono::seconds(5));
             } else if (attempts < 10) {
-                success << "Download suceeded after " << 10 - attempts << " attempts" << endl;
+                RESTSuccess << "Download suceeded after " << 10 - attempts << " attempts" << RESTendl;
             }
             attempts--;
         } while (out == 1024 && attempts > 0);
@@ -976,8 +976,8 @@ std::string TRestTools::DownloadRemoteFile(string url) {
 int TRestTools::DownloadRemoteFile(string remoteFile, string localFile) {
     TUrl url(remoteFile.c_str());
 
-    info << "Downloading remote file : " << remoteFile << endl;
-    info << "To local file : " << localFile << endl;
+    RESTInfo << "Downloading remote file : " << remoteFile << RESTendl;
+    RESTInfo << "To local file : " << localFile << RESTendl;
 
     string localFiletmp = localFile + ".restdownload";
     if ((string)url.GetProtocol() == "https" || (string)url.GetProtocol() == "http") {
@@ -988,20 +988,20 @@ int TRestTools::DownloadRemoteFile(string remoteFile, string localFile) {
 
         string cmd = "wget --no-check-certificate " + EscapeSpecialLetters(remoteFile) + " -O " +
                      EscapeSpecialLetters(localFiletmp) + " -q";
-        debug << cmd << endl;
+        RESTDebug << cmd << RESTendl;
         int a = system(cmd.c_str());
 
         if (a == 0) {
             rename(localFiletmp.c_str(), localFile.c_str());
             return 0;
         } else {
-            ferr << "download failed! (" << remoteFile << ")" << endl;
+            RESTFerr << "download failed! (" << remoteFile << ")" << RESTendl;
             if (a == 1024) {
-                ferr << "Network connection problem?" << endl;
+                RESTFerr << "Network connection problem?" << RESTendl;
                 return 1024;
             }
             if (a == 2048) {
-                ferr << "File does NOT exist in remotely?" << endl;
+                RESTFerr << "File does NOT exist in remotely?" << RESTendl;
                 return 2048;
             }
         }
@@ -1015,7 +1015,7 @@ int TRestTools::DownloadRemoteFile(string remoteFile, string localFile) {
             return 0;
         }
     } else {
-        ferr << "unknown protocol!" << endl;
+        RESTFerr << "unknown protocol!" << RESTendl;
     }
 
     return -1;
@@ -1059,7 +1059,8 @@ std::string TRestTools::POSTRequest(const std::string& url, const std::map<std::
         /* Perform the request, res will get the return code */
         res = curl_easy_perform(curl);
         /* Check for errors */
-        if (res != CURLE_OK) ferr << "curl_easy_perform() failed: " << curl_easy_strerror(res) << endl;
+        if (res != CURLE_OK)
+            RESTFerr << "curl_easy_perform() failed: " << curl_easy_strerror(res) << RESTendl;
 
         /* always cleanup */
         curl_easy_cleanup(curl);
@@ -1069,10 +1070,11 @@ std::string TRestTools::POSTRequest(const std::string& url, const std::map<std::
 
     std::getline(std::ifstream(filename), file_content, '\0');
 #else
-    ferr << "TRestTools::POSTRequest. REST framework was compiled without CURL support" << endl;
-    ferr << "Please recompile REST after installing curl development libraries." << endl;
-    ferr << "Depending on your system this might be: curl-dev, curl-devel or libcurl-openssl-dev. " << endl;
-    ferr << "No file will be downloaded" << endl;
+    RESTFerr << "TRestTools::POSTRequest. REST framework was compiled without CURL support" << RESTendl;
+    RESTFerr << "Please recompile REST after installing curl development libraries." << RESTendl;
+    RESTFerr << "Depending on your system this might be: curl-dev, curl-devel or libcurl-openssl-dev. "
+             << RESTendl;
+    RESTFerr << "No file will be downloaded" << RESTendl;
 #endif
 
     return file_content;
@@ -1109,11 +1111,11 @@ int TRestTools::UploadToServer(string localFile, string remoteFile, string metho
         int a = system(cmd.c_str());
 
         if (a != 0) {
-            ferr << __PRETTY_FUNCTION__ << endl;
-            ferr << "problem copying gases definitions to remote server" << endl;
-            ferr << "Please report this problem at "
-                    "http://gifna.unizar.es/rest-forum/"
-                 << endl;
+            RESTFerr << __PRETTY_FUNCTION__ << RESTendl;
+            RESTFerr << "problem copying gases definitions to remote server" << RESTendl;
+            RESTFerr << "Please report this problem at "
+                        "http://gifna.unizar.es/rest-forum/"
+                     << RESTendl;
             return -1;
         }
 

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -142,7 +142,7 @@ template <typename T>
 int TRestTools::ExportASCIITable(std::string fname, std::vector<std::vector<T>>& data) {
     ofstream file(fname);
     if (!file.is_open()) {
-        RESTFerr << "Unable to open file for writing : " << fname << RESTendl;
+        RESTError << "Unable to open file for writing : " << fname << RESTendl;
         return 1;
     }
 
@@ -171,7 +171,7 @@ template <typename T>
 int TRestTools::ExportBinaryTable(std::string fname, std::vector<std::vector<T>>& data) {
     ofstream file(fname, ios::out | ios::binary);
     if (!file.is_open()) {
-        RESTFerr << "Unable to open file for writing : " << fname << RESTendl;
+        RESTError << "Unable to open file for writing : " << fname << RESTendl;
         return 1;
     }
 
@@ -209,16 +209,16 @@ template int TRestTools::ExportBinaryTable<Double_t>(std::string fname,
 template <typename T>
 int TRestTools::ReadBinaryTable(string fName, std::vector<std::vector<T>>& data, Int_t columns) {
     if (!TRestTools::isValidFile((string)fName)) {
-        RESTFerr << "TRestTools::ReadBinaryTable. Error." << RESTendl;
-        RESTFerr << "Cannot open file : " << fName << RESTendl;
+        RESTError << "TRestTools::ReadBinaryTable. Error." << RESTendl;
+        RESTError << "Cannot open file : " << fName << RESTendl;
         return 0;
     }
 
     if (columns == -1) {
         columns = GetBinaryFileColumns(fName);
         if (columns == -1) {
-            RESTFerr << "TRestTools::ReadBinaryTable. Format extension error." << RESTendl;
-            RESTFerr << "Please, specify the number of columns at the method 3rd argument" << RESTendl;
+            RESTError << "TRestTools::ReadBinaryTable. Format extension error." << RESTendl;
+            RESTError << "Please, specify the number of columns at the method 3rd argument" << RESTendl;
             return 0;
         }
     }
@@ -290,7 +290,7 @@ int TRestTools::GetBinaryFileColumns(string fname) {
         return StringToInteger(extension.substr(1, pos - 1));
     }
 
-    RESTFerr << "Format " << ToUpper(extension) << " not recognized" << RESTendl;
+    RESTError << "Format " << ToUpper(extension) << " not recognized" << RESTendl;
     return -1;
 }
 
@@ -995,13 +995,13 @@ int TRestTools::DownloadRemoteFile(string remoteFile, string localFile) {
             rename(localFiletmp.c_str(), localFile.c_str());
             return 0;
         } else {
-            RESTFerr << "download failed! (" << remoteFile << ")" << RESTendl;
+            RESTError << "download failed! (" << remoteFile << ")" << RESTendl;
             if (a == 1024) {
-                RESTFerr << "Network connection problem?" << RESTendl;
+                RESTError << "Network connection problem?" << RESTendl;
                 return 1024;
             }
             if (a == 2048) {
-                RESTFerr << "File does NOT exist in remotely?" << RESTendl;
+                RESTError << "File does NOT exist in remotely?" << RESTendl;
                 return 2048;
             }
         }
@@ -1015,7 +1015,7 @@ int TRestTools::DownloadRemoteFile(string remoteFile, string localFile) {
             return 0;
         }
     } else {
-        RESTFerr << "unknown protocol!" << RESTendl;
+        RESTError << "unknown protocol!" << RESTendl;
     }
 
     return -1;
@@ -1060,7 +1060,7 @@ std::string TRestTools::POSTRequest(const std::string& url, const std::map<std::
         res = curl_easy_perform(curl);
         /* Check for errors */
         if (res != CURLE_OK)
-            RESTFerr << "curl_easy_perform() failed: " << curl_easy_strerror(res) << RESTendl;
+            RESTError << "curl_easy_perform() failed: " << curl_easy_strerror(res) << RESTendl;
 
         /* always cleanup */
         curl_easy_cleanup(curl);
@@ -1070,11 +1070,11 @@ std::string TRestTools::POSTRequest(const std::string& url, const std::map<std::
 
     std::getline(std::ifstream(filename), file_content, '\0');
 #else
-    RESTFerr << "TRestTools::POSTRequest. REST framework was compiled without CURL support" << RESTendl;
-    RESTFerr << "Please recompile REST after installing curl development libraries." << RESTendl;
-    RESTFerr << "Depending on your system this might be: curl-dev, curl-devel or libcurl-openssl-dev. "
-             << RESTendl;
-    RESTFerr << "No file will be downloaded" << RESTendl;
+    RESTError << "TRestTools::POSTRequest. REST framework was compiled without CURL support" << RESTendl;
+    RESTError << "Please recompile REST after installing curl development libraries." << RESTendl;
+    RESTError << "Depending on your system this might be: curl-dev, curl-devel or libcurl-openssl-dev. "
+              << RESTendl;
+    RESTError << "No file will be downloaded" << RESTendl;
 #endif
 
     return file_content;
@@ -1111,11 +1111,11 @@ int TRestTools::UploadToServer(string localFile, string remoteFile, string metho
         int a = system(cmd.c_str());
 
         if (a != 0) {
-            RESTFerr << __PRETTY_FUNCTION__ << RESTendl;
-            RESTFerr << "problem copying gases definitions to remote server" << RESTendl;
-            RESTFerr << "Please report this problem at "
-                        "http://gifna.unizar.es/rest-forum/"
-                     << RESTendl;
+            RESTError << __PRETTY_FUNCTION__ << RESTendl;
+            RESTError << "problem copying gases definitions to remote server" << RESTendl;
+            RESTError << "Please report this problem at "
+                         "http://gifna.unizar.es/rest-forum/"
+                      << RESTendl;
             return -1;
         }
 


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Large: 1276](https://badgen.net/badge/PR%20Size/Large%3A%201276/red) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/RESTendl/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/RESTendl)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR try to address the misleading use of custom `endl` and renames the different custom logger functions:
- Renamed custom `endl` to `RESTendl`. Note that we have 2 different ´RESTendl´. `endl_t RESTendl` inside `TRestMetadata` and `static RESTendl` inside `TRestStringOuput`. However, the implementation has not been changed.
- Renamed other logger functions
  - `info` --> `RESTInfo`  
  - `debug` --> `RESTDebug`
  - `essential` --> `RESTEssential`
  - `warning` --> `RESTWarning`
  - `fout` --> `RESTcout`
  - `ferr` --> `RESTError`
- Added `REST_Verbose_Level` enum inside `TRestStringOuput` class, now verbosity is written as `TRestStringOutput::REST_Verbose_Level::REST_XXXX`.
-  Added `REST_Display_Orientation` enum inside  `TRestStringOuput.h`
- Removal of extern functions from `startup.cpp` now the custom loggers are defined as `static` functions inside `TRestStringOuput.h`
- Removal of `define COLOR_XXX` inside `TRestStringOuput.h`, using `constexpr const char* const COLOR_` instead.

Related PR:
- https://github.com/rest-for-physics/detectorlib/pull/49
- https://github.com/rest-for-physics/geant4lib/pull/49
- https://github.com/rest-for-physics/rawlib/pull/63
- https://github.com/rest-for-physics/tracklib/pull/17
- https://github.com/rest-for-physics/connectorslib/pull/13
- https://github.com/rest-for-physics/axionlib/pull/24
- https://github.com/rest-for-physics/restG4/pull/47