### PR TITLE
Minor updates

### DIFF
--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -13,7 +13,7 @@ using namespace std;
 #ifdef WIN32
 // in windows the pointer address from string conversion is without "0x", we must add
 // the prefix so that ROOT can correctly initialize run/metadata objects
-#define PTR_ADDR_PREFIX "0x"  
+#define PTR_ADDR_PREFIX "0x"
 #else
 #define PTR_ADDR_PREFIX ""
 #endif  // WIN32
@@ -75,6 +75,7 @@ int main(int argc, char* argv[]) {
 
     gROOT->ProcessLine("#include <TRestStringHelper.h>");
     gROOT->ProcessLine("#include <TRestPhysics.h>");
+    gROOT->ProcessLine("#include <TRestSystemOfUnits.h>");
     if (loadMacros) {
         if (!silent) printf("= Loading macros ...\n");
         auto a = TRestTools::Execute(

--- a/source/framework/tools/inc/TRestStringHelper.h
+++ b/source/framework/tools/inc/TRestStringHelper.h
@@ -32,8 +32,8 @@ std::string EvaluateExpression(std::string exp);
 Float_t StringToFloat(std::string in);
 Double_t StringToDouble(std::string in);
 Int_t StringToInteger(std::string in);
-std::string IntegerToString(Int_t n);
-std::string DoubleToString(Double_t d);
+std::string IntegerToString(Int_t n, std::string format = "%d");
+std::string DoubleToString(Double_t d, std::string format = "%4.2lf");
 Bool_t StringToBool(std::string in);
 Long64_t StringToLong(std::string in);
 TVector3 StringTo3DVector(std::string in);
@@ -111,7 +111,7 @@ inline void usleep(int usec) {
     if (usec >= 1000) {
         _sleep(usec / 1000);
     } else {
-        _sleep(1); // sleep minimum 1ms on windows
+        _sleep(1);  // sleep minimum 1ms on windows
     }
 }
 inline void sleep(int sec) { _sleep(1000 * sec); }

--- a/source/framework/tools/src/TRestStringHelper.cxx
+++ b/source/framework/tools/src/TRestStringHelper.cxx
@@ -298,21 +298,21 @@ Int_t REST_StringHelper::FindNthStringPosition(const string& in, size_t pos, con
     return FindNthStringPosition(in, found_pos + 1, strToFind, nth - 1);
 }
 
-/// \brief This method matches a string with certain matcher. Returns true if matched. 
+/// \brief This method matches a string with certain matcher. Returns true if matched.
 /// Supports wildcard characters.
 ///
 /// Wildcard character includes "*" and "?". "*" means to replace any number of any characters
 /// "?" means to replace a single arbitary character.
-/// 
+///
 /// e.g. (string, matcher)
 /// "abcddd", "abc?d" --> not matched
 /// "abcddd", "abc??d" --> matched
 /// "abcddd", "abc*d" --> matched
-/// 
+///
 /// Note that this method is in equal-match logic. It is not matching substrings. So:
 /// "abcddd", "abcddd" --> matched
 /// "abcddd", "a?c" --> not matched
-/// 
+///
 /// Source code from
 /// https://blog.csdn.net/dalao_whs/article/details/110477705
 ///
@@ -579,12 +579,12 @@ Int_t REST_StringHelper::StringToInteger(string in) {
 ///////////////////////////////////////////////
 /// \brief Gets a string from an integer.
 ///
-string REST_StringHelper::IntegerToString(Int_t n) { return Form("%d", n); }
+string REST_StringHelper::IntegerToString(Int_t n, std::string format) { return Form(format.c_str(), n); }
 
 ///////////////////////////////////////////////
 /// \brief Gets a string from a double
 ///
-string REST_StringHelper::DoubleToString(Double_t d) { return Form("%4.2lf", d); }
+string REST_StringHelper::DoubleToString(Double_t d, std::string format) { return Form(format.c_str(), d); }
 
 Bool_t REST_StringHelper::StringToBool(std::string in) {
     return (ToUpper(in) == "TRUE" || ToUpper(in) == "ON");


### PR DESCRIPTION
- `restRoot` now will accept `units` directly by including `TRestSystemOfUnits.h`.

- `DoubleToString` and `IntegerToString` methods now receive an additional argument where we are able to define the output string format.
