### PR TITLE
TRestAnalysisPlot - it now accepts substrings of a runtag

### DIFF
--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -738,13 +738,11 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
                 auto run = GetRunInfo(fRunInputFileName[j]);
                 // apply "classify" condition
                 bool flag = true;
-                auto iter = hist.classifyMap.begin();
-                while (iter != hist.classifyMap.end()) {
-		    if (run->GetRunInformation(iter->first).find(iter->second) == string::npos ) {
+                for (const auto& [inputFile, info] : hist.classifyMap) {
+                    if (run->GetRunInformation(inputFile).find(info) == string::npos) {
                         flag = false;
                         break;
                     }
-                    iter++;
                 }
                 if (!flag) continue;
 
@@ -792,10 +790,10 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
                             hTotal->SetCanExtend(TH1::kAllAxes);
                             tree->Draw(plotString + ">>+" + hTotal->GetName(), cutString, optString,
                                        fDrawNEntries, fDrawFirstEntry);
-			    RESTInfo << "AnalysisTree->Draw(\"" << plotString << ">>+" << hTotal->GetName() << "\", \"" << cutString
-				 << "\", \"" << optString << "\", " << fDrawNEntries << ", " << fDrawFirstEntry << ")"
-				 << RESTendl;
-			    hTotal->SetDirectory(0);
+                            RESTInfo << "AnalysisTree->Draw(\"" << plotString << ">>+" << hTotal->GetName()
+                                     << "\", \"" << cutString << "\", \"" << optString << "\", "
+                                     << fDrawNEntries << ", " << fDrawFirstEntry << ")" << RESTendl;
+                            hTotal->SetDirectory(0);
                         } else {
                             hTotal->Add(hh);
                         }


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Ok: 7](https://badgen.net/badge/PR%20Size/Ok%3A%207/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/plotsRunTagSubstring/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/plotsRunTagSubstring)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Feature added: the classify condition now accepts substrings of the run tag. 

E.g., if we have two files with differnet run tags, one can now combine them just by using a common substring.
```xml
<addFile name="R01564_00000_rawToTrack_XeNeIso_Calibration_0Vetos_cristina_2.3.10.root" />
<addFile name="R01658_00000_rawToTrack_XeNeIso_Calibration_57Vetoes_cristina_2.3.10.root" />
...
<classify fRunTag="Calibration"/>
```