### PR TITLE
CMakeLists.txt adding std++fs linking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ find_package(ROOT REQUIRED COMPONENTS ${ROOT_REQUIRED_LIBRARIES})
 
 message(STATUS "ROOT LIBRARIES: ${ROOT_LIBRARIES}")
 
-set(external_libs "${external_libs};${ROOT_LIBRARIES}")
+set(external_libs "${external_libs};${ROOT_LIBRARIES};stdc++fs")
 
 set(ROOTCINT_EXECUTABLE ${ROOT_rootcint_CMD})
 


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_build_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_build_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I found out that I need to add this fix in order to be able to compile at sultan2, strange ... but