### PR TITLE
Work around to avoid return when test are enabled

### DIFF
--- a/source/framework/core/src/startup.cpp
+++ b/source/framework/core/src/startup.cpp
@@ -27,10 +27,7 @@ map<string, RESTVirtualConverter*> RESTConverterMethodBase = {};
 struct __REST_CONST_INIT {
    public:
     __REST_CONST_INIT() {
-// TODO: fix to avoid this dirty fix
-#ifdef REST_TESTING_ENABLED
-        return;
-#endif
+
         REST_COMMIT = TRestTools::Execute("rest-config --commit");
 
         char* _REST_PATH = getenv("REST_PATH");
@@ -38,15 +35,18 @@ struct __REST_CONST_INIT {
         char* _REST_USERHOME = getenv("HOME");
 
         if (_REST_PATH == nullptr) {
-            cout << "REST ERROR!! Lacking system env \"REST_PATH\"! Cannot start!" << endl;
-            cout << "You need to source \"thisREST.sh\" first" << endl;
+            RESTError << "Lacking system env \"REST_PATH\"! Cannot start!" << RESTendl;
+            RESTError << "You need to source \"thisREST.sh\" first" << RESTendl;
+            #ifndef REST_TESTING_ENABLED
             abort();
+            #endif
+        } else {
+            REST_PATH = _REST_PATH;
         }
-        REST_PATH = _REST_PATH;
 
         if (_REST_USER == nullptr) {
-            cout << "REST WARNING!! Lacking system env \"USER\"!" << endl;
-            cout << "Setting user name to : \"defaultUser\"" << endl;
+            RESTWarning << "Lacking system env \"USER\"!" << RESTendl;
+            RESTWarning << "Setting user name to : \"defaultUser\"" << RESTendl;
             REST_USER = "defaultUser";
             setenv("USER", REST_USER.c_str(), true);
 
@@ -55,8 +55,8 @@ struct __REST_CONST_INIT {
         }
 
         if (_REST_USERHOME == nullptr) {
-            cout << "REST WARNING!! Lacking system env \"HOME\"!" << endl;
-            cout << "Setting REST temp path to : " << REST_PATH + "/data" << endl;
+            RESTWarning << "Lacking system env \"HOME\"!" << RESTendl;
+            RESTWarning << "Setting REST temp path to : " << REST_PATH + "/data" << RESTendl;
             REST_USER_PATH = REST_PATH + "/data";
         } else {
             string restUserPath = (string)_REST_USERHOME + "/.rest";


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 11](https://badgen.net/badge/PR%20Size/Ok%3A%2011/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/issue169/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/issue169)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Potential fix for #169 
- Now `REST_PATH` is not set in case of testing are enabled. I checked that is working fine with the test currently implemented, however we might have potential issues in case `REST_PATH` is required. However, `REST_PATH` cannot be set during test since installation path is not present at this stage...
- Doesn't change the logic when test are disabled.
- Added new`RESTError` and `RESTWarning` functions instead of `std::cout`