### PR TITLE
Adding new library legacylib

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -84,8 +84,8 @@ Build and Test:
     - cd ${CI_PROJECT_DIR}
     - python3 pull-submodules.py --force --dontask --latest:${CI_COMMIT_BRANCH}
     - mkdir ${CI_PROJECT_DIR}/build && cd ${CI_PROJECT_DIR}/build
-    - cmake ${CI_PROJECT_DIR}
-      -DTEST=ON -DREST_GARFIELD=OFF -DREST_G4=ON -DRESTLIB_DETECTOR=ON -DRESTLIB_RAW=ON -DRESTLIB_TRACK=ON
+    - cmake ${CI_PROJECT_DIR} -DTEST=ON -DREST_ALL_LIBS=ON
+      -DREST_GARFIELD=OFF -DREST_G4=ON -DREST_WELCOME=OFF
     - make -j2
     - ctest --output-on-failure -O ${CI_PROJECT_DIR}/build/Testing/summary.txt
 
@@ -103,7 +103,7 @@ Build and Install:
     - rm -rf ${CI_PROJECT_DIR}/build && mkdir ${CI_PROJECT_DIR}/build && cd ${CI_PROJECT_DIR}/build
     - rm -rf ${CI_PROJECT_DIR}/install
     - cmake ${CI_PROJECT_DIR} -DCMAKE_INSTALL_PREFIX=${CI_PROJECT_DIR}/install
-      -DREST_GARFIELD=ON -DREST_G4=ON -DRESTLIB_DETECTOR=ON -DRESTLIB_RAW=ON -DRESTLIB_TRACK=ON -DRESTLIB_AXION=ON -DREST_WELCOME=OFF
+      -DREST_ALL_LIBS=ON -DREST_GARFIELD=ON -DREST_G4=ON -DREST_WELCOME=OFF
     - make install -j2
 
   artifacts:

--- a/.gitmodules
+++ b/.gitmodules
@@ -67,3 +67,6 @@
 [submodule "projects/alphacamm"]
 	path = projects/alphacamm
 	url = git@lfna.unizar.es:gifna/alphacamm.git
+[submodule "source/libraries/legacy"]
+	path = source/libraries/legacy
+	url = https://github.com/rest-for-physics/geant4lib.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -69,4 +69,4 @@
 	url = git@lfna.unizar.es:gifna/alphacamm.git
 [submodule "source/libraries/legacy"]
 	path = source/libraries/legacy
-	url = https://github.com/rest-for-physics/geant4lib.git
+	url = https://github.com/rest-for-physics/legacylib.git

--- a/scripts/reformat-files.sh
+++ b/scripts/reformat-files.sh
@@ -46,6 +46,7 @@ if ! type -P $CLANG_FORMAT; then
   CLANG_FORMAT_DISABLED=True
 fi
 
+export XMLLINT_INDENT="    "
 if ! type -P $XML_LINT; then
   echo "WARNING: '$XML_LINT' was not found in your system! we cannot format *.rml files"
   XML_LINT_DISABLED=True

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -499,9 +499,21 @@ void TRestRun::ReadInputFileMetadata() {
         set<string> addednames;
         while ((key = (TKey*)nextkey())) {
             RESTDebug << "Reading key with name : " << key->GetName() << RESTendl;
+            RESTDebug << "Key type (class) : " << key->GetClassName() << RESTendl;
+
+            if (!TClass::GetClass(key->GetClassName())->IsLoaded()) {
+                RESTError << "-- Class " << key->GetClassName() << " has no dictionary!" << RESTendl;
+                RESTError << "- Any relevant REST library missing? " << RESTendl;
+                RESTError << "- File reading will continue without loading " << key->GetClassName()
+                          << RESTendl;
+                continue;
+            }
+
             if (addednames.count(key->GetName()) != 0) continue;
 
             TRestMetadata* a = (TRestMetadata*)f->Get(key->GetName());
+            RESTDebug << "Key of type : " << a->ClassName() << "(" << a << ")" << RESTendl;
+
             if (!a) {
                 RESTError << "TRestRun::ReadInputFileMetadata." << RESTendl;
                 RESTError << "Key name : " << key->GetName() << RESTendl;

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -504,7 +504,7 @@ void TRestRun::ReadInputFileMetadata() {
             if (!TClass::GetClass(key->GetClassName())->IsLoaded()) {
                 RESTError << "-- Class " << key->GetClassName() << " has no dictionary!" << RESTendl;
                 RESTError << "- Any relevant REST library missing? " << RESTendl;
-                RESTError << "- File reading will continue without loading " << key->GetClassName()
+                RESTError << "- File reading will continue without loading key: " << key->GetName()
                           << RESTendl;
                 continue;
             }

--- a/source/framework/tools/inc/TRestStringHelper.h
+++ b/source/framework/tools/inc/TRestStringHelper.h
@@ -83,6 +83,8 @@ inline std::vector<T2> Vector_cast(std::vector<T1> vecstring) {
 std::string ToUpper(std::string in);
 std::string ToLower(std::string in);
 
+std::string FirstToUpper(std::string s);
+
 std::string RightTrim(std::string s, const char* t = " \t\n\r\f\v");
 std::string LeftTrim(std::string s, const char* t = " \t\n\r\f\v");
 std::string Trim(std::string s, const char* t = " \t\n\r\f\v");

--- a/source/framework/tools/src/TRestStringHelper.cxx
+++ b/source/framework/tools/src/TRestStringHelper.cxx
@@ -614,6 +614,7 @@ std::string REST_StringHelper::ToUpper(std::string s) {
 /// \brief Convert the first character of a string to upper case.
 ///
 std::string REST_StringHelper::FirstToUpper(std::string s) {
+    if (s.length() == 0) return s;
     s[0] = *REST_StringHelper::ToUpper(std::string(&s[0], 1)).c_str();
     return s;
 }

--- a/source/framework/tools/src/TRestStringHelper.cxx
+++ b/source/framework/tools/src/TRestStringHelper.cxx
@@ -611,6 +611,14 @@ std::string REST_StringHelper::ToUpper(std::string s) {
 }
 
 ///////////////////////////////////////////////
+/// \brief Convert the first character of a string to upper case.
+///
+std::string REST_StringHelper::FirstToUpper(std::string s) {
+    s[0] = *REST_StringHelper::ToUpper(std::string(&s[0], 1)).c_str();
+    return s;
+}
+
+///////////////////////////////////////////////
 /// \brief Convert string to its lower case. Alternative of TString::ToLower
 ///
 std::string REST_StringHelper::ToLower(std::string s) {


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 31](https://badgen.net/badge/PR%20Size/Ok%3A%2031/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/legacylib/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/legacylib)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

New `legacy` library has been added to the repository, check https://github.com/rest-for-physics/legacylib for more details.

The new  `legacy` library is meant to store deprecated libraries in order to keep backward compatibility of the data with the following conditions:
- A `legacy` class can be instanciated, in this case a warning in displayed.
- A `legacy` class doesn't implement any function e.g. "ProcessEvent", an error is displayed and the program exit in case.
- A `legacy` class is capable to print any metadata.
- All  `legacy` classes inherits from `TRestLegacyProcess`, which ensure the proper handling of legacy classes.

For the time being only `TRestRawZeroSuppresionProcess.h` is implemented as legacy class, however more classes can be added following this template. A base class and a template for `TRestLegacyMetadata` can be provided in case of need.

Also, when REST has not been compiled with all libraries, when trying to read a file that contains classes from the missing libraries, it would produce a seg.fault. This is fixed now by @jgalan

- Added method `REST_StringHelper::FirstToUpper`.