### PR TITLE
Fixes installation issue in CMake > 3.21

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -20,7 +20,9 @@ if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
 endif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
 
 # https://github.com/rest-for-physics/framework/issues/162 & https://github.com/rest-for-physics/framework/issues/236
-cmake_policy(SET CMP0082 OLD)
+if (${CMAKE_VERSION} VERSION_LESS "3.23")
+    cmake_policy(SET CMP0082 OLD)
+endif ()
 
 # Install path
 if (NOT DEFINED INSTALL_PREFIX)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,10 +19,8 @@ if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
     SET(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-stdlib=libc++")
 endif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
 
-# https://github.com/rest-for-physics/framework/issues/162
-if (${CMAKE_VERSION} VERSION_LESS "3.21")
-    cmake_policy(SET CMP0082 OLD)
-endif ()
+# https://github.com/rest-for-physics/framework/issues/162 & https://github.com/rest-for-physics/framework/issues/236
+cmake_policy(SET CMP0082 OLD)
 
 # Install path
 if (NOT DEFINED INSTALL_PREFIX)


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/236-installation-problem-with-ubuntu-2204-cmake-related/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/236-installation-problem-with-ubuntu-2204-cmake-related)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Closes https://github.com/rest-for-physics/framework/issues/236