### PR TITLE
Using `whoami` when USER is not defined instead of default user

### DIFF
--- a/source/framework/core/src/startup.cpp
+++ b/source/framework/core/src/startup.cpp
@@ -27,7 +27,6 @@ map<string, RESTVirtualConverter*> RESTConverterMethodBase = {};
 struct __REST_CONST_INIT {
    public:
     __REST_CONST_INIT() {
-
         REST_COMMIT = TRestTools::Execute("rest-config --commit");
 
         char* _REST_PATH = getenv("REST_PATH");
@@ -37,17 +36,22 @@ struct __REST_CONST_INIT {
         if (_REST_PATH == nullptr) {
             RESTError << "Lacking system env \"REST_PATH\"! Cannot start!" << RESTendl;
             RESTError << "You need to source \"thisREST.sh\" first" << RESTendl;
-            #ifndef REST_TESTING_ENABLED
+#ifndef REST_TESTING_ENABLED
             abort();
-            #endif
+#endif
         } else {
             REST_PATH = _REST_PATH;
         }
 
         if (_REST_USER == nullptr) {
             RESTWarning << "Lacking system env \"USER\"!" << RESTendl;
-            RESTWarning << "Setting user name to : \"defaultUser\"" << RESTendl;
-            REST_USER = "defaultUser";
+            const string systemUsername = TRestTools::Execute("whoami");
+            if (!systemUsername.empty()) {
+                REST_USER = systemUsername;
+            } else {
+                REST_USER = "defaultUser";
+            }
+            RESTWarning << "Setting user name to : \"" << REST_USER << "\"" << RESTendl;
             setenv("USER", REST_USER.c_str(), true);
 
         } else {

--- a/source/framework/core/src/startup.cpp
+++ b/source/framework/core/src/startup.cpp
@@ -44,11 +44,13 @@ struct __REST_CONST_INIT {
         }
 
         if (_REST_USER == nullptr) {
-            RESTWarning << "Lacking system env \"USER\"!" << RESTendl;
             const string systemUsername = TRestTools::Execute("whoami");
             if (!systemUsername.empty()) {
                 REST_USER = systemUsername;
             } else {
+                RESTWarning
+                    << R"(Cannot find username. "USER" env variable is not set and "whoami" utility is not working)"
+                    << RESTendl;
                 REST_USER = "defaultUser";
             }
             RESTWarning << "Setting user name to : \"" << REST_USER << "\"" << RESTendl;


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 12](https://badgen.net/badge/PR%20Size/Ok%3A%2012/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-default-user/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-default-user)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Currently if the `USER` environment variable is not set, `defaultUser` is set as `USER`.

This PR makes use of `whoami` (which also exists on windows apparently) to get the current username, which is not always present in the environtment variable. The `USER` env variable will still take precendence.

If for some reason `whoami` is not found, it will still use `defaultUser` and it won't raise an exception.