### PR TITLE
New workflow frameworkPR for automatic submodule PR merging

### DIFF
--- a/.github/workflows/frameworkPR.yml
+++ b/.github/workflows/frameworkPR.yml
@@ -1,0 +1,89 @@
+name: Check on submodules PR
+
+on:
+  pull_request:
+    branches: [ "master" ]
+    types: [ "opened", "reopened", "created", "closed", "synchronize"]
+
+  workflow_dispatch:
+
+permissions: write-all
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  framework-pr:
+    strategy:
+      matrix:
+        submodules: ["rest-for-physics/rawlib", "rest-for-physics/detectorlib", "rest-for-physics/geant4lib","rest-for-physics/tracklib", "rest-for-physics/connectorslib", "rest-for-physics/axionlib", "rest-for-physics/legacylib", "rest-for-physics/restG4"]
+    runs-on: ubuntu-latest
+    if: github.head_ref || github.ref_name != 'master'
+    steps:
+    - uses: actions/checkout@v3
+    - name: Checkout submodules
+      uses: actions/checkout@v3
+      with: 
+        repository: ${{ matrix.submodules }}
+        path: submodule
+    - name: Check submodule branch
+      id: submoduleBranch
+      run: |
+        cd submodule
+        var=$(git ls-remote --heads origin ${{ env.BRANCH_NAME }})
+        echo $var
+        if [[ -z $var ]]; then
+          echo "Branch "${{ env.BRANCH_NAME }}" not found in " ${{ matrix.submodules }}
+          echo "::set-output name=exist::false"
+        else
+          echo "HEAD=$(echo ${{ env.BRANCH_NAME }})" >> $GITHUB_ENV
+          git fetch
+          git checkout ${{ env.BRANCH_NAME }}
+          git pull
+          echo "::set-output name=exist::true"
+        fi
+    - name: Check PR
+      id: PRCheck
+      if:  steps.submoduleBranch.outputs.exist == 'true'
+      run: |
+        cd submodule
+        #Check submodule PR
+        #gh config set git_protocol ssh --host github.com
+        gh auth status
+        gh pr status
+        gh pr view
+        prurl=$(gh pr view --json url -t '{{ .url }}')
+        echo "::set-output name=submoduleprurl::$prurl"
+        gh pr list
+        propen=$(gh pr list --head ${{ env.BRANCH_NAME }} --state open )
+        prreview=$(gh pr list --head ${{ env.BRANCH_NAME }} --state open --search "review:required" )
+        prapproved=$(gh pr list --head ${{ env.BRANCH_NAME }} --state open --search "review:approved" )
+        prstatus=$(gh pr list --head ${{ env.BRANCH_NAME }} --state open --search "status" )
+        echo "PR open " $propen " Review required " $prreview " Review approved " $prapproved " Status " $prstatus
+          if [[ -z $propen ]]; then
+            echo "No PR found or approved for branch " ${{ env.BRANCH_NAME }} " in submodule " ${{ matrix.submodules }}  " merge is not allowed"
+            exit 1
+          else
+            echo "::set-output name=mergeable::true"
+          fi
+      env:
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+    - name: Check output
+      run: |
+        echo "Mergeable " ${{ steps.PRCheck.outputs.mergeable }}
+        echo "Submodule PR url " ${{ steps.PRCheck.outputs.submoduleprurl }}
+    - name: Merge submodules
+      if: (github.event.action == 'closed' && github.event.pull_request.merged == true && steps.PRCheck.outputs.mergeable == 'true' && steps.submoduleBranch.outputs.exist == 'true')
+      run: |
+        cd submodule
+        #gh config set git_protocol ssh --host github.com
+        gh auth status
+        echo "actor " ${{ github.actor }}
+        gh pr merge --auto --merge "$PR_URL"
+      env:
+        PR_URL: ${{ steps.PRCheck.outputs.submoduleprurl }}
+        GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
Added new workflow for automatic merging of submodule PR when a submodule branch matches and a submodule PR exist:
- Check if any submodule branch matches framework branch
- In case a branch matches it check if a PR in the submodule exist
- Workflow will fail in case a matching submodule branch exist and there is no associated PR
- When the framework PR is merged, the associated submodules PR should be also merged
- Access tokens for the submodule merge are needed (need to be discussed)

Contributes to https://github.com/rest-for-physics/framework/issues/250