### PR TITLE
validateProcesses.py adding a quick fix while searching ProcessEvent method

### DIFF
--- a/pipeline/validateProcesses.py
+++ b/pipeline/validateProcesses.py
@@ -19,7 +19,7 @@ def validateProcess(className):
     with open(className, 'r', encoding="utf-8") as file:
         data = file.read()
 
-        data = data[data.find("ProcessEvent"):]
+        data = data[data.find("::ProcessEvent"):]
         data = removeCppComment(data)
         data = getMethodDefinition(data)
         #data = removeCppComment(data)


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/validate_processes_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/validate_processes_fix) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=validate_processes_fix)](https://github.com/rest-for-physics/framework/commits/validate_processes_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The `validateProcesses.py` is failing on the pipeline validation: rest-for-physics/axionlib#12

The problem is that the keyword `ProcessEvent` appears in the documentation of `TRestAxionEventProcess` but in reality there is no `::ProcessEvent` implementation. I added a more strict method search inside the script.