### PR TITLE
Added global TRestRun store

### DIFF
--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -101,7 +101,8 @@ class TRestRun : public TRestMetadata {
     }
 
     TString FormFormat(const TString& FilenameFormat);
-    TFile* MergeToOutputFile(std::vector<std::string> filefullnames, std::string outputfilename = "");
+    TFile* MergeToOutputFile(const std::vector<std::string>& filefullnames,
+                             const std::string& outputfilename = "");
     TFile* FormOutputFile();
     TFile* UpdateOutputFile();
 

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -154,7 +154,7 @@ class TRestRun : public TRestMetadata {
     inline int GetCurrentEntry() const { return fCurrentEvent; }
     inline Long64_t GetBytesReaded() const { return fBytesRead; }
     Long64_t GetTotalBytes();
-    int GetEntries() const;
+    Long64_t GetEntries() const;
 
     /// Calling `GetInputEvent()` will return a basic `TRestEvent*`
     inline TRestEvent* GetInputEvent() const { return fInputEvent; }

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -256,6 +256,9 @@ class TRestRun : public TRestMetadata {
     // Constructor & Destructor
     TRestRun();
     TRestRun(const std::string& filename);
+    inline TRestRun(const char* filename) { TRestRun(std::string(filename)); }
+    inline TRestRun(const TString& filename) { TRestRun(filename.Data()); }
+
     ~TRestRun();
 
     ClassDefOverride(TRestRun, 6);

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -64,6 +64,8 @@ class TRestRun : public TRestMetadata {
    private:
     std::string ReplaceMetadataMember(const std::string& instr);
 
+    static std::vector<const TRestRun*> fGlobalRunStore;  //!
+
    public:
     /// REST run class
     void Initialize() override;
@@ -254,6 +256,8 @@ class TRestRun : public TRestMetadata {
 
     Int_t Write(const char* name = nullptr, Int_t option = 0, Int_t bufsize = 0) override;
 
+    inline static const std::vector<const TRestRun*>& GetGlobalStore() { return fGlobalRunStore; }
+
     // Constructor & Destructor
     TRestRun();
     TRestRun(const std::string& filename);
@@ -262,7 +266,7 @@ class TRestRun : public TRestMetadata {
 
     ~TRestRun();
 
-    ClassDefOverride(TRestRun, 6);
+    ClassDefOverride(TRestRun, 7);
 };
 
 #endif

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -35,7 +35,7 @@ class TRestRun : public TRestMetadata {
     Double_t fStartTime;  ///< Event absolute starting time/date (unix timestamp)
     Double_t fEndTime;    ///< Event absolute ending time/date (unix timestamp)
     Int_t fEntriesSaved;
-    Int_t fNFilesSplit;  // Number of files being split. Used when retrieveing
+    Int_t fNFilesSplit;  // Number of files being split. Used when retrieving
 
     // data-like metadata objects
     std::vector<TRestMetadata*> fMetadata;       //!
@@ -79,7 +79,7 @@ class TRestRun : public TRestMetadata {
     void ResetEntry();
 
     Int_t GetNextEvent(TRestEvent* targetEvent, TRestAnalysisTree* targetTree);
-    void GetEntry(int i) {
+    inline void GetEntry(int i) {
         if (fAnalysisTree != nullptr) {
             fAnalysisTree->GetEntry(i);
         }
@@ -95,7 +95,7 @@ class TRestRun : public TRestMetadata {
         fCurrentEvent = i;
     }
 
-    void GetNextEntry() {
+    inline void GetNextEntry() {
         if (fCurrentEvent + 1 >= GetEntries()) fCurrentEvent = -1;
         GetEntry(fCurrentEvent + 1);
     }
@@ -105,7 +105,7 @@ class TRestRun : public TRestMetadata {
     TFile* FormOutputFile();
     TFile* UpdateOutputFile();
 
-    void PassOutputFile() {
+    inline void PassOutputFile() {
         fOutputFile = fInputFile;
         fOutputFileName = fOutputFile->GetName();
     }
@@ -127,7 +127,7 @@ class TRestRun : public TRestMetadata {
     void AddEventBranch(TRestEvent* event);
     void SkipEventTree() {}
 
-    void cd() {
+    inline void cd() {
         if (fInputFile != nullptr) fInputFile->cd();
     }
 
@@ -229,7 +229,7 @@ class TRestRun : public TRestMetadata {
     void PrintMetadata() override;
     inline void PrintAllMetadata() {
         PrintMetadata();
-        for (unsigned int i = 0; i < fMetadata.size(); i++) fMetadata[i]->PrintMetadata();
+        for (auto& metadata : fMetadata) metadata->PrintMetadata();
     }
     inline void PrintTrees() const {
         if (fEventTree != nullptr) {

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -32,8 +32,9 @@
 #include <windows.h>
 #undef GetClassName
 #else
-#include "unistd.h"
 #include <sys/stat.h>
+
+#include "unistd.h"
 #endif  // !WIN32
 
 #include "TRestDataBase.h"
@@ -1151,7 +1152,7 @@ void TRestRun::CloseFile() {
     }
 
     if (fEventTree != nullptr) {
-        if (fEventTree->GetEntries() > 0 && fInputFile == nullptr) fEventTree->Write(0, kWriteDelete);
+        if (fEventTree->GetEntries() > 0 && fInputFile == nullptr) fEventTree->Write(nullptr, kWriteDelete);
         delete fEventTree;
         fEventTree = nullptr;
     }
@@ -1204,7 +1205,7 @@ void TRestRun::SetExtProcess(TRestEventProcess* p) {
         p->SetAnalysisTree(fAnalysisTree);
         fTotalBytes = p->GetTotalBytes();
 
-        GetNextEvent(fInputEvent, 0);
+        GetNextEvent(fInputEvent, nullptr);
         // fAnalysisTree->CreateBranches();
         RESTInfo << "The external file process has been set! Name : " << fFileProcess->GetName() << RESTendl;
     } else {
@@ -1344,7 +1345,7 @@ Long64_t TRestRun::GetTotalBytes() {
     return fTotalBytes;
 }
 
-int TRestRun::GetEntries() const {
+Long64_t TRestRun::GetEntries() const {
     if (fAnalysisTree != nullptr) {
         return fAnalysisTree->GetEntries();
     }

--- a/source/framework/test/src/FrameworkCore.cxx
+++ b/source/framework/test/src/FrameworkCore.cxx
@@ -41,6 +41,26 @@ TEST(FrameworkCore, TRestRun) {
     EXPECT_TRUE(run.GetVerboseLevelString() == "debug");
 }
 
+TEST(FrameworkCore, TRestRun_store) {
+    const auto& store = TRestRun::GetGlobalStore();
+    EXPECT_EQ(store.empty(), true);
+
+    {
+        TRestRun run;
+        EXPECT_EQ(store.size() == 1, true);
+
+        TRestRun run2;
+        EXPECT_EQ(store.size() == 2, true);
+
+        auto run3 = new TRestRun();
+        EXPECT_EQ(store.size() == 3, true);
+        delete run3;
+        EXPECT_EQ(store.size() == 2, true);
+    }
+
+    EXPECT_EQ(store.empty(), true);
+}
+
 TEST(FrameworkCore, TRestMetadata) {
     // Create new TRestMetadata class
     class TRestMetadataTest : public TRestMetadata {


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Medium: 153](https://badgen.net/badge/PR%20Size/Medium%3A%20153/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-run-global-store/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-run-global-store) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=lobis-run-global-store)](https://github.com/rest-for-physics/framework/commits/lobis-run-global-store)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR adds a global store which provides access to all currently existing `TRestRun` objects from a static method. This is added at 6e769158278e48515fe1508f6d2c6af4e49f155f. This PR also has some small non-functional changes to the `TRestRun` class.

A test to check this is also added in this same PR.

How it works:

* The constructor of `TRestRun` will add a pointer to itself to the global store (which is static vector).
* The destructor of `TRestRun` will remove the pointers from the vector. This means that by construction all pointers inside the global store cannot be null, since once they are deleted, they get removed automatically.

Why this change was introduced:

This change does not add any overhead and provides a convinient way to access the current run without having to do injection. For example a `TRestGeant4Track` which is stored in a REST file may use this to access its `TRestRun` and from it get access to its corresponding `TRestGeant4Metadata` which could be used to get geometry information on the `PrintTrack` method, allowing to print volume names instead of ids which is what we are limited to at the moment.