### PR TITLE
updated thisREST script to work when root/Geant4 is installed in `/usr`

### DIFF
--- a/cmake/thisREST.cmake
+++ b/cmake/thisREST.cmake
@@ -15,8 +15,8 @@ string(REGEX REPLACE "\n$" "" GEANT4_PATH "${GEANT4_PATH}")
 set(thisGeant4 "${GEANT4_PATH}/bin/geant4.sh")
 
 if (${REST_G4} MATCHES "ON")
-    set(loadG4 "\# if geant4.sh script is found we load the same Geant4 version as used in compilation\n if [[ -f \\\"${thisGeant4}\\\" && ${thisGeant4} != /usr/* ]]; then
-		source ${thisGeant4}\n fi\n")
+    set(loadG4 "\# if geant4.sh script is found we load the same Geant4 version as used in compilation\n if [[ -f \\\"${thisGeant4}\\\" ]]; then
+    source ${thisGeant4}\n fi\n")
 else ()
     set(loadG4 "")
 endif (${REST_G4} MATCHES "ON")
@@ -63,8 +63,8 @@ else
 fi
 
 \# if thisroot.sh script is found we load the same ROOT version as used in compilation
-if [[ -f \\\"${thisROOT}\\\" && ${thisROOT} != /usr/* ]]; then
-	source ${thisROOT}
+if [[ -f \\\"${thisROOT}\\\" ]]; then
+    source ${thisROOT}
 fi
 
 ${loadG4}


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 4](https://badgen.net/badge/PR%20Size/Ok%3A%204/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-update-thisREST-fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-update-thisREST-fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Currently `thisREST.sh` script does not source the root or Geant4 installations if they are installed under `/usr`. I don't understand why though, any explanation would be welcome.

I have removed this since the current docker image used for CI has dependencies installed in that directory and github actions pipeline are failing because of this.