### PR TITLE
Update TRestMetadata classes default title and name

### DIFF
--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -817,8 +817,9 @@ Int_t TRestMetadata::LoadSectionMetadata() {
     this->SetName(GetParameter("name", "default" + string(this->ClassName())).c_str());
     this->SetTitle(GetParameter("title", "Default " + string(this->ClassName())).c_str());
     this->SetSectionName(this->ClassName());
-    fStore =
-        ToUpper(GetParameter("store", "true")) == "TRUE" || ToUpper(GetParameter("store", "true")) == "ON";
+
+    fStore = StringToBool(GetParameter("store", to_string(true)));
+
     return 0;
 }
 

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -814,12 +814,11 @@ Int_t TRestMetadata::LoadSectionMetadata() {
     fVerboseLevel = StringToVerboseLevel(debugStr);
 
     // fill the general metadata info: name, title, fstore
-    this->SetName(GetParameter("name", "defaultName").c_str());
-    this->SetTitle(GetParameter("title", "defaultTitle").c_str());
+    this->SetName(GetParameter("name", "default" + string(this->ClassName())).c_str());
+    this->SetTitle(GetParameter("title", "Default " + string(this->ClassName())).c_str());
     this->SetSectionName(this->ClassName());
     fStore =
         ToUpper(GetParameter("store", "true")) == "TRUE" || ToUpper(GetParameter("store", "true")) == "ON";
-
     return 0;
 }
 

--- a/source/framework/tools/inc/TRestStringHelper.h
+++ b/source/framework/tools/inc/TRestStringHelper.h
@@ -36,7 +36,7 @@ Double_t StringToDouble(std::string in);
 Int_t StringToInteger(std::string in);
 std::string IntegerToString(Int_t n, std::string format = "%d");
 std::string DoubleToString(Double_t d, std::string format = "%4.2lf");
-Bool_t StringToBool(const std::string& booleanString);
+Bool_t StringToBool(std::string booleanString);
 Long64_t StringToLong(std::string in);
 TVector3 StringTo3DVector(std::string in);
 TVector2 StringTo2DVector(std::string in);

--- a/source/framework/tools/inc/TRestStringHelper.h
+++ b/source/framework/tools/inc/TRestStringHelper.h
@@ -36,7 +36,7 @@ Double_t StringToDouble(std::string in);
 Int_t StringToInteger(std::string in);
 std::string IntegerToString(Int_t n, std::string format = "%d");
 std::string DoubleToString(Double_t d, std::string format = "%4.2lf");
-Bool_t StringToBool(std::string in);
+Bool_t StringToBool(const std::string& booleanString);
 Long64_t StringToLong(std::string in);
 TVector3 StringTo3DVector(std::string in);
 TVector2 StringTo2DVector(std::string in);

--- a/source/framework/tools/src/TRestStringHelper.cxx
+++ b/source/framework/tools/src/TRestStringHelper.cxx
@@ -1,15 +1,15 @@
 #include "TRestStringHelper.h"
 
+#include <Rtypes.h>
+#include <TApplication.h>
+#include <TSystem.h>
+
 #include <thread>
 
-#include "Rtypes.h"
-#include "TApplication.h"
-#include "TSystem.h"
-
 #if ROOT_VERSION_CODE < ROOT_VERSION(6, 0, 0)
-#include "TFormula.h"
+#include <TFormula.h>
 #else
-#include "v5/TFormula.h"
+#include <v5/TFormula.h>
 #endif
 
 using namespace std;
@@ -33,7 +33,7 @@ Int_t REST_StringHelper::isAExpression(const string& in) {
 
     vector<string> funcs{"sqrt", "log", "exp", "gaus", "cos", "sin", "tan", "atan", "acos", "asin"};
     for (const auto& item : funcs) {
-        if (in.find(item) != std::string::npos) {
+        if (in.find(item) != string::npos) {
             symbol = true;
             break;
         }
@@ -58,7 +58,7 @@ Int_t REST_StringHelper::isAExpression(const string& in) {
         for (const auto& item : funcs) {
             temp = Replace(temp, item, "0", 0);
         }
-        if (temp.find_first_not_of("-0123456789e+*/.,)( ^%") == std::string::npos) {
+        if (temp.find_first_not_of("-0123456789e+*/.,)( ^%") == string::npos) {
             if (temp.find("/") == 0 || temp.find("./") == 0 || temp.find("../") == 0)
                 return 0;  // identify path
             return 1;
@@ -76,10 +76,10 @@ Int_t REST_StringHelper::isAExpression(const string& in) {
 ///
 /// It will not round the number. Perhaps on the next update of this method.
 ///
-std::string REST_StringHelper::CropWithPrecision(std::string in, Int_t precision) {
+string REST_StringHelper::CropWithPrecision(string in, Int_t precision) {
     if (precision == 0) return in;
     if (REST_StringHelper::isANumber(in) && in.find(".") != string::npos) {
-        std::string rootStr;
+        string rootStr;
         if (in.find("e") != string::npos) rootStr = in.substr(in.find("e"), -1);
         return in.substr(0, in.find(".") + precision + 1) + rootStr;
     }
@@ -95,21 +95,21 @@ std::string REST_StringHelper::CropWithPrecision(std::string in, Int_t precision
 /// I.e. The sentence "The following operation 3 x 4 is '3*4'" will be translated to
 /// "The following operatin 3 x 4 is 12".
 ///
-std::string REST_StringHelper::ReplaceMathematicalExpressions(std::string buffer, Int_t precision,
-                                                              std::string errorMessage) {
+string REST_StringHelper::ReplaceMathematicalExpressions(string buffer, Int_t precision,
+                                                         string errorMessage) {
     buffer = Replace(buffer, " AND ", " && ");
     buffer = Replace(buffer, " OR ", " || ");
 
-    if (buffer.find("'") != string::npos && std::count(buffer.begin(), buffer.end(), '\'') % 2 == 0) {
+    if (buffer.find("'") != string::npos && count(buffer.begin(), buffer.end(), '\'') % 2 == 0) {
         size_t pos1 = buffer.find("'");
         size_t pos2 = buffer.find("'", pos1 + 1);
         string expr = buffer.substr(pos1 + 1, pos2 - pos1 - 1);
 
         if (!isAExpression(expr)) return buffer;
 
-        std::string evalExpr = ReplaceMathematicalExpressions(expr, precision);
+        string evalExpr = ReplaceMathematicalExpressions(expr, precision);
         expr = "'" + expr + "'";
-        std::string newbuff = Replace(buffer, expr, evalExpr);
+        string newbuff = Replace(buffer, expr, evalExpr);
 
         return ReplaceMathematicalExpressions(newbuff, precision, errorMessage);
     }
@@ -123,7 +123,7 @@ std::string REST_StringHelper::ReplaceMathematicalExpressions(std::string buffer
 
     bool erased = false;
 
-    std::vector<std::string> Expressions = Split(temp, ",");
+    vector<string> Expressions = Split(temp, ",");
 
     if (Expressions.size() > 1 && Expressions[0][0] == '(' &&
         Expressions[Expressions.size() - 1][Expressions[Expressions.size() - 1].size() - 1] == ')') {
@@ -159,7 +159,7 @@ std::string REST_StringHelper::ReplaceMathematicalExpressions(std::string buffer
 /// \brief Evaluates a complex numerical expression and returns the resulting
 /// value using TFormula.
 ///
-std::string REST_StringHelper::EvaluateExpression(std::string exp) {
+string REST_StringHelper::EvaluateExpression(string exp) {
     if (!isAExpression(exp)) {
         return exp;
     }
@@ -212,7 +212,7 @@ Int_t REST_StringHelper::GetChar(string hint) {
 /// not it returns 0.
 ///
 Int_t REST_StringHelper::isANumber(string in) {
-    return (in.find_first_not_of("-+0123456789.eE") == std::string::npos && in.length() != 0);
+    return (in.find_first_not_of("-+0123456789.eE") == string::npos && in.length() != 0);
 }
 
 ///////////////////////////////////////////////
@@ -225,9 +225,9 @@ Int_t REST_StringHelper::isANumber(string in) {
 /// Input: "abc" and "", Output: { "a", "b", "c" }
 /// Input: "abc:def" and ":", Output: { "abc", "def" }
 /// Input: "abc:def" and ":def", Output: { "abc" }
-std::vector<string> REST_StringHelper::Split(std::string in, string separator, bool allowBlankString,
-                                             bool removeWhiteSpaces, int startPos) {
-    std::vector<string> result;
+vector<string> REST_StringHelper::Split(string in, string separator, bool allowBlankString,
+                                        bool removeWhiteSpaces, int startPos) {
+    vector<string> result;
 
     int pos = startPos;
     int front = 0;
@@ -250,7 +250,7 @@ std::vector<string> REST_StringHelper::Split(std::string in, string separator, b
 ///
 /// e.g. Input: "1,2,3,4", Output: {1.,2.,3.,4.}
 ///
-std::vector<double> REST_StringHelper::StringToElements(std::string in, string separator) {
+vector<double> REST_StringHelper::StringToElements(string in, string separator) {
     vector<double> result;
     vector<string> vec_str = REST_StringHelper::Split(in, separator);
     for (unsigned int i = 0; i < vec_str.size(); i++) {
@@ -268,15 +268,15 @@ std::vector<double> REST_StringHelper::StringToElements(std::string in, string s
 /// elements from a string with the following format "[a,b,c]" where a,b,c
 /// are double numbers.
 ///
-std::vector<double> REST_StringHelper::StringToElements(std::string in, string headChar, string separator,
-                                                        string tailChar) {
-    std::vector<double> result;
+vector<double> REST_StringHelper::StringToElements(string in, string headChar, string separator,
+                                                   string tailChar) {
+    vector<double> result;
     size_t startPos = in.find(headChar);
     size_t endPos = in.find(tailChar);
     if (startPos == string::npos || endPos == string::npos) {
         return result;
     }
-    std::vector<string> values = Split(in.substr(startPos + 1, endPos - startPos - 1), ",");
+    vector<string> values = Split(in.substr(startPos + 1, endPos - startPos - 1), ",");
 
     for (unsigned int i = 0; i < values.size(); i++) {
         double temp = REST_StringHelper::StringToDouble(values[i]);
@@ -355,7 +355,7 @@ Int_t REST_StringHelper::FindNthStringPosition(const string& in, size_t pos, con
 /// Source code from
 /// https://blog.csdn.net/dalao_whs/article/details/110477705
 ///
-Bool_t REST_StringHelper::MatchString(std::string str, std::string matcher) {
+Bool_t REST_StringHelper::MatchString(string str, string matcher) {
     if (str.size() > 256 || matcher.size() > 256) {
         RESTError << "REST_StringHelper::MatchString(): string size too large" << RESTendl;
         return false;
@@ -475,7 +475,7 @@ string REST_StringHelper::Replace(string in, string thisString, string byThisStr
     return out;
 }
 
-std::string REST_StringHelper::EscapeSpecialLetters(string in) {
+string REST_StringHelper::EscapeSpecialLetters(string in) {
     string result = Replace(in, "(", "\\(", 0);
     result = Replace(result, ")", "\\)", 0);
     result = Replace(result, "$", "\\$", 0);
@@ -610,7 +610,7 @@ Float_t REST_StringHelper::StringToFloat(string in) {
 ///
 Int_t REST_StringHelper::StringToInteger(string in) {
     // If we find a hexadecimal number
-    if (in.find("0x") != std::string::npos) return (Int_t)std::stoul(in, nullptr, 16);
+    if (in.find("0x") != string::npos) return (Int_t)stoul(in, nullptr, 16);
 
     return (Int_t)StringToDouble(in);
 }
@@ -618,20 +618,20 @@ Int_t REST_StringHelper::StringToInteger(string in) {
 ///////////////////////////////////////////////
 /// \brief Gets a string from an integer.
 ///
-string REST_StringHelper::IntegerToString(Int_t n, std::string format) { return Form(format.c_str(), n); }
+string REST_StringHelper::IntegerToString(Int_t n, string format) { return Form(format.c_str(), n); }
 
 ///////////////////////////////////////////////
 /// \brief Gets a string from a double
 ///
-string REST_StringHelper::DoubleToString(Double_t d, std::string format) { return Form(format.c_str(), d); }
+string REST_StringHelper::DoubleToString(Double_t d, string format) { return Form(format.c_str(), d); }
 
-Bool_t REST_StringHelper::StringToBool(const std::string& booleanString) {
+Bool_t REST_StringHelper::StringToBool(const string& booleanString) {
     const auto booleanStringUpper = ToUpper(booleanString);
     return (booleanStringUpper == "TRUE" || booleanStringUpper == "ON" ||
             booleanStringUpper == to_string(true));
 }
 
-Long64_t REST_StringHelper::StringToLong(std::string in) {
+Long64_t REST_StringHelper::StringToLong(string in) {
     if (in.find_first_of("eE") != string::npos) {
         // in case for scientific numbers
         return (Long64_t)StringToDouble(in);
@@ -703,7 +703,7 @@ TVector2 REST_StringHelper::StringTo2DVector(string in) {
 ///////////////////////////////////////////////
 /// \brief Convert string to its upper case. Alternative of TString::ToUpper
 ///
-std::string REST_StringHelper::ToUpper(std::string s) {
+string REST_StringHelper::ToUpper(string s) {
     transform(s.begin(), s.end(), s.begin(), (int (*)(int))toupper);
     return s;
 }
@@ -711,16 +711,16 @@ std::string REST_StringHelper::ToUpper(std::string s) {
 ///////////////////////////////////////////////
 /// \brief Convert the first character of a string to upper case.
 ///
-std::string REST_StringHelper::FirstToUpper(std::string s) {
+string REST_StringHelper::FirstToUpper(string s) {
     if (s.length() == 0) return s;
-    s[0] = *REST_StringHelper::ToUpper(std::string(&s[0], 1)).c_str();
+    s[0] = *REST_StringHelper::ToUpper(string(&s[0], 1)).c_str();
     return s;
 }
 
 ///////////////////////////////////////////////
 /// \brief Convert string to its lower case. Alternative of TString::ToLower
 ///
-std::string REST_StringHelper::ToLower(std::string s) {
+string REST_StringHelper::ToLower(string s) {
     transform(s.begin(), s.end(), s.begin(), (int (*)(int))tolower);
     return s;
 }
@@ -729,7 +729,7 @@ std::string REST_StringHelper::ToLower(std::string s) {
 /// \brief Removes all white spaces found at the end of the string
 /// (https://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring)
 ///
-std::string REST_StringHelper::RightTrim(std::string s, const char* t) {
+string REST_StringHelper::RightTrim(string s, const char* t) {
     s.erase(s.find_last_not_of(t) + 1);
     return s;
 }
@@ -738,7 +738,7 @@ std::string REST_StringHelper::RightTrim(std::string s, const char* t) {
 /// \brief Removes all white spaces found at the beginning of the string
 /// (https://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring)
 ///
-std::string REST_StringHelper::LeftTrim(std::string s, const char* t) {
+string REST_StringHelper::LeftTrim(string s, const char* t) {
     s.erase(0, s.find_first_not_of(t));
     return s;
 }
@@ -747,12 +747,12 @@ std::string REST_StringHelper::LeftTrim(std::string s, const char* t) {
 /// \brief Removes all white spaces found at the beginning and the end of the string
 /// (https://stackoverflow.com/questions/216823/whats-the-best-way-to-trim-stdstring)
 ///
-std::string REST_StringHelper::Trim(std::string s, const char* t) { return LeftTrim(RightTrim(s, t), t); }
+string REST_StringHelper::Trim(string s, const char* t) { return LeftTrim(RightTrim(s, t), t); }
 
 ///////////////////////////////////////////////
 /// \brief It trims and uppers the string
 ///
-std::string REST_StringHelper::TrimAndUpper(std::string s) {
+string REST_StringHelper::TrimAndUpper(string s) {
     s = Trim(s);
     s = ToUpper(s);
     return s;
@@ -761,7 +761,7 @@ std::string REST_StringHelper::TrimAndUpper(std::string s) {
 ///////////////////////////////////////////////
 /// \brief It trims and lowers the string
 ///
-std::string REST_StringHelper::TrimAndLower(std::string s) {
+string REST_StringHelper::TrimAndLower(string s) {
     s = Trim(s);
     s = ToLower(s);
     return s;
@@ -835,14 +835,14 @@ string REST_StringHelper::ParameterNameToDataMemberName(string name) {
 /// delete ff;
 /// \endcode
 ///
-TF1* REST_StringHelper::CreateTF1FromString(std::string func, double init, double end) {
+TF1* REST_StringHelper::CreateTF1FromString(string func, double init, double end) {
     string tf1 = func;
     // Number of parameters
-    size_t n = std::count(func.begin(), func.end(), '[');
+    size_t n = count(func.begin(), func.end(), '[');
     // Reading options
     int a = 0;
     vector<int> optPos(n);
-    std::vector<std::string> options(n);  // Vector of strings of any size.
+    vector<string> options(n);  // Vector of strings of any size.
     for (int i = 0; i < n; i++) {
         optPos[i] = func.find("[", a);
         options[i] =
@@ -852,7 +852,7 @@ TF1* REST_StringHelper::CreateTF1FromString(std::string func, double init, doubl
     // Removing options from function string
     for (int i = 0; i < n; i++) {
         tf1.replace(optPos[n - 1 - i] + 1, (func.find("]", optPos[n - 1 - i]) - optPos[n - 1 - i] - 1),
-                    std::string(1, func[optPos[n - 1 - i] + 1]));
+                    string(1, func[optPos[n - 1 - i] + 1]));
     }
 
     // Function
@@ -861,7 +861,7 @@ TF1* REST_StringHelper::CreateTF1FromString(std::string func, double init, doubl
 
     // Initial conditions
     for (int i = 0; i < n; i++) {
-        if (options[i].find("=") != std::string::npos) {
+        if (options[i].find("=") != string::npos) {
             string op = options[i].substr(options[i].find_last_of("=") + 1,
                                           options[i].find("(") - options[i].find_last_of("=") - 1);
             if (isANumber(op)) {
@@ -876,7 +876,7 @@ TF1* REST_StringHelper::CreateTF1FromString(std::string func, double init, doubl
 
     // Fixed values
     for (int i = 0; i < n; i++) {
-        if (std::count(options[i].begin(), options[i].end(), '=') == 2) {
+        if (count(options[i].begin(), options[i].end(), '=') == 2) {
             string op = options[i].substr(options[i].find_last_of("=") + 1,
                                           options[i].find("(") - options[i].find_last_of("=") - 1);
             if (isANumber(op)) {
@@ -888,7 +888,7 @@ TF1* REST_StringHelper::CreateTF1FromString(std::string func, double init, doubl
 
     // Ranges
     for (int i = 0; i < n; i++) {
-        if (options[i].find("(") != std::string::npos) {
+        if (options[i].find("(") != string::npos) {
             string op =
                 options[i].substr(options[i].find("(") + 1, options[i].find(")") - options[i].find("(") - 1);
             f->SetParLimits(i, stod(op.substr(0, op.find(","))),

--- a/source/framework/tools/src/TRestStringHelper.cxx
+++ b/source/framework/tools/src/TRestStringHelper.cxx
@@ -625,8 +625,10 @@ string REST_StringHelper::IntegerToString(Int_t n, std::string format) { return 
 ///
 string REST_StringHelper::DoubleToString(Double_t d, std::string format) { return Form(format.c_str(), d); }
 
-Bool_t REST_StringHelper::StringToBool(std::string in) {
-    return (ToUpper(in) == "TRUE" || ToUpper(in) == "ON");
+Bool_t REST_StringHelper::StringToBool(const std::string& booleanString) {
+    const auto booleanStringUpper = ToUpper(booleanString);
+    return (booleanStringUpper == "TRUE" || booleanStringUpper == "ON" ||
+            booleanStringUpper == to_string(true));
 }
 
 Long64_t REST_StringHelper::StringToLong(std::string in) {

--- a/source/framework/tools/src/TRestStringHelper.cxx
+++ b/source/framework/tools/src/TRestStringHelper.cxx
@@ -625,10 +625,10 @@ string REST_StringHelper::IntegerToString(Int_t n, string format) { return Form(
 ///
 string REST_StringHelper::DoubleToString(Double_t d, string format) { return Form(format.c_str(), d); }
 
-Bool_t REST_StringHelper::StringToBool(const string& booleanString) {
+Bool_t REST_StringHelper::StringToBool(string booleanString) {
     const auto booleanStringUpper = ToUpper(booleanString);
-    return (booleanStringUpper == "TRUE" || booleanStringUpper == "ON" ||
-            booleanStringUpper == to_string(true));
+    return booleanStringUpper == "TRUE" || booleanStringUpper == "ON" ||
+           booleanStringUpper == to_string(true);
 }
 
 Long64_t REST_StringHelper::StringToLong(string in) {


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 57](https://badgen.net/badge/PR%20Size/Ok%3A%2057/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-metadata-defaults/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-metadata-defaults) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=lobis-metadata-defaults)](https://github.com/rest-for-physics/framework/commits/lobis-metadata-defaults)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Before this PR all `TRestMetadata` classes were using `defaultName` and `defaultTitle` for the default value of said parameters. This was causing an issue when multiple metadata classes were left with the default name values, as the name needs to be unique in the root file.

This PR updates the name of these parameters so that it depends on the class name (`defaultName` -> `defaultTRestGeant4Metadata` etc.). This way if the metadata classes are unique in the root file there won't be a problem even if they are not explicitly named (such is the case in `restG4` simulations).

I also updated the `REST_StringHelper::StringToBool` to also support `std::to_string(true)` as argument and normalized the usage of `std::` in the source file.

I had to add 5e78026dc0b8dd21b4d7b594305bd37d39d23bf5 to fix compilation issues related to reflection, perhaps @nkx111 could take a look and prevent these from happening in the future.