### PR TITLE
Implementing read of child metadata elements automatically

### DIFF
--- a/source/framework/core/inc/TRestMetadata.h
+++ b/source/framework/core/inc/TRestMetadata.h
@@ -135,11 +135,17 @@ class TRestMetadata : public TNamed {
     virtual Int_t LoadSectionMetadata();
     /// To make settings from rml file. This method must be implemented in the derived class.
     virtual void InitFromConfigFile() {
+        RESTDebug << "TRestMetadata::InitFromConfigFile" << RESTendl;
         std::map<std::string, std::string> parameters = GetParametersList();
 
         for (auto& p : parameters) p.second = ReplaceMathematicalExpressions(p.second);
 
         ReadParametersList(parameters);
+
+        /// For the moment this method will attempt to instantiate, just like that for testing
+        std::vector<std::pair<std::string, std::string>> mdChildren = GetChildrenList();
+
+        //       for (const auto x : mdChildren) std::cout << x.first << " : " << x.second << std::endl;
     }
 
     /// Method called after the object is retrieved from root file.
@@ -200,7 +206,12 @@ class TRestMetadata : public TNamed {
     TString fWarningMessage = "";
 
     std::map<std::string, std::string> GetParametersList();
+
     void ReadAllParameters();
+
+    std::vector<std::pair<std::string, std::string>> GetChildrenList();
+
+    void InstantiateChild(const std::string& className, const std::string& childName, TiXmlElement* e);
 
     TRestMetadata();
     TRestMetadata(const char* configFilename);


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 73](https://badgen.net/badge/PR%20Size/Ok%3A%2073/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_child_metadata/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_child_metadata)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I am trying the implementation of an automatic read of child metadata definitions.

For example, if I have the following class definition:

```
    TRestMyClass::TRestMetadata {
              Double_t fMyParameter = 0;
            
              TRestOtherMdClass *fMdName = nullptr;
```

Then, I can create the following RML definition.

```
<TRestMyClass name="awesome_md" >
     <parameter name="myParameter" value="3.15" />

     <TRestOtherMdClass name="mdName">
            ....

     </TRestOtherMdClass>
</TRestMyClass>
```

I think it would be really interesting that we are able to construct metadata classes with sub-metadata classes, and initialize the corresponding metadata member.

What do you think? @rest-for-physics/core_dev 

I have been trying to do a first draft implementation but I am not very familiar with reflection, and not sure if it is that easy to achieve that.

The first application to test these new routines can be found at rest-for-physics/axionlib#25 



I also thought about the possibility of having a `std::vector <TRestOtherMdClass *>` so that it there are several definitions we place them in a vector.

I implemented `GetChildrenList` that returns a list of children with their respective name, then I attempt to create an instance pointing to the memory address. But for the moment no sucess :(


Any help is welcome!