### PR TITLE
Updated validation image tag to `rest-for-physics`

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -29,7 +29,7 @@ jobs:
     name: Build and run tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-dev
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
       - uses: actions/checkout@v3
       - name: Build and install
@@ -48,7 +48,7 @@ jobs:
     name: Build and cache installation
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-dev
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
       - uses: actions/checkout@v3
       - name: Build and install
@@ -80,7 +80,7 @@ jobs:
     name: "Metadata"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-dev
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v3
@@ -132,7 +132,7 @@ jobs:
     name: "PandaX-III"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-dev
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v3
@@ -209,7 +209,7 @@ jobs:
     name: "TREX-DM"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-dev
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v3
@@ -261,7 +261,7 @@ jobs:
     name: Run examples
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-dev
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v3

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics-dev
+image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
 
 # variables:
 #    GIT_SUBMODULE_STRATEGY: recursive
@@ -78,17 +78,17 @@ Validate Code:
     - python3 pull-submodules.py --force --dontask --latest:${CI_COMMIT_BRANCH} --exclude:iaxo,detector-template
     - python3 pipeline/validateProcesses.py source/libraries/
 
-#Build and Test:
-#  stage: test
-#  script:
-#    - cd ${CI_PROJECT_DIR}
-#    - python3 pull-submodules.py --force --dontask --latest:${CI_COMMIT_BRANCH} --exclude:iaxo,detector-template
-#    - mkdir ${CI_PROJECT_DIR}/build && cd ${CI_PROJECT_DIR}/build
-#    - cmake ${CI_PROJECT_DIR} -DTEST=ON -DREST_ALL_LIBS=ON
-#      -DREST_GARFIELD=OFF -DREST_G4=ON -DREST_WELCOME=OFF -DCMAKE_INSTALL_PREFIX=${CI_PROJECT_DIR}/install-test
-#    - make -j2 install
-#    - source ${CI_PROJECT_DIR}/install-test/thisREST.sh
-#    - ctest --output-on-failure -O ${CI_PROJECT_DIR}/build/Testing/summary.txt
+  #Build and Test:
+  #  stage: test
+  #  script:
+  #    - cd ${CI_PROJECT_DIR}
+  #    - python3 pull-submodules.py --force --dontask --latest:${CI_COMMIT_BRANCH} --exclude:iaxo,detector-template
+  #    - mkdir ${CI_PROJECT_DIR}/build && cd ${CI_PROJECT_DIR}/build
+  #    - cmake ${CI_PROJECT_DIR} -DTEST=ON -DREST_ALL_LIBS=ON
+  #      -DREST_GARFIELD=OFF -DREST_G4=ON -DREST_WELCOME=OFF -DCMAKE_INSTALL_PREFIX=${CI_PROJECT_DIR}/install-test
+  #    - make -j2 install
+  #    - source ${CI_PROJECT_DIR}/install-test/thisREST.sh
+  #    - ctest --output-on-failure -O ${CI_PROJECT_DIR}/build/Testing/summary.txt
 
   artifacts:
     name: "Testing"


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 18](https://badgen.net/badge/PR%20Size/Ok%3A%2018/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-update-pipeline-image/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-update-pipeline-image) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=lobis-update-pipeline-image)](https://github.com/rest-for-physics/framework/commits/lobis-update-pipeline-image)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

CI image was updated to `rest-for-physics-dev` in some parts of the pipeline / repositories due to compatibility problems, but it can now be unified with `rest-for-physics`.

The old `rest-for-physics` image (at the time of writing this PR) can be found under `rest-for-physics-reference-jun2022` tag.

Related PR:
* https://github.com/rest-for-physics/restG4/pull/59