### PR TITLE
pull-submodules.py minor update

### DIFF
--- a/pull-submodules.py
+++ b/pull-submodules.py
@@ -222,7 +222,7 @@ Are you sure to proceed? (y/n)
                                     print(f" --> Pulling branch: {branchToPull}", end='')
 
                                     p = subprocess.run(
-                                        f"cd {root}/{submodule} && git fetch && git checkout {branchToPull} && git pull origin {branchToPull}",  #
+                                        f"cd {root}/{submodule} && git fetch && git checkout {branchToPull} && git pull",  #
                                         shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                                     if debug:
                                         print(p.stdout.decode("utf-8"))

--- a/pull-submodules.py
+++ b/pull-submodules.py
@@ -222,7 +222,7 @@ Are you sure to proceed? (y/n)
                                     print(f" --> Pulling branch: {branchToPull}", end='')
 
                                     p = subprocess.run(
-                                        f"cd {root}/{submodule} && git fetch && git checkout {branchToPull} && git pull",  #
+                                        f"cd {root}/{submodule} && git fetch && git checkout {branchToPull} && git pull origin {branchToPull}",  #
                                         shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
                                     if debug:
                                         print(p.stdout.decode("utf-8"))


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/pull_modules_minor_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/pull_modules_minor_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I think we had to add the following patch in order to get the latest remote. If not, the local master branch was not always synced. Recently remarked by @KonradAltenmueller