### PR TITLE
Fix potential issue in pre-commit submodule hooks

### DIFF
--- a/cmake/GitHooks.cmake
+++ b/cmake/GitHooks.cmake
@@ -13,13 +13,12 @@ if (NOT EXISTS ${PROJECT_SOURCE_DIR}/.git)
     return()
 endif ()
 
-if (EXISTS ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
+if (NOT EXISTS ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
+    # We cannot write the file from here because we need exec permissions
+    configure_file(${CMAKE_SOURCE_DIR}/cmake/utils/git_pre-commit.in ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
+else ()
     message(DEBUG "git hook found at ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit")
-    return()
 endif ()
-
-# We cannot write the file from here because we need exec permissions
-configure_file(${CMAKE_SOURCE_DIR}/cmake/utils/git_pre-commit.in ${PROJECT_SOURCE_DIR}/.git/hooks/pre-commit)
 
 find_package(Git)
 


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 4](https://badgen.net/badge/PR%20Size/Ok%3A%204/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/submodule-pre-commit-fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/submodule-pre-commit-fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Found in https://github.com/rest-for-physics/geant4lib/pull/50#issuecomment-1137076035 that pre-commit hooks are not working for submodules in case cmake was performed between these 2 PR:
- https://github.com/rest-for-physics/framework/pull/203
- https://github.com/rest-for-physics/framework/pull/208

Now the existence of the `pre-commit` submodule `hook` is checked every time, independenty of the `pre-commmit` present in `framework`