### PR TITLE
Added a pointer to TRestRun in TRestEvent

### DIFF
--- a/source/framework/core/inc/TRestEvent.h
+++ b/source/framework/core/inc/TRestEvent.h
@@ -115,6 +115,6 @@ class TRestEvent : public TObject {
     // Destructor
     virtual ~TRestEvent();
 
-    ClassDef(TRestEvent, 2);
+    ClassDef(TRestEvent, 1);
 };
 #endif

--- a/source/framework/core/inc/TRestEvent.h
+++ b/source/framework/core/inc/TRestEvent.h
@@ -46,6 +46,7 @@ class TRestEvent : public TObject {
     TTimeStamp fEventTime;  ///< Absolute event time
     Bool_t fOk;  ///< Flag to be used by processes to define an event status. fOk=true is the default.
 
+    TRestRun* fRun = nullptr;  //!
 #ifndef __CINT__
 
     TPad* fPad;  //!
@@ -105,6 +106,8 @@ class TRestEvent : public TObject {
     // Destructor
     virtual ~TRestEvent();
 
-    ClassDef(TRestEvent, 1);
+    friend class TRestRun;
+
+    ClassDef(TRestEvent, 2);
 };
 #endif

--- a/source/framework/core/inc/TRestEvent.h
+++ b/source/framework/core/inc/TRestEvent.h
@@ -86,7 +86,16 @@ class TRestEvent : public TObject {
     inline Bool_t isOk() const { return fOk; }
 
     virtual void Initialize() = 0;
-    virtual void InitializeWithMetadata(TRestRun* r);
+    virtual void InitializeWithMetadata(TRestRun* run);
+
+    //////////////////////////////////////////////////////////////////////////
+    /// \brief Initialize dynamical references when loading the event from a root file
+    ///
+    /// This method should only be called from `TRestRun::GetEntry` and it will give the corresponding
+    /// `TRestEvent` access to the instance of `TRestRun`.
+    /// In a derived class such as `TRestGeant4Event`, it can be overwritten to give each track access to the
+    /// event
+    virtual void InitializeReferences(TRestRun* run);
 
     virtual void PrintEvent() const;
 
@@ -105,8 +114,6 @@ class TRestEvent : public TObject {
     TRestEvent();
     // Destructor
     virtual ~TRestEvent();
-
-    friend class TRestRun;
 
     ClassDef(TRestEvent, 2);
 };

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -93,8 +93,10 @@ class TRestRun : public TRestMetadata {
         }
 
         fCurrentEvent = i;
-        
-        if (fInputEvent != nullptr) fInputEvent->fRun = this;
+
+        if (fInputEvent != nullptr) {
+            fInputEvent->InitializeReferences(this);
+        }
     }
 
     void GetNextEntry() {

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -93,7 +93,8 @@ class TRestRun : public TRestMetadata {
         }
 
         fCurrentEvent = i;
-        fInputEvent->fRun = this;
+        
+        if (fInputEvent != nullptr) fInputEvent->fRun = this;
     }
 
     void GetNextEntry() {

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -35,7 +35,7 @@ class TRestRun : public TRestMetadata {
     Double_t fStartTime;  ///< Event absolute starting time/date (unix timestamp)
     Double_t fEndTime;    ///< Event absolute ending time/date (unix timestamp)
     Int_t fEntriesSaved;
-    Int_t fNFilesSplit;  // Number of files being split. Used when retrieveing
+    Int_t fNFilesSplit;  // Number of files being split. Used when retrieving
 
     // data-like metadata objects
     std::vector<TRestMetadata*> fMetadata;       //!
@@ -93,6 +93,7 @@ class TRestRun : public TRestMetadata {
         }
 
         fCurrentEvent = i;
+        fInputEvent->fRun = this;
     }
 
     void GetNextEntry() {

--- a/source/framework/core/src/TRestEvent.cxx
+++ b/source/framework/core/src/TRestEvent.cxx
@@ -168,7 +168,9 @@ void TRestEvent::RestartPad(Int_t nElements) {
     fPad->Draw();
 }
 
-void TRestEvent::InitializeWithMetadata(TRestRun* r) { Initialize(); }
+void TRestEvent::InitializeWithMetadata(TRestRun* run) { Initialize(); }
+
+void TRestEvent::InitializeReferences(TRestRun* run) { fRun = run; }
 
 //////////////////////////////////////////////////////////////////////////
 /// Run to print event data info on console


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 19](https://badgen.net/badge/PR%20Size/Ok%3A%2019/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-trestrun-event-injection/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-trestrun-event-injection) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=lobis-trestrun-event-injection)](https://github.com/rest-for-physics/framework/commits/lobis-trestrun-event-injection)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR adds a pointer to `TRestRun` to `TRestEvent` which is initialized when retrieving the event via `TRestRun::GetEntry`. This allows `TRestEvent` to access its corresponding metadata which can be used to improve print methods output for example.

https://github.com/rest-for-physics/geant4lib/pull/56 makes use of this PR.