### PR TITLE
Simplified some of TRestTools methods using `<filesystem>` and avoid usage of env variables

### DIFF
--- a/source/framework/core/src/TRestGDMLParser.cxx
+++ b/source/framework/core/src/TRestGDMLParser.cxx
@@ -84,12 +84,11 @@ void TRestGDMLParser::Load(const string& filename) {
 TGeoManager* TRestGDMLParser::CreateGeoManager() {
     // We must change to the gdml file directory, otherwise ROOT cannot load.
     if (!fOutputGdmlFilename.empty()) {
-        char originDirectory[256];
-        sprintf(originDirectory, "%s", getenv("PWD"));
-        chdir(fOutputGdmlDirectory.c_str());
+        const auto currentPath = filesystem::current_path();
+        filesystem::current_path(fOutputGdmlDirectory);
         auto geoManager = new TGeoManager();
         geoManager->Import(fOutputGdmlFilename.c_str());
-        chdir(originDirectory);
+        filesystem::current_path(currentPath);
         return geoManager;
     }
     return nullptr;

--- a/source/framework/core/src/TRestGDMLParser.cxx
+++ b/source/framework/core/src/TRestGDMLParser.cxx
@@ -119,7 +119,7 @@ void TRestGDMLParser::ReplaceEntity() {
             }
             entityFile = entityField;
         } else {
-            entityFile = fPath + entityFile;
+            entityFile = fPath + "/" + entityFile;
         }
 
         int pos5 = 0;

--- a/source/framework/core/src/TRestGDMLParser.cxx
+++ b/source/framework/core/src/TRestGDMLParser.cxx
@@ -14,70 +14,69 @@ string TRestGDMLParser::GetEntityVersion(const string& name) const {
 }
 
 void TRestGDMLParser::Load(const string& filename) {
-    const auto filenameAbsolute = TRestTools::ToAbsoluteName(filename);
-    if (TRestTools::fileExists(filenameAbsolute)) {
-        fConfigFileName = filenameAbsolute;
-        fPath = TRestTools::SeparatePathAndName(filenameAbsolute).first;
-
-        std::ifstream t(filenameAbsolute);
-        std::string str((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
-        fFileString = str;
-        t.close();
-
-        int pp = fFileString.find("##VERSION", 0);
-        if (pp != string::npos) {
-            int pp2 = fFileString.find("##", pp + 4);
-            if (pp2 != string::npos) fGdmlVersion = fFileString.substr(pp + 9, pp2 - pp - 9);
-            fGdmlVersion = ReplaceMathematicalExpressions(ReplaceConstants(ReplaceVariables(fGdmlVersion)));
-        }
-
-        fFileString = ReplaceConstants(ReplaceVariables(fFileString));
-
-        cout << "TRestGDMLParser: Initializing variables" << endl;
-        int pos = fFileString.find("<gdml", 0);
-        if (pos != -1) {
-            string elementString = fFileString.substr(pos, -1);
-
-            fElement = StringToElement(elementString);
-            fElementGlobal = GetElement("define", fElement);
-
-            LoadSectionMetadata();
-        }
-
-        cout << "TRestGDMLParser: Replacing expressions in GDML" << endl;
-        ReplaceEntity();
-        fFileString = Replace(fFileString, "= \"", "=\"");
-        fFileString = Replace(fFileString, " =\"", "=\"");
-        fFileString = Replace(fFileString, " = \"", "=\"");
-
-        ReplaceAttributeWithKeyWord("cos(");
-        ReplaceAttributeWithKeyWord("sin(");
-        ReplaceAttributeWithKeyWord("tan(");
-        ReplaceAttributeWithKeyWord("sqrt(");
-        ReplaceAttributeWithKeyWord("log(");
-        ReplaceAttributeWithKeyWord("exp(");
-
-        string filenameNoPath = TRestTools::SeparatePathAndName(filenameAbsolute).second;
-        // we have to use a unique identifier on the file to prevent collision when launching multiple jobs
-        fOutputGdmlFilename = fOutputGdmlDirectory + "PID" + std::to_string(getpid()) + "_" + filenameNoPath;
-        cout << "TRestGDMLParser: Creating temporary file at: \"" << fOutputGdmlFilename << "\"" << endl;
-
-        filesystem::create_directories(fOutputGdmlDirectory);
-
-        ofstream outputFile;
-        outputFile.open(fOutputGdmlFilename, ios::trunc);
-        outputFile << fFileString << endl;
-        outputFile.close();
-
-        std::ifstream fileToCheckExistence(fOutputGdmlFilename);
-        if (!fileToCheckExistence) {
-            std::cout << "TRestGDMLParser: Problem writing temporary file." << std::endl;
-            exit(1);
-        }
-
-    } else {
-        RESTError << "TRestGDMLParser: Input GDML file: \"" << filename
+    const string filenameAbsolute = TRestTools::ToAbsoluteName(filename);
+    if (!TRestTools::fileExists(filenameAbsolute)) {
+        RESTError << "TRestGDMLParser: Input GDML file: \"" << filenameAbsolute
                   << "\" does not exist. Please double check your current path and filename" << RESTendl;
+        exit(1);
+    }
+
+    fConfigFileName = filenameAbsolute;
+    fPath = TRestTools::SeparatePathAndName(filenameAbsolute).first;
+
+    std::ifstream t(filenameAbsolute);
+    std::string str((std::istreambuf_iterator<char>(t)), std::istreambuf_iterator<char>());
+    fFileString = str;
+    t.close();
+
+    int pp = fFileString.find("##VERSION", 0);
+    if (pp != string::npos) {
+        int pp2 = fFileString.find("##", pp + 4);
+        if (pp2 != string::npos) fGdmlVersion = fFileString.substr(pp + 9, pp2 - pp - 9);
+        fGdmlVersion = ReplaceMathematicalExpressions(ReplaceConstants(ReplaceVariables(fGdmlVersion)));
+    }
+
+    fFileString = ReplaceConstants(ReplaceVariables(fFileString));
+
+    cout << "TRestGDMLParser: Initializing variables" << endl;
+    int pos = fFileString.find("<gdml", 0);
+    if (pos != -1) {
+        string elementString = fFileString.substr(pos, -1);
+
+        fElement = StringToElement(elementString);
+        fElementGlobal = GetElement("define", fElement);
+
+        LoadSectionMetadata();
+    }
+
+    cout << "TRestGDMLParser: Replacing expressions in GDML" << endl;
+    ReplaceEntity();
+    fFileString = Replace(fFileString, "= \"", "=\"");
+    fFileString = Replace(fFileString, " =\"", "=\"");
+    fFileString = Replace(fFileString, " = \"", "=\"");
+
+    ReplaceAttributeWithKeyWord("cos(");
+    ReplaceAttributeWithKeyWord("sin(");
+    ReplaceAttributeWithKeyWord("tan(");
+    ReplaceAttributeWithKeyWord("sqrt(");
+    ReplaceAttributeWithKeyWord("log(");
+    ReplaceAttributeWithKeyWord("exp(");
+
+    string filenameNoPath = TRestTools::SeparatePathAndName(filenameAbsolute).second;
+    // we have to use a unique identifier on the file to prevent collision when launching multiple jobs
+    fOutputGdmlFilename = fOutputGdmlDirectory + "PID" + std::to_string(getpid()) + "_" + filenameNoPath;
+    cout << "TRestGDMLParser: Creating temporary file at: \"" << fOutputGdmlFilename << "\"" << endl;
+
+    filesystem::create_directories(fOutputGdmlDirectory);
+
+    ofstream outputFile;
+    outputFile.open(fOutputGdmlFilename, ios::trunc);
+    outputFile << fFileString << endl;
+    outputFile.close();
+
+    std::ifstream fileToCheckExistence(fOutputGdmlFilename);
+    if (!fileToCheckExistence) {
+        std::cout << "TRestGDMLParser: Problem writing temporary file." << std::endl;
         exit(1);
     }
 }

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -97,7 +97,7 @@ class TRestTools {
     static std::string ToAbsoluteName(const std::string& filename);
     static std::vector<std::string> GetSubdirectories(const std::string& path, int recursion = -1);
     static std::pair<std::string, std::string> SeparatePathAndName(const std::string fullname);
-    static std::string GetPureFileName(std::string fullPathFileName);
+    static std::string GetPureFileName(const std::string& fullPathFileName);
     static std::string SearchFileInPath(std::vector<std::string> path, std::string filename);
     static Int_t CheckTheFile(std::string configFilename);
     static std::vector<std::string> GetFilesMatchingPattern(std::string pattern);

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -61,8 +61,8 @@ class TRestTools {
 
     static Bool_t IsBinaryFile(std::string fname);
 
-    static std::string GetFileNameExtension(std::string fullname);
-    static std::string GetFileNameRoot(std::string fullname);
+    static std::string GetFileNameExtension(const std::string& fullname);
+    static std::string GetFileNameRoot(const std::string& fullname);
 
     static int GetBinaryFileColumns(std::string fname);
 
@@ -96,7 +96,7 @@ class TRestTools {
     static std::string RemoveMultipleSlash(std::string);
     static std::string ToAbsoluteName(const std::string& filename);
     static std::vector<std::string> GetSubdirectories(const std::string& path, int recursion = -1);
-    static std::pair<std::string, std::string> SeparatePathAndName(const std::string fullname);
+    static std::pair<std::string, std::string> SeparatePathAndName(const std::string& fullname);
     static std::string GetPureFileName(const std::string& fullPathFileName);
     static std::string SearchFileInPath(std::vector<std::string> path, std::string filename);
     static Int_t CheckTheFile(std::string configFilename);

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -94,7 +94,7 @@ class TRestTools {
     static bool isPathWritable(const std::string& path);
     static bool isAbsolutePath(const std::string& path);
     static std::string RemoveMultipleSlash(std::string);
-    static std::string ToAbsoluteName(std::string filename);
+    static std::string ToAbsoluteName(const std::string& filename);
     static std::vector<std::string> GetSubdirectories(const std::string& path, int recursion = -1);
     static std::pair<std::string, std::string> SeparatePathAndName(const std::string fullname);
     static std::string GetPureFileName(std::string fullPathFileName);

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -111,8 +111,7 @@ class TRestTools {
     static int UploadToServer(std::string localFile, std::string remoteFile, std::string methodUrl = "");
 
     static std::string POSTRequest(const std::string& url, const std::map<std::string, std::string>& keys);
-    static void ChangeDirectory(std::string toDirectory);
-    static void ReturnToPreviousDirectory();
+    static void ChangeDirectory(const std::string& toDirectory);
 
     /// Rest tools class
     ClassDef(TRestTools, 1);

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -1125,30 +1125,4 @@ int TRestTools::UploadToServer(string localFile, string remoteFile, string metho
     return 0;
 }
 
-void TRestTools::ChangeDirectory(string toDirectory) {
-    char originDirectory[256];
-    sprintf(originDirectory, "%s", getenv("PWD"));
-    chdir(toDirectory.c_str());
-
-    string fullPath = "";
-    if (toDirectory[0] == '/')
-        fullPath = toDirectory;
-    else
-        fullPath = (string)originDirectory + "/" + toDirectory;
-
-    setenv("PWD", fullPath.c_str(), 1);
-    setenv("OLDPWD", originDirectory, 1);
-}
-
-void TRestTools::ReturnToPreviousDirectory() {
-    char originDirectory[256];
-    sprintf(originDirectory, "%s", getenv("PWD"));
-
-    char newDirectory[256];
-    sprintf(newDirectory, "%s", getenv("OLDPWD"));
-
-    setenv("PWD", newDirectory, 1);
-    setenv("OLDPWD", originDirectory, 1);
-
-    chdir(newDirectory);
-}
+void TRestTools::ChangeDirectory(const string& toDirectory) { filesystem::current_path(toDirectory); }

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -621,56 +621,26 @@ bool TRestTools::isAbsolutePath(const string& path) {
 /// Input: "abc.txt" and ":", Output: { ".", "abc.txt" }
 /// Input: "/home/nkx/" and ":", Output: { "/home/nkx/", "" }
 ///
-std::pair<string, string> TRestTools::SeparatePathAndName(string fullname) {
-    fullname = RemoveMultipleSlash(fullname);
-    pair<string, string> result;
-    int pos = fullname.find_last_of('/', -1);
-
-    if (pos == -1) {
-        result.first = ".";
-        result.second = fullname;
-    } else if (pos == 0) {
-        result.first = "/";
-        result.second = fullname.substr(1, fullname.size() - 1);
-    } else if (pos == fullname.size() - 1) {
-        result.first = fullname;
-        result.second = "";
-    } else {
-        result.first = fullname.substr(0, pos + 1);
-        result.second = fullname.substr(pos + 1, fullname.size() - pos - 1);
-    }
-    return result;
+std::pair<string, string> TRestTools::SeparatePathAndName(const string& fullname) {
+    filesystem::path path(fullname);
+    return {path.parent_path(), path.filename()};
 }
 
 ///////////////////////////////////////////////
-/// \brief Gets the file extension as the substring found after the lastest "."
+/// \brief Gets the file extension as the substring found after the latest "."
 ///
 /// Input: "/home/jgalan/abc.txt" Output: "txt"
 ///
-string TRestTools::GetFileNameExtension(string fullname) {
-    int pos = fullname.find_last_of('.', -1);
-
-    if (pos != -1) {
-        return fullname.substr(pos + 1, fullname.size() - pos - 1);
-    }
-    return fullname;
+string TRestTools::GetFileNameExtension(const string& fullname) {
+    return filesystem::path(fullname).extension();
 }
 
 ///////////////////////////////////////////////
-/// \brief Gets the filename root as the substring found before the lastest "."
+/// \brief Gets the filename root as the substring found before the latest "."
 ///
 /// Input: "/home/jgalan/abc.txt" Output: "abc"
 ///
-string TRestTools::GetFileNameRoot(string fullname) {
-    size_t pos1 = fullname.find_last_of('/', -1);
-    size_t pos2 = fullname.find_last_of('.', -1);
-
-    if (pos1 != string::npos && pos2 != string::npos) return fullname.substr(pos1 + 1, pos2 - pos1 - 1);
-
-    if (pos1 == string::npos && pos2 != string::npos) return fullname.substr(0, pos2);
-
-    return fullname;
-}
+string TRestTools::GetFileNameRoot(const string& fullname) { return filesystem::path(fullname).stem(); }
 
 ///////////////////////////////////////////////
 /// \brief Returns the input string but without multiple slashes ("/")

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -54,6 +54,7 @@
 #include <dirent.h>
 
 #include <chrono>
+#include <filesystem>
 #include <iostream>
 #include <limits>
 #include <memory>
@@ -706,12 +707,12 @@ string TRestTools::GetPureFileName(string fullPathFileName) {
 /// the directory the system is at the moment of the method call,
 /// through the PWD system variable.
 ///
-string TRestTools::ToAbsoluteName(string filename) {
+string TRestTools::ToAbsoluteName(const string& filename) {
     string result = filename;
     if (filename[0] == '~') {
         result = (string)getenv("HOME") + filename.substr(1, -1);
     } else if (filename[0] != '/') {
-        result = (string)getenv("PWD") + "/" + filename;
+        result = filesystem::weakly_canonical(filename);
     }
     result = RemoveMultipleSlash(result);
     return result;

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -697,26 +697,12 @@ string TRestTools::RemoveMultipleSlash(string str) {
 /// Input: "/home/nkx/abc.txt", Returns: "abc.txt"
 /// Input: "/home/nkx/", Output: ""
 ///
-string TRestTools::GetPureFileName(string fullPathFileName) {
-    fullPathFileName = RemoveMultipleSlash(fullPathFileName);
-    return SeparatePathAndName(fullPathFileName).second;
-}
+string TRestTools::GetPureFileName(const string& path) { return filesystem::path(path).filename(); }
 
 ///////////////////////////////////////////////
-/// \brief It takes a filename and adds it a full path based on
-/// the directory the system is at the moment of the method call,
-/// through the PWD system variable.
+/// \brief It takes a path and returns its absolute path
 ///
-string TRestTools::ToAbsoluteName(const string& filename) {
-    string result = filename;
-    if (filename[0] == '~') {
-        result = (string)getenv("HOME") + filename.substr(1, -1);
-    } else if (filename[0] != '/') {
-        result = filesystem::weakly_canonical(filename);
-    }
-    result = RemoveMultipleSlash(result);
-    return result;
-}
+string TRestTools::ToAbsoluteName(const string& filename) { return filesystem::weakly_canonical(filename); }
 
 ///////////////////////////////////////////////
 /// \brief It lists all the subdirectories inside path and adds

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -672,7 +672,32 @@ string TRestTools::GetPureFileName(const string& path) { return filesystem::path
 ///////////////////////////////////////////////
 /// \brief It takes a path and returns its absolute path
 ///
-string TRestTools::ToAbsoluteName(const string& filename) { return filesystem::weakly_canonical(filename); }
+string TRestTools::ToAbsoluteName(const string& filename) {
+    filesystem::path path;
+    for (const auto directory : filesystem::path(filename)) {
+        if (path.empty() && directory == "~") {
+            // path starts with ~
+            const auto envVariableHome = getenv("HOME");
+            if (envVariableHome == nullptr) {
+                cout << "TRestTools::ToAbsoluteName - ERROR - "
+                        "cannot resolve ~ because 'HOME' env variable does not exist"
+                     << endl;
+                exit(1);
+            }
+            const auto userHomePath = filesystem::path(envVariableHome);
+            if (userHomePath.empty()) {
+                cout << "TRestTools::ToAbsoluteName - ERROR - "
+                        "cannot resolve ~ because 'HOME' env variable is not set to a valid value"
+                     << endl;
+                exit(1);
+            }
+            path /= userHomePath;
+        } else {
+            path /= directory;
+        }
+    }
+    return filesystem::weakly_canonical(path);
+}
 
 ///////////////////////////////////////////////
 /// \brief It lists all the subdirectories inside path and adds


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Medium: 104](https://badgen.net/badge/PR%20Size/Medium%3A%20104/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-filesystem/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-filesystem)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Before C++17 we had to do some complicated logic to work with paths, this is solved with the `<filesystem> header, now present at REST.

Some methods to work with paths in REST relied on environment variables to work, such as `PWD`. This was causing some unexpected issues on my dev environment when the `PWD` env variable doesn't match the current working directory.

I have removed all apperances of environment variables when working on paths and I have rewritten the old methods to use `<filesystem>`. Now these methods are a single line and could probably be removed altogether so people start using the filesystem library, but they remain for now.

I removed the method `TRestTools::ReturnToPreviousDirectory` as it relied on environment variables for state management and it was only used once in the whole code base. I replaced its usage in restG4.

Related PR:

* https://github.com/rest-for-physics/restG4/pull/48/files