### PR TITLE
TRestTools::isRootFile improving filename extension identification

### DIFF
--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -617,9 +617,9 @@ bool TRestTools::fileExists(const string& filename) { return std::filesystem::ex
 /// \brief Returns true if the **filename** has *.root* extension.
 ///
 bool TRestTools::isRootFile(const string& filename) {
-    if (filename.find(".root") == string::npos) return false;
+    if (GetFileNameExtension(filename) == ".root") return true;
 
-    return true;
+    return false;
 }
 
 ///////////////////////////////////////////////

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -617,9 +617,7 @@ bool TRestTools::fileExists(const string& filename) { return std::filesystem::ex
 /// \brief Returns true if the **filename** has *.root* extension.
 ///
 bool TRestTools::isRootFile(const string& filename) {
-    if (GetFileNameExtension(filename) == ".root") return true;
-
-    return false;
+    return GetFileNameExtension(filename) == ".root";
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_tools_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_tools_fix) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_tools_fix)](https://github.com/rest-for-physics/framework/commits/jgalan_tools_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Some times if we invoke `restRoot` with a macro in the command line that takes as argument a `.root` file, it will interpret that it is a file and not a macro. The problem was not really bad, but it was generating an unnecessary warning telling that the file was not found.

The problem was solved by improving `TRestTools::IsRootFile` method.