### PR TITLE
Renamed method to check if file is accessible (`CheckFileIsAccessible`)

### DIFF
--- a/source/framework/core/inc/TRestBrowser.h
+++ b/source/framework/core/inc/TRestBrowser.h
@@ -50,8 +50,8 @@ class TRestBrowser {
     Int_t fEventId = 0;              //!
     Int_t fEventSubId = 0;           //!
 
-    TBrowser* b = nullptr;  //!
-    TRestRun* r = nullptr;  //!
+    TBrowser* fBrowser = nullptr;  //!
+    TRestRun* fRestRun = nullptr;  //!
 #endif
 
    private:
@@ -62,17 +62,17 @@ class TRestBrowser {
     TRestEventViewer* fEventViewer = nullptr;  //!
 
     void SetViewer(TRestEventViewer* eV);
-    void SetViewer(TString viewerName);
+    void SetViewer(const TString& viewerName);
     void SetButtons();
-    Bool_t LoadEventId(Int_t id, Int_t subid = -1);
+    Bool_t LoadEventId(Int_t eventID, Int_t subEventID = -1);
     Bool_t LoadEventEntry(Int_t n);
 #endif
 
    public:
     // tool method
-    void Initialize(TString opt = "FI");
+    void Initialize(const TString& opt = "FI");
     void InitFromConfigFile();
-    Bool_t OpenFile(TString filename);
+    Bool_t OpenFile(const TString& filename);
 
     // setters
     void SetInputEvent(TRestEvent*);
@@ -96,7 +96,7 @@ class TRestBrowser {
 
     // Constructors
     TRestBrowser();
-    TRestBrowser(TString viewerName);
+    TRestBrowser(const TString& viewerName);
 
     // Destructor
     ~TRestBrowser();

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -124,7 +124,7 @@ class TRestRun : public TRestMetadata {
             RESTWarning << "REST Warning! A null metadata wants to be added in TRestRun!" << RESTendl;
         }
     }
-    void AddEventBranch(TRestEvent* eve);
+    void AddEventBranch(TRestEvent* event);
     void SkipEventTree() {}
 
     void cd() {
@@ -178,8 +178,8 @@ class TRestRun : public TRestMetadata {
     inline TTree* GetEventTree() const { return fEventTree; }
     inline Int_t GetInputFileNumber() const { return fFileProcess == nullptr ? fInputFileNames.size() : 1; }
 
-    TRestMetadata* GetMetadata(const TString& name, TFile* f = nullptr);
-    TRestMetadata* GetMetadataClass(const TString& type, TFile* f = nullptr);
+    TRestMetadata* GetMetadata(const TString& name, TFile* file = nullptr);
+    TRestMetadata* GetMetadataClass(const TString& type, TFile* file = nullptr);
     std::vector<std::string> GetMetadataStructureNames();
     std::vector<std::string> GetMetadataStructureTitles();
     inline int GetNumberOfMetadataStructures() const { return fMetadata.size(); }

--- a/source/framework/core/src/TRestBrowser.cxx
+++ b/source/framework/core/src/TRestBrowser.cxx
@@ -34,12 +34,12 @@ TRestBrowser::TRestBrowser() {
         OpenFile(gDirectory->GetFile()->GetName());
         cout << "Loaded File : " << fInputFileName << endl;
     } else {
-        b = new TBrowser("Browser", 0, "REST Browser");
-        r = new TRestRun();
+        fBrowser = new TBrowser("Browser", nullptr, "REST Browser");
+        fRestRun = new TRestRun();
     }
 }
 
-TRestBrowser::TRestBrowser(TString viewerName) {
+TRestBrowser::TRestBrowser(const TString& viewerName) {
     Initialize("I");
     SetViewer(viewerName);
 }
@@ -49,29 +49,29 @@ TRestBrowser::~TRestBrowser() {
     // delete frmMain;
 }
 
-void TRestBrowser::Initialize(TString opt) {
+void TRestBrowser::Initialize(const TString& opt) {
     pureAnalysis = kFALSE;
 
-    r = new TRestRun();
+    fRestRun = new TRestRun();
 
-    b = new TBrowser("Browser", 0, "REST Browser", opt);
-    TGMainFrame* fr = b->GetBrowserImp()->GetMainFrame();
+    fBrowser = new TBrowser("Browser", 0, "REST Browser", opt);
+    TGMainFrame* fr = fBrowser->GetBrowserImp()->GetMainFrame();
     if (fr == nullptr) {
         RESTWarning << "No x11 interface is available. Cannot call the browser window!" << RESTendl;
         exit(1);
     }
     fr->DontCallClose();
 
-    b->StartEmbedding(0, -1);
+    fBrowser->StartEmbedding(0, -1);
     frmMain = new TGMainFrame(gClient->GetRoot(), 300);
     frmMain->SetCleanup(kDeepCleanup);
     frmMain->SetWindowName("Controller");
     SetButtons();
-    b->StopEmbedding();
+    fBrowser->StopEmbedding();
 
-    b->StartEmbedding(1, -1);
+    fBrowser->StartEmbedding(1, -1);
     fCanDefault = new TCanvas();
-    b->StopEmbedding();
+    fBrowser->StopEmbedding();
     // frmMain->DontCallClose();
     frmMain->MapSubwindows();
     // frmMain->Resize();
@@ -87,12 +87,12 @@ void TRestBrowser::SetViewer(TRestEventViewer* eV) {
     if (eV != nullptr) {
         fEventViewer = eV;
         // b->StartEmbedding(1, -1);
-        eV->Embed(b);
+        eV->Embed(fBrowser);
         // b->StopEmbedding();
     }
 }
 
-void TRestBrowser::SetViewer(TString viewerName) {
+void TRestBrowser::SetViewer(const TString& viewerName) {
     if (Count((string)viewerName, "Viewer") > 0) {
         TRestEventViewer* viewer = REST_Reflection::Assembly((string)viewerName);
         if (viewer != nullptr) {
@@ -112,86 +112,86 @@ void TRestBrowser::SetViewer(TString viewerName) {
 void TRestBrowser::SetButtons() {
     TString icondir = (TString)getenv("ROOTSYS") + "/icons/";
 
-    auto fVFrame = new TGVerticalFrame(frmMain);
-    fVFrame->Resize(300, 200);
+    auto vFrame = new TGVerticalFrame(frmMain);
+    vFrame->Resize(300, 200);
 
     // row in the tree
-    fEventRowLabel = new TGLabel(fVFrame, "Entry:");
-    fVFrame->AddFrame(fEventRowLabel, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+    fEventRowLabel = new TGLabel(vFrame, "Entry:");
+    vFrame->AddFrame(fEventRowLabel, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-    fEventRowNumberBox = new TGNumberEntry(fVFrame, fEventRow);
+    fEventRowNumberBox = new TGNumberEntry(vFrame, fEventRow);
     fEventRowNumberBox->Connect("ValueSet(Long_t)", "TRestBrowser", this, "RowValueChangedAction(Long_t)");
-    fVFrame->AddFrame(fEventRowNumberBox, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+    vFrame->AddFrame(fEventRowNumberBox, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
     // event id and sub event id
-    auto labelbar = new TGHorizontalFrame(fVFrame);
+    auto labelBar = new TGHorizontalFrame(vFrame);
     {
-        fEventIdLabel = new TGLabel(labelbar, "Event ID:");
-        labelbar->AddFrame(fEventIdLabel, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+        fEventIdLabel = new TGLabel(labelBar, "Event ID:");
+        labelBar->AddFrame(fEventIdLabel, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-        fEventSubIdLabel = new TGLabel(labelbar, "Sub ID:");
-        labelbar->AddFrame(fEventSubIdLabel, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+        fEventSubIdLabel = new TGLabel(labelBar, "Sub ID:");
+        labelBar->AddFrame(fEventSubIdLabel, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
     }
-    fVFrame->AddFrame(labelbar, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+    vFrame->AddFrame(labelBar, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-    auto numberboxbar = new TGHorizontalFrame(fVFrame);
+    auto numberBoxBar = new TGHorizontalFrame(vFrame);
     {
-        fEventIdNumberBox = new TGNumberEntry(numberboxbar, fEventId);
+        fEventIdNumberBox = new TGNumberEntry(numberBoxBar, fEventId);
         fEventIdNumberBox->Connect("ValueSet(Long_t)", "TRestBrowser", this, "IdValueChangedAction(Long_t)");
-        numberboxbar->AddFrame(fEventIdNumberBox, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+        numberBoxBar->AddFrame(fEventIdNumberBox, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-        fEventSubIdNumberBox = new TGNumberEntry(numberboxbar, fEventSubId);
+        fEventSubIdNumberBox = new TGNumberEntry(numberBoxBar, fEventSubId);
         fEventSubIdNumberBox->Connect("ValueSet(Long_t)", "TRestBrowser", this,
                                       "IdValueChangedAction(Long_t)");
-        numberboxbar->AddFrame(fEventSubIdNumberBox, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+        numberBoxBar->AddFrame(fEventSubIdNumberBox, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
     }
-    fVFrame->AddFrame(numberboxbar, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+    vFrame->AddFrame(numberBoxBar, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
     // event type to choose
-    fEventTypeLabel = new TGLabel(fVFrame, "Event Type:");
-    fVFrame->AddFrame(fEventTypeLabel, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+    fEventTypeLabel = new TGLabel(vFrame, "Event Type:");
+    vFrame->AddFrame(fEventTypeLabel, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-    fEventTypeComboBox = new TGComboBox(fVFrame);
+    fEventTypeComboBox = new TGComboBox(vFrame);
     fEventTypeComboBox->Connect("Selected(Int_t)", "TRestBrowser", this, "EventTypeChangedAction(Int_t)");
-    fVFrame->AddFrame(fEventTypeComboBox, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+    vFrame->AddFrame(fEventTypeComboBox, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
     // plot option buttons
-    fPlotOptionLabel = new TGLabel(fVFrame, "Plot Options:");
-    fVFrame->AddFrame(fPlotOptionLabel, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+    fPlotOptionLabel = new TGLabel(vFrame, "Plot Options:");
+    vFrame->AddFrame(fPlotOptionLabel, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-    fPlotOptionTextBox = new TGTextEntry(fVFrame, "");
+    fPlotOptionTextBox = new TGTextEntry(vFrame, "");
     fPlotOptionTextBox->SetText("");
     fPlotOptionTextBox->Connect("ReturnPressed()", "TRestBrowser", this, "PlotAction()");
-    fVFrame->AddFrame(fPlotOptionTextBox, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+    vFrame->AddFrame(fPlotOptionTextBox, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-    auto switchbuttonbar = new TGHorizontalFrame(fVFrame);
+    auto switchButtonBar = new TGHorizontalFrame(vFrame);
     {
-        fButOptPrev = new TGTextButton(switchbuttonbar, "<<Previous");  ///< Load Event button
+        fButOptPrev = new TGTextButton(switchButtonBar, "<<Previous");  ///< Load Event button
         fButOptPrev->Connect("Clicked()", "TRestBrowser", this, "PreviousPlotOptionAction()");
-        switchbuttonbar->AddFrame(fButOptPrev, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+        switchButtonBar->AddFrame(fButOptPrev, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-        fButOptRefresh = new TGTextButton(switchbuttonbar, "Plot");  ///< Load Event button
+        fButOptRefresh = new TGTextButton(switchButtonBar, "Plot");  ///< Load Event button
         fButOptRefresh->Connect("Clicked()", "TRestBrowser", this, "PlotAction()");
-        switchbuttonbar->AddFrame(fButOptRefresh, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+        switchButtonBar->AddFrame(fButOptRefresh, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-        fButOptNext = new TGTextButton(switchbuttonbar, "Next>>");  ///< Load Event button
+        fButOptNext = new TGTextButton(switchButtonBar, "Next>>");  ///< Load Event button
         fButOptNext->Connect("Clicked()", "TRestBrowser", this, "NextPlotOptionAction()");
-        switchbuttonbar->AddFrame(fButOptNext, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+        switchButtonBar->AddFrame(fButOptNext, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
     }
-    fVFrame->AddFrame(switchbuttonbar, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+    vFrame->AddFrame(switchButtonBar, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
     // tool buttons
-    fMenuOpen = new TGPictureButton(fVFrame, gClient->GetPicture(icondir + "bld_open.png"));
+    fMenuOpen = new TGPictureButton(vFrame, gClient->GetPicture(icondir + "bld_open.png"));
     fMenuOpen->Connect("Clicked()", "TRestBrowser", this, "LoadFileAction()");
-    fVFrame->AddFrame(fMenuOpen, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+    vFrame->AddFrame(fMenuOpen, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-    fExit = new TGTextButton(fVFrame, "EXIT");  ///< Exit button
+    fExit = new TGTextButton(vFrame, "EXIT");  ///< Exit button
     fExit->Connect("Clicked()", "TRestBrowser", this, "ExitAction()");
-    fVFrame->AddFrame(fExit, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+    vFrame->AddFrame(fExit, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
 
-    frmMain->Resize(TGDimension(300, frmMain->GetHeight() + fVFrame->GetHeight()));
+    frmMain->Resize(TGDimension(300, frmMain->GetHeight() + vFrame->GetHeight()));
 
-    frmMain->AddFrame(fVFrame, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
+    frmMain->AddFrame(vFrame, new TGLayoutHints(kLHintsExpandX | kLHintsExpandY));
     // frmMain->DontCallClose();
     frmMain->MapSubwindows();
     // frmMain->Resize();
@@ -201,14 +201,14 @@ void TRestBrowser::SetButtons() {
 
 void TRestBrowser::InitFromConfigFile() { cout << __PRETTY_FUNCTION__ << endl; }
 
-void TRestBrowser::SetInputEvent(TRestEvent* eve) {
-    if (r != nullptr) {
-        r->SetInputEvent(eve);
+void TRestBrowser::SetInputEvent(TRestEvent* event) {
+    if (fRestRun != nullptr) {
+        fRestRun->SetInputEvent(event);
     }
 }
 
 Bool_t TRestBrowser::LoadEventEntry(Int_t n) {
-    if (r->GetInputFile() == nullptr || r->GetInputFile()->IsZombie()) {
+    if (fRestRun->GetInputFile() == nullptr || fRestRun->GetInputFile()->IsZombie()) {
         RESTWarning << "TRestBrowser::LoadEventEntry. No File..." << RESTendl;
         return kFALSE;
     }
@@ -217,21 +217,21 @@ Bool_t TRestBrowser::LoadEventEntry(Int_t n) {
         return kFALSE;
     }
 
-    if (r->GetAnalysisTree() != nullptr && n < r->GetAnalysisTree()->GetEntries() && n >= 0) {
-        r->GetEntry(n);
-        TRestEvent* ev = r->GetInputEvent();
+    if (fRestRun->GetAnalysisTree() != nullptr && n < fRestRun->GetAnalysisTree()->GetEntries() && n >= 0) {
+        fRestRun->GetEntry(n);
+        TRestEvent* ev = fRestRun->GetInputEvent();
         if (!ev) {
             RESTError << "internal error!" << RESTendl;
             return kFALSE;
         } else {
-            fEventRow = r->GetCurrentEntry();
+            fEventRow = fRestRun->GetCurrentEntry();
             fEventId = ev->GetID();
             fEventSubId = ev->GetSubID();
 
             fEventRowNumberBox->SetIntNumber(fEventRow);
             fEventIdNumberBox->SetIntNumber(fEventId);
             fEventSubIdNumberBox->SetIntNumber(fEventSubId);
-            r->GetAnalysisTree()->PrintObservables();
+            fRestRun->GetAnalysisTree()->PrintObservables();
         }
     } else {
         RESTWarning << "TRestBrowser::LoadEventEntry. Event out of limits" << RESTendl;
@@ -239,7 +239,7 @@ Bool_t TRestBrowser::LoadEventEntry(Int_t n) {
     }
 
     if (fEventViewer != nullptr) {
-        fEventViewer->AddEvent(r->GetInputEvent());
+        fEventViewer->AddEvent(fRestRun->GetInputEvent());
         fEventViewer->Plot(fPlotOptionTextBox->GetText());
         cout << endl;
     }
@@ -248,8 +248,8 @@ Bool_t TRestBrowser::LoadEventEntry(Int_t n) {
     return kTRUE;
 }
 
-Bool_t TRestBrowser::LoadEventId(Int_t id, Int_t subid) {
-    if (r->GetInputFile() == nullptr || r->GetInputFile()->IsZombie()) {
+Bool_t TRestBrowser::LoadEventId(Int_t eventID, Int_t subEventID) {
+    if (fRestRun->GetInputFile() == nullptr || fRestRun->GetInputFile()->IsZombie()) {
         RESTWarning << "TRestBrowser::LoadEventEntry. No File..." << RESTendl;
         return kFALSE;
     }
@@ -259,20 +259,21 @@ Bool_t TRestBrowser::LoadEventId(Int_t id, Int_t subid) {
         return kFALSE;
     }
 
-    if (r->GetAnalysisTree() != nullptr && r->GetAnalysisTree()->GetEntries() > 0) {
-        TRestEvent* ev = r->GetEventWithID(id, subid);
-        if (!ev) {
-            RESTWarning << "Event ID : " << id << " with sub ID : " << subid << " not found!" << RESTendl;
+    if (fRestRun->GetAnalysisTree() != nullptr && fRestRun->GetAnalysisTree()->GetEntries() > 0) {
+        TRestEvent* event = fRestRun->GetEventWithID(eventID, subEventID);
+        if (event != nullptr) {
+            RESTWarning << "Event ID : " << eventID << " with sub ID : " << subEventID << " not found!"
+                        << RESTendl;
             return kFALSE;
         } else {
-            fEventRow = r->GetCurrentEntry();
-            fEventId = ev->GetID();
-            fEventSubId = ev->GetSubID();
+            fEventRow = fRestRun->GetCurrentEntry();
+            fEventId = event->GetID();
+            fEventSubId = event->GetSubID();
 
             fEventRowNumberBox->SetIntNumber(fEventRow);
             fEventIdNumberBox->SetIntNumber(fEventId);
             fEventSubIdNumberBox->SetIntNumber(fEventSubId);
-            r->GetAnalysisTree()->PrintObservables();
+            fRestRun->GetAnalysisTree()->PrintObservables();
         }
     } else {
         RESTWarning << "TRestBrowser::LoadEventEntry. Event out of limits" << RESTendl;
@@ -280,7 +281,7 @@ Bool_t TRestBrowser::LoadEventId(Int_t id, Int_t subid) {
     }
 
     if (fEventViewer != nullptr) {
-        fEventViewer->AddEvent(r->GetInputEvent());
+        fEventViewer->AddEvent(fRestRun->GetInputEvent());
         fEventViewer->Plot(fPlotOptionTextBox->GetText());
         cout << endl;
     }
@@ -289,13 +290,13 @@ Bool_t TRestBrowser::LoadEventId(Int_t id, Int_t subid) {
     return kTRUE;
 }
 
-Bool_t TRestBrowser::OpenFile(TString filename) {
+Bool_t TRestBrowser::OpenFile(const TString& filename) {
     if (filename.Contains("http") || TRestTools::fileExists(filename.Data())) {
         fInputFileName = filename;
 
-        r->OpenInputFile(fInputFileName);
-        TFile* f = r->GetInputFile();
-        TTree* t = r->GetEventTree();
+        fRestRun->OpenInputFile(fInputFileName);
+        TFile* f = fRestRun->GetInputFile();
+        TTree* t = fRestRun->GetEventTree();
 
         TGeoManager* geometry = gGeoManager;
 
@@ -303,13 +304,13 @@ Bool_t TRestBrowser::OpenFile(TString filename) {
             // add entry for other event types
             TObjArray* branches = t->GetListOfBranches();
             for (int i = 0; i <= branches->GetLast(); i++) {
-                TBranch* br = (TBranch*)branches->At(i);
-                if (((string)br->GetName()).find("EventBranch") != -1) {
-                    string eventtype = Replace((string)br->GetName(), "Branch", "");
-                    fEventTypeComboBox->AddEntry(eventtype.c_str(), fEventTypeComboBox->GetNumberOfEntries());
+                auto branch = (TBranch*)branches->At(i);
+                if (((string)branch->GetName()).find("EventBranch") != -1) {
+                    string eventType = Replace((string)branch->GetName(), "Branch", "");
+                    fEventTypeComboBox->AddEntry(eventType.c_str(), fEventTypeComboBox->GetNumberOfEntries());
                     // we make the entry of input event being selected
-                    if (r->GetInputEvent() != nullptr &&
-                        (string)r->GetInputEvent()->ClassName() == eventtype) {
+                    if (fRestRun->GetInputEvent() != nullptr &&
+                        (string)fRestRun->GetInputEvent()->ClassName() == eventType) {
                         fEventTypeComboBox->Select(fEventTypeComboBox->GetNumberOfEntries() - 1, false);
                     }
                 }
@@ -324,11 +325,11 @@ Bool_t TRestBrowser::OpenFile(TString filename) {
             pureAnalysis = kTRUE;
         }
 
-        TRestEvent* ev = r->GetInputEvent();
+        TRestEvent* ev = fRestRun->GetInputEvent();
         if (!ev) {
             RESTError << "internal error!" << RESTendl;
         } else {
-            fEventRowNumberBox->SetIntNumber(r->GetCurrentEntry());
+            fEventRowNumberBox->SetIntNumber(fRestRun->GetCurrentEntry());
             fEventIdNumberBox->SetIntNumber(ev->GetID());
             fEventSubIdNumberBox->SetIntNumber(ev->GetSubID());
         }
@@ -370,7 +371,7 @@ void TRestBrowser::PlotAction() {
 }
 
 void TRestBrowser::RowValueChangedAction(Long_t val) {
-    int rowold = fEventRow;
+    int eventRow = fEventRow;
     fEventRow = (Int_t)fEventRowNumberBox->GetNumber();
 
     RESTDebug << "TRestBrowser::LoadEventAction. Entry:" << fEventRow << RESTendl;
@@ -378,24 +379,24 @@ void TRestBrowser::RowValueChangedAction(Long_t val) {
     bool success = LoadEventEntry(fEventRow);
 
     if (!success) {
-        fEventRow = rowold;
+        fEventRow = eventRow;
         fEventRowNumberBox->SetIntNumber(fEventRow);
     }
 }
 
 void TRestBrowser::EventTypeChangedAction(Int_t id) {
-    string eventtype = fEventTypeComboBox->GetSelectedEntry()->GetTitle();
-    TRestEvent* eve = REST_Reflection::Assembly(eventtype);
+    string eventType = fEventTypeComboBox->GetSelectedEntry()->GetTitle();
+    TRestEvent* eve = REST_Reflection::Assembly(eventType);
 
     if (eve != nullptr) {
-        r->SetInputEvent(eve);
+        fRestRun->SetInputEvent(eve);
         RowValueChangedAction(0);
     }
 }
 
 void TRestBrowser::IdValueChangedAction(Long_t val) {
-    int idold = fEventId;
-    int subidold = fEventSubId;
+    int eventID = fEventId;
+    int subEventID = fEventSubId;
 
     fEventId = (Int_t)fEventIdNumberBox->GetNumber();
     fEventSubId = (Int_t)fEventSubIdNumberBox->GetNumber();
@@ -406,8 +407,8 @@ void TRestBrowser::IdValueChangedAction(Long_t val) {
     bool success = LoadEventId(fEventId, fEventSubId);
 
     if (!success) {
-        fEventId = idold;
-        fEventSubId = subidold;
+        fEventId = eventID;
+        fEventSubId = subEventID;
         fEventIdNumberBox->SetIntNumber(fEventId);
         fEventSubIdNumberBox->SetIntNumber(fEventSubId);
     }

--- a/source/framework/core/src/TRestThread.cxx
+++ b/source/framework/core/src/TRestThread.cxx
@@ -404,18 +404,14 @@ void TRestThread::PrepareToProcess(bool* outputConfig) {
         fEventTree = new TTree((TString) "EventTree_" + ToString(fThreadId), "dummyTree");
         // fEventTree->CreateEventBranches();
 
-        if (outputConfig[2] == true) {
+        if (outputConfig[2]) {
             TString BranchName = (TString)fInputEvent->GetName() + "Branch";
             if (fEventTree->GetBranch(BranchName) == nullptr)  // avoid duplicated branch
+            {
                 fEventTree->Branch(BranchName, fInputEvent->ClassName(), fInputEvent);
+            }
         }
-        // currently external process analysis is not supported!
-
-        // if (fEventTree->GetListOfBranches()->GetLast() < 1)
-        //{
-        //	delete fEventTree; fEventTree = nullptr;
-        //}
-        // fAnalysisTree->CreateBranches();
+        // currently, external process analysis is not supported!
     }
     if (outputConfigToDel) delete outputConfig;
 }
@@ -432,7 +428,7 @@ void TRestThread::PrepareToProcess(bool* outputConfig) {
 /// Note: The methods GetNextevtFunc() and FillThreadEventFunc() are all from
 /// TRestProcessRunner. The later two will call back the method FillEvent(),
 /// EndProcess() in this class. The idea to do so is to make a unified
-/// managemenet of these i-o related methods. In TRestRun the three methods are
+/// management of these i-o related methods. In TRestRun the three methods are
 /// mutex locked. They will be paused until the host run allows it to run. This
 /// prevents segmentation violation due to simultaneously read/write.
 void TRestThread::StartProcess() {

--- a/source/framework/tools/inc/TRestStringOutput.h
+++ b/source/framework/tools/inc/TRestStringOutput.h
@@ -144,18 +144,17 @@ struct endl_t {
 /// To use this tool class in the other classes, include this header file.
 /// You will get several global output objects: fout, info, essential, debug, etc.
 /// they works similarly as std::cout: `fout<<"hello world"<<endl;`. It is also possible
-/// to initialize a local TRestStringOutput object. Then one can costomize output color,
+/// to initialize a local TRestStringOutput object. Then one can customize output color,
 /// border and orientation on that.
 class TRestStringOutput {
    public:
     //////////////////////////////////////////////////////////////////////////
     /// Enumerate of verbose level, containing five levels
     enum class REST_Verbose_Level {
-        REST_Silent = 0,     //!< show minimum information of the software, as well as error
-                             //!< messages
+        REST_Silent = 0,     //!< show minimum information of the software, as well as error messages
         REST_Essential = 1,  //!< +show some essential information, as well as warnings
         REST_Warning = REST_Essential,
-        REST_Info = 2,    //!< +show most of the infomation for each steps
+        REST_Info = 2,    //!< +show most of the information for each steps
         REST_Debug = 3,   //!< +show the defined debug messages
         REST_Extreme = 4  //!< show everything
     };
@@ -175,9 +174,6 @@ class TRestStringOutput {
     int length;
 
     REST_Verbose_Level verbose;
-
-    void lock();
-    void unlock();
 
    public:
     REST_Verbose_Level GetVerboseLevel() { return verbose; }

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -108,7 +108,7 @@ class TRestTools {
     static std::pair<std::string, std::string> SeparatePathAndName(const std::string& fullname);
     static std::string GetPureFileName(const std::string& fullPathFileName);
     static std::string SearchFileInPath(std::vector<std::string> path, std::string filename);
-    static Int_t CheckTheFile(std::string configFilename);
+    static bool CheckFileIsAccessible(const std::string&);
     static std::vector<std::string> GetFilesMatchingPattern(std::string pattern);
     static int ConvertVersionCode(std::string in);
     static std::istream& GetLine(std::istream& is, std::string& t);

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -770,19 +770,19 @@ string TRestTools::SearchFileInPath(vector<string> paths, string filename) {
 }
 
 ///////////////////////////////////////////////
-/// \brief Checks if the config file can be openned. It returns OK in case of
-/// success, ERROR otherwise.
+/// \brief Checks if the config file can be opened (and thus exists).
+/// It returns true in case of success, false otherwise.
 ///
-Int_t TRestTools::CheckTheFile(std::string configFilename) {
+bool TRestTools::CheckFileIsAccessible(const std::string& filename) {
     ifstream ifs;
-    ifs.open(configFilename.c_str());
+    ifs.open(filename.c_str());
 
     if (!ifs) {
-        return -1;
-    } else
+        return false;
+    } else {
         ifs.close();
-
-    return 0;
+    }
+    return true;
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Medium: 154](https://badgen.net/badge/PR%20Size/Medium%3A%20154/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-fix-restG4-pipeline/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-fix-restG4-pipeline)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is part of the code originally presented in https://github.com/rest-for-physics/framework/pull/239. 

It contains minor changes and a renamed method `CheckFileIsAccessible` and some minor formatting.

Method is added at https://github.com/rest-for-physics/framework/pull/239/commits/e44b616049b6bd41090660c7e8d926b65fb374ac.