### PR TITLE
TRestPhysics.h added parabolic/hyperbolic interaction

### DIFF
--- a/source/framework/tools/inc/TRestPhysics.h
+++ b/source/framework/tools/inc/TRestPhysics.h
@@ -78,7 +78,7 @@ TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, TV
                                     TVector3 const& a);
   
 TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
-                                         const Double_t& R3, const Double_t& lMirr);
+                                        const Double_t& R3, const Double_t& lMirr);
 
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
                                          const Double_t& R3, const Double_t& lMirr, const Double_t& focal);

--- a/source/framework/tools/inc/TRestPhysics.h
+++ b/source/framework/tools/inc/TRestPhysics.h
@@ -76,8 +76,18 @@ Double_t GetVectorsAngle(const TVector3& v1, const TVector3& v2);
 
 TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, TVector3 const& n,
                                     TVector3 const& a);
+  
+TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
+                                         const Double_t& R3);
+
+TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
+                                         const Double_t& R3, const Double_t& focal);
 
 TVector3 GetConeNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R = 0);
+  
+TVector3 GetParabolicNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R3);
+  
+TVector3 GetHyperbolicNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R3, const Double_t& focal);
 
 TMatrixD GetConeMatrix(const TVector3& d, const Double_t& cosTheta);
 

--- a/source/framework/tools/inc/TRestPhysics.h
+++ b/source/framework/tools/inc/TRestPhysics.h
@@ -78,10 +78,10 @@ TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, TV
                                     TVector3 const& a);
   
 TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
-                                         const Double_t& R3);
+                                         const Double_t& R3, const Double_t& lMirr);
 
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
-                                         const Double_t& R3, const Double_t& focal);
+                                         const Double_t& R3, const Double_t& lMirr, const Double_t& focal);
 
 TVector3 GetConeNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R = 0);
   

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -207,7 +207,7 @@ TVector3 GetParabolicNormal(const TVector3& pos, const Double_t& alpha, const Do
         1 / (R3 * TMath::Tan(alpha) / TMath::Sqrt(R3 * R3 + R3 * 2 * TMath::Tan(alpha) * (-pos.Z())));
     Double_t n = TMath::Sqrt(pos.X() * pos.X() + pos.Y() * pos.Y()) - m * pos.Z();
     normalVec.SetZ(pos.Z() - (-n / m));
-    return normalVec;
+    return normalVec.Unit();
 }
 
 ///////////////////////////////////////////////
@@ -227,7 +227,7 @@ TVector3 GetHyperbolicNormal(const TVector3& pos, const Double_t& alpha, const D
                                                 (1.0 + (-z) / (focal + R3 / TMath::Tan(2 * alpha)))));
     Double_t n = TMath::Sqrt(pos.X() * pos.X() + pos.Y() * pos.Y()) - m * pos.Z();
     normalVec.SetZ(pos.Z() - (-n / m));
-    return normalVec;
+    return normalVec.Unit();
 }
 
 ///////////////////////////////////////////////

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -218,13 +218,12 @@ TVector3 GetParabolicNormal(const TVector3& pos, const Double_t& alpha, const Do
 ///
 TVector3 GetHyperbolicNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R3,
                              const Double_t& focal) {
-    Double_t z = 1;  /// This is just a temp value to fix compilation issues
     TVector3 normalVec = pos;
     Double_t beta = 3 * alpha;
     /// Just replaced here *TMath::Cot by /TMath::Tan to fix compilation issues
-    Double_t m = 1 / (R3 * TMath::Tan(beta) * (1 + 2 * (-z) / (focal + R3 / TMath::Tan(2 * alpha))) /
-                      TMath::Sqrt(R3 * R3 + R3 * 2 * TMath::Tan(beta) * (-z) *
-                                                (1.0 + (-z) / (focal + R3 / TMath::Tan(2 * alpha)))));
+    Double_t m = 1 / (R3 * TMath::Tan(beta) * (1 - 2 * pos.Z() / (focal + R3 / TMath::Tan(2 * alpha))) /
+                      TMath::Sqrt(R3 * R3 - R3 * 2 * TMath::Tan(beta) * pos.Z() *
+                                                (1.0 - pos.Z() / (focal + R3 / TMath::Tan(2 * alpha)))));
     Double_t n = TMath::Sqrt(pos.X() * pos.X() + pos.Y() * pos.Y()) - m * pos.Z();
     normalVec.SetZ(pos.Z() - (-n / m));
     return normalVec.Unit();

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -103,7 +103,7 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
         return pos + root1 * dir;
     }
     else if (pos.Z() + root2 * dir.Z() > -lMirr and pos.Z() + root2 * dir.Z() < 0){
-        return pos + root1 * dir;
+        return pos + root2 * dir;
     }
     RESTError << "No intersection found" << RESTendl;
     return pos + 0 * dir;
@@ -120,7 +120,7 @@ TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& di
                                          const Double_t& R3, const Double_t& lMirr, const Double_t& focal) {
     Double_t beta = 3 * alpha;
     Double_t e = 2 * R3 * TMath::Tan(beta);
-    Double_t g = 2.0 * R3 * TMath::Tan(beta) / (focal + R3 * TMath::Cot(2.0 * alpha));
+    Double_t g = 2 * R3 * TMath::Tan(beta) / (focal + R3 * TMath::Cot(2 * alpha));
     Double_t a = dir.X() * dir.X() + dir.Y() * dir.Y() - g * dir.Z() * dir.Z();
     Double_t b = 2 * (pos.X() * dir.X() + pos.Y() * dir.Y() - g * dir.Z() * pos.Z()) + e * dir.Z();
     Double_t halfb = b / 2;
@@ -132,7 +132,7 @@ TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& di
         return pos + root1 * dir;
     }
     else if (pos.Z() + root2 * dir.Z() > 0 and pos.Z() + root2 * dir.Z() < lMirr){
-        return pos + root1 * dir;
+        return pos + root2 * dir;
     }
     RESTError << "No intersection found" << RESTendl;
     return pos + 0 * dir;
@@ -193,6 +193,19 @@ TVector3 GetConeNormal(const TVector3& pos, const Double_t& alpha, const Double_
 
     return -TVector3(cosA * pos.X() / r, cosA * pos.Y() / r, sinA);
 }
+
+    
+TVector3 GetParabolicNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R3){
+    TVector3 normalVec = pos;
+    Double_t m = 1 / (R3 * TMath::Tan(alpha) / TMath::Sqrt(R3 * R3 + R3 * 2 * TMath::Tan(alpha) * (- pos.Z())));
+    Double_t n = TMath::Sqrt(pos.X() * pos.X() + pos.Y() * pos.Y()) - m * pos.Z();
+    normalVec.SetZ(pos.Z() - (- n / m));
+    return normalVec;
+}
+  
+TVector3 GetHyperbolicNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R3, const Double_t& focal){
+}
+
 
 ///////////////////////////////////////////////
 /// \brief This method will find the intersection of the trajectory defined by the vector starting at

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -87,32 +87,55 @@ TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, co
 /// This method will find the intersection between a vector and a parabolic shape where alpha is the angle 
 /// between the optical axis and the paraboloid at the plane where the paraboloid has a radius of R3.
 /// The paraboloid is rotational symmetric around the optical axis. Alpha in rad.
-/// Te region in which the intersection can happen here is between -lMirr and 0 on the z (optical) axis
+/// The region in which the intersection can happen here is between -lMirr and 0 on the z (optical) axis
     
 TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
                                          const Double_t& R3, const Double_t& lMirr) {
     Double_t e = 2 * R3 * TMath::Tan(alpha);
-    Double_t a = dir[0] * dir[0] + dir[1] * dir[1];
-    Double_t b = 2 * (pos[0] * dir[0] + pos[1] * dir[1]) + e * dir[2];
+    Double_t a = dir.X() * dir.X() + dir.Y() * dir.Y();
+    Double_t b = 2 * (pos.X() * dir.X() + pos.Y() * dir.Y()) + e * dir.Z();
     Double_t halfb = b / 2;
-    Double_t c = pos[0] * pos[0] + pos[1] * pos[1] - R3 * R3 + e * pos[2];
+    Double_t c = pos.X() * pos.X() + pos.Y() * pos.Y() - R3 * R3 + e * pos.Z();
     Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
     Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
     Double_t s = 0;
-    if (pos[2] + root1 * dir[2] > -lMirr and pos[2] + root1 * dir[2] < 0){
+    if (pos.Z() + root1 * dir.Z() > -lMirr and pos.Z() + root1 * dir.Z() < 0){
         return pos + root1 * dir;
     }
-    else if (pos[2] + root2 * dir[2] > -lMirr and pos[2] + root2 * dir[2] < 0){
+    else if (pos.Z() + root2 * dir.Z() > -lMirr and pos.Z() + root2 * dir.Z() < 0){
         return pos + root1 * dir;
     }
     RESTError << "No intersection found" << RESTendl;
-    return pos + 0 * dir
+    return pos + 0 * dir;
  
 }    
 
+//////////////////////////////////////////////
+/// This method will find the intersection between a vector and a hyperbolic shape where 3 * alpha is the angle 
+/// between the optical axis and the hyperboloid at the plane where the hyperboloid has a radius of R3.
+/// The hyperboloid is rotational symmetric around the optical axis. Alpha in rad.
+/// hTe region in which the intersection can happen here is between 0 and lMirr on the z (optical) axis  
+    
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
-                                         const Double_t& R3, const Double_t& focal) {
-
+                                         const Double_t& R3, const Double_t& lMirr, const Double_t& focal) {
+    Double_t beta = 3 * alpha;
+    Double_t e = 2 * R3 * TMath::Tan(beta);
+    Double_t g = 2.0 * R3 * TMath::Tan(beta) / (focal + R3 * TMath::Cot(2.0 * alpha));
+    Double_t a = dir.X() * dir.X() + dir.Y() * dir.Y() - g * dir.Z() * dir.Z();
+    Double_t b = 2 * (pos.X() * dir.X() + pos.Y() * dir.Y() - g * dir.Z() * pos.Z()) + e * dir.Z();
+    Double_t halfb = b / 2;
+    Double_t c = pos.X() * pos.X() + pos.Y() * pos.Y() - R3 * R3 + e * pos.Z() - g * pos.Z() * pos.Z();
+    Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
+    Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
+    Double_t s = 0;
+    if (pos.Z()+ root1 * dir.Z() > 0 and pos.Z() + root1 * dir.Z() < lMirr){
+        return pos + root1 * dir;
+    }
+    else if (pos.Z() + root2 * dir.Z() > 0 and pos.Z() + root2 * dir.Z() < lMirr){
+        return pos + root1 * dir;
+    }
+    RESTError << "No intersection found" << RESTendl;
+    return pos + 0 * dir;
 }
 
 ///////////////////////////////////////////////

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -84,10 +84,10 @@ TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, co
 }
     
 //////////////////////////////////////////////
-/// This method will find the intersection between a vector and a parabolic shape where alpha is the angle 
-/// between the optical axis and the paraboloid at the plane where the paraboloid has a radius of R3.
-/// The paraboloid is rotational symmetric around the optical axis. Alpha in rad.
-/// The region in which the intersection can happen here is between -lMirr and 0 on the z (optical) axis
+/// This method will find the intersection between a vector and a parabolic shape where `alpha` is the angle 
+/// between the optical axis and the paraboloid at the plane where the paraboloid has a radius of `R3`.
+/// The paraboloid is rotational symmetric around the optical axis. `Alpha` in rad.
+/// The region in which the intersection can happen here is between `-lMirr` and 0 on the z (optical) axis
     
 TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
                                          const Double_t& R3, const Double_t& lMirr) {
@@ -111,10 +111,10 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
 }    
 
 //////////////////////////////////////////////
-/// This method will find the intersection between a vector and a hyperbolic shape where 3 * alpha is the angle 
-/// between the optical axis and the hyperboloid at the plane where the hyperboloid has a radius of R3.
-/// The hyperboloid is rotational symmetric around the optical axis. Alpha in rad.
-/// hTe region in which the intersection can happen here is between 0 and lMirr on the z (optical) axis  
+/// This method will find the intersection between a vector and a hyperbolic shape where 3 * `alpha` is the angle 
+/// between the optical axis and the hyperboloid at the plane where the hyperboloid has a radius of `R3`.
+/// The hyperboloid is rotational symmetric around the optical axis. `Alpha` in rad.
+/// hTe region in which the intersection can happen here is between 0 and `lMirr` on the `z` (optical) axis  
     
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
                                          const Double_t& R3, const Double_t& lMirr, const Double_t& focal) {
@@ -194,7 +194,12 @@ TVector3 GetConeNormal(const TVector3& pos, const Double_t& alpha, const Double_
     return -TVector3(cosA * pos.X() / r, cosA * pos.Y() / r, sinA);
 }
 
-    
+///////////////////////////////////////////////
+/// \brief This method returns the normal vector on a parabolic surface pointing towards the inside
+/// of the paraboloid. `pos` is the origin point of the normal vector on the parabolic plane and 
+/// `alpha` is the angle between the paraboloid and the optical (z) axis at the plane where the 
+/// paraboloid has the radius `R3`.
+///    
 TVector3 GetParabolicNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R3){
     TVector3 normalVec = pos;
     Double_t m = 1 / (R3 * TMath::Tan(alpha) / TMath::Sqrt(R3 * R3 + R3 * 2 * TMath::Tan(alpha) * (- pos.Z())));
@@ -202,8 +207,21 @@ TVector3 GetParabolicNormal(const TVector3& pos, const Double_t& alpha, const Do
     normalVec.SetZ(pos.Z() - (- n / m));
     return normalVec;
 }
-  
+    
+///////////////////////////////////////////////
+/// \brief This method returns the normal vector on a hyperbolic surface pointing towards the inside
+/// of the hyperboloid. `pos` is the origin point of the normal vector on the hyperbolic plane and 
+/// `beta` is the angle between the hyperboloid and the optical (z) axis at the plane where the 
+/// hyperboloid has the radius `R3`.
+///  
 TVector3 GetHyperbolicNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R3, const Double_t& focal){
+    TVector3 normalVec = pos;
+    Double_t beta = 3 * alpha;
+    Double_t m = 1 / (R3 * TMath::Tan(beta) * (1 + 2 * (- z) / (focal + R3 * TMath::Cot(2 * alpha))) /
+        TMath::Sqrt(R3 * R3 + R3 * 2 * TMath::Tan(beta) * (- z) * (1.0 + (- z) / (focal + R3 * TMath::Cot(2 * alpha)))));
+    Double_t n = TMath::Sqrt(pos.X() * pos.X() + pos.Y() * pos.Y()) - m * pos.Z();
+    normalVec.SetZ(pos.Z() - (- n / m));
+    return normalVec;
 }
 
 

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -82,6 +82,38 @@ TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, co
                                     const TVector3& a) {
     return MoveToPlane(pos, dir, n, a);
 }
+    
+//////////////////////////////////////////////
+/// This method will find the intersection between a vector and a parabolic shape where alpha is the angle 
+/// between the optical axis and the paraboloid at the plane where the paraboloid has a radius of R3.
+/// The paraboloid is rotational symmetric around the optical axis. Alpha in rad.
+/// Te region in which the intersection can happen here is between -lMirr and 0 on the z (optical) axis
+    
+TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
+                                         const Double_t& R3, const Double_t& lMirr) {
+    Double_t e = 2 * R3 * TMath::Tan(alpha);
+    Double_t a = dir[0] * dir[0] + dir[1] * dir[1];
+    Double_t b = 2 * (pos[0] * dir[0] + pos[1] * dir[1]) + e * dir[2];
+    Double_t halfb = b / 2;
+    Double_t c = pos[0] * pos[0] + pos[1] * pos[1] - R3 * R3 + e * pos[2];
+    Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
+    Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
+    Double_t s = 0;
+    if (pos[2] + root1 * dir[2] > -lMirr and pos[2] + root1 * dir[2] < 0){
+        return pos + root1 * dir;
+    }
+    else if (pos[2] + root2 * dir[2] > -lMirr and pos[2] + root2 * dir[2] < 0){
+        return pos + root1 * dir;
+    }
+    RESTError << "No intersection found" << RESTendl;
+    return pos + 0 * dir
+ 
+}    
+
+TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
+                                         const Double_t& R3, const Double_t& focal) {
+
+}
 
 ///////////////////////////////////////////////
 /// \brief It returns the cone matrix M = d^T x d - cosTheta^2 x I, extracted from the document

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -86,7 +86,7 @@ TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, co
 //////////////////////////////////////////////
 /// This method will find the intersection between a vector and a parabolic shape where `alpha` is the angle
 /// between the optical axis and the paraboloid at the plane where the paraboloid has a radius of `R3`.
-/// The paraboloid is rotational symmetric around the optical axis. `Alpha` in rad.
+/// The paraboloid is rotationally symmetric around the optical axis. `alpha` in rad.
 /// The region in which the intersection can happen here is between `-lMirr` and 0 on the z (optical) axis
 ///
 /// In case no intersection is found this method returns the unmodified input position
@@ -112,7 +112,7 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
 //////////////////////////////////////////////
 /// This method will find the intersection between a vector and a hyperbolic shape where 3 * `alpha` is the
 /// angle between the optical axis and the hyperboloid at the plane where the hyperboloid has a radius of
-/// `R3`. The hyperboloid is rotational symmetric around the optical axis. `Alpha` in rad. hTe region in which
+/// `R3`. The hyperboloid is rotationally symmetric around the optical axis. `alpha` in rad. The region in which
 /// the intersection can happen here is between 0 and `lMirr` on the `z` (optical) axis
 ///
 /// In case no intersection is found this method returns the unmodified input position

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -82,60 +82,61 @@ TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, co
                                     const TVector3& a) {
     return MoveToPlane(pos, dir, n, a);
 }
-    
+
 //////////////////////////////////////////////
-/// This method will find the intersection between a vector and a parabolic shape where `alpha` is the angle 
+/// This method will find the intersection between a vector and a parabolic shape where `alpha` is the angle
 /// between the optical axis and the paraboloid at the plane where the paraboloid has a radius of `R3`.
 /// The paraboloid is rotational symmetric around the optical axis. `Alpha` in rad.
 /// The region in which the intersection can happen here is between `-lMirr` and 0 on the z (optical) axis
-    
+///
+/// In case no intersection is found this method returns the unmodified input position
+///
 TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
-                                         const Double_t& R3, const Double_t& lMirr) {
+                                        const Double_t& R3, const Double_t& lMirr) {
     Double_t e = 2 * R3 * TMath::Tan(alpha);
     Double_t a = dir.X() * dir.X() + dir.Y() * dir.Y();
     Double_t b = 2 * (pos.X() * dir.X() + pos.Y() * dir.Y()) + e * dir.Z();
-    Double_t halfb = b / 2;
+    Double_t half_b = b / 2;
     Double_t c = pos.X() * pos.X() + pos.Y() * pos.Y() - R3 * R3 + e * pos.Z();
     Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
     Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
     Double_t s = 0;
-    if (pos.Z() + root1 * dir.Z() > -lMirr and pos.Z() + root1 * dir.Z() < 0){
+    if (pos.Z() + root1 * dir.Z() > -lMirr and pos.Z() + root1 * dir.Z() < 0) {
         return pos + root1 * dir;
-    }
-    else if (pos.Z() + root2 * dir.Z() > -lMirr and pos.Z() + root2 * dir.Z() < 0){
+    } else if (pos.Z() + root2 * dir.Z() > -lMirr and pos.Z() + root2 * dir.Z() < 0) {
         return pos + root2 * dir;
     }
-    RESTError << "No intersection found" << RESTendl;
-    return pos + 0 * dir;
- 
-}    
+    return pos;
+}
 
 //////////////////////////////////////////////
-/// This method will find the intersection between a vector and a hyperbolic shape where 3 * `alpha` is the angle 
-/// between the optical axis and the hyperboloid at the plane where the hyperboloid has a radius of `R3`.
-/// The hyperboloid is rotational symmetric around the optical axis. `Alpha` in rad.
-/// hTe region in which the intersection can happen here is between 0 and `lMirr` on the `z` (optical) axis  
-    
+/// This method will find the intersection between a vector and a hyperbolic shape where 3 * `alpha` is the
+/// angle between the optical axis and the hyperboloid at the plane where the hyperboloid has a radius of
+/// `R3`. The hyperboloid is rotational symmetric around the optical axis. `Alpha` in rad. hTe region in which
+/// the intersection can happen here is between 0 and `lMirr` on the `z` (optical) axis
+///
+/// In case no intersection is found this method returns the unmodified input position
+///
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t& alpha,
                                          const Double_t& R3, const Double_t& lMirr, const Double_t& focal) {
     Double_t beta = 3 * alpha;
     Double_t e = 2 * R3 * TMath::Tan(beta);
-    Double_t g = 2 * R3 * TMath::Tan(beta) / (focal + R3 * TMath::Cot(2 * alpha));
+    /// Just replaced here *TMath::Cot by /TMath::Tan to fix compilation issues
+    Double_t g = 2 * R3 * TMath::Tan(beta) / (focal + R3 / TMath::Tan(2 * alpha));
     Double_t a = dir.X() * dir.X() + dir.Y() * dir.Y() - g * dir.Z() * dir.Z();
     Double_t b = 2 * (pos.X() * dir.X() + pos.Y() * dir.Y() - g * dir.Z() * pos.Z()) + e * dir.Z();
-    Double_t halfb = b / 2;
+    Double_t half_b = b / 2;
     Double_t c = pos.X() * pos.X() + pos.Y() * pos.Y() - R3 * R3 + e * pos.Z() - g * pos.Z() * pos.Z();
     Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
     Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
     Double_t s = 0;
-    if (pos.Z()+ root1 * dir.Z() > 0 and pos.Z() + root1 * dir.Z() < lMirr){
+    if (pos.Z() + root1 * dir.Z() > 0 and pos.Z() + root1 * dir.Z() < lMirr) {
         return pos + root1 * dir;
-    }
-    else if (pos.Z() + root2 * dir.Z() > 0 and pos.Z() + root2 * dir.Z() < lMirr){
+    } else if (pos.Z() + root2 * dir.Z() > 0 and pos.Z() + root2 * dir.Z() < lMirr) {
         return pos + root2 * dir;
     }
-    RESTError << "No intersection found" << RESTendl;
-    return pos + 0 * dir;
+
+    return pos;
 }
 
 ///////////////////////////////////////////////
@@ -196,34 +197,38 @@ TVector3 GetConeNormal(const TVector3& pos, const Double_t& alpha, const Double_
 
 ///////////////////////////////////////////////
 /// \brief This method returns the normal vector on a parabolic surface pointing towards the inside
-/// of the paraboloid. `pos` is the origin point of the normal vector on the parabolic plane and 
-/// `alpha` is the angle between the paraboloid and the optical (z) axis at the plane where the 
+/// of the paraboloid. `pos` is the origin point of the normal vector on the parabolic plane and
+/// `alpha` is the angle between the paraboloid and the optical (z) axis at the plane where the
 /// paraboloid has the radius `R3`.
-///    
-TVector3 GetParabolicNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R3){
+///
+TVector3 GetParabolicNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R3) {
     TVector3 normalVec = pos;
-    Double_t m = 1 / (R3 * TMath::Tan(alpha) / TMath::Sqrt(R3 * R3 + R3 * 2 * TMath::Tan(alpha) * (- pos.Z())));
+    Double_t m =
+        1 / (R3 * TMath::Tan(alpha) / TMath::Sqrt(R3 * R3 + R3 * 2 * TMath::Tan(alpha) * (-pos.Z())));
     Double_t n = TMath::Sqrt(pos.X() * pos.X() + pos.Y() * pos.Y()) - m * pos.Z();
-    normalVec.SetZ(pos.Z() - (- n / m));
-    return normalVec;
-}
-    
-///////////////////////////////////////////////
-/// \brief This method returns the normal vector on a hyperbolic surface pointing towards the inside
-/// of the hyperboloid. `pos` is the origin point of the normal vector on the hyperbolic plane and 
-/// `beta` is the angle between the hyperboloid and the optical (z) axis at the plane where the 
-/// hyperboloid has the radius `R3`.
-///  
-TVector3 GetHyperbolicNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R3, const Double_t& focal){
-    TVector3 normalVec = pos;
-    Double_t beta = 3 * alpha;
-    Double_t m = 1 / (R3 * TMath::Tan(beta) * (1 + 2 * (- z) / (focal + R3 * TMath::Cot(2 * alpha))) /
-        TMath::Sqrt(R3 * R3 + R3 * 2 * TMath::Tan(beta) * (- z) * (1.0 + (- z) / (focal + R3 * TMath::Cot(2 * alpha)))));
-    Double_t n = TMath::Sqrt(pos.X() * pos.X() + pos.Y() * pos.Y()) - m * pos.Z();
-    normalVec.SetZ(pos.Z() - (- n / m));
+    normalVec.SetZ(pos.Z() - (-n / m));
     return normalVec;
 }
 
+///////////////////////////////////////////////
+/// \brief This method returns the normal vector on a hyperbolic surface pointing towards the inside
+/// of the hyperboloid. `pos` is the origin point of the normal vector on the hyperbolic plane and
+/// `beta` is the angle between the hyperboloid and the optical (z) axis at the plane where the
+/// hyperboloid has the radius `R3`.
+///
+TVector3 GetHyperbolicNormal(const TVector3& pos, const Double_t& alpha, const Double_t& R3,
+                             const Double_t& focal) {
+    Double_t z = 1;  /// This is just a temp value to fix compilation issues
+    TVector3 normalVec = pos;
+    Double_t beta = 3 * alpha;
+    /// Just replaced here *TMath::Cot by /TMath::Tan to fix compilation issues
+    Double_t m = 1 / (R3 * TMath::Tan(beta) * (1 + 2 * (-z) / (focal + R3 / TMath::Tan(2 * alpha))) /
+                      TMath::Sqrt(R3 * R3 + R3 * 2 * TMath::Tan(beta) * (-z) *
+                                                (1.0 + (-z) / (focal + R3 / TMath::Tan(2 * alpha)))));
+    Double_t n = TMath::Sqrt(pos.X() * pos.X() + pos.Y() * pos.Y()) - m * pos.Z();
+    normalVec.SetZ(pos.Z() - (-n / m));
+    return normalVec;
+}
 
 ///////////////////////////////////////////////
 /// \brief This method will find the intersection of the trajectory defined by the vector starting at


### PR DESCRIPTION
![jovoy](https://badgen.net/badge/PR%20submitted%20by%3A/jovoy/blue) ![Medium: 100](https://badgen.net/badge/PR%20Size/Medium%3A%20100/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/true_wolter_interaction/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/true_wolter_interaction) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=true_wolter_interaction)](https://github.com/rest-for-physics/framework/commits/true_wolter_interaction)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adding the interaction between a vector and a parabolic/hyperbolic shaped mirror:

- [x] Find interaction point between vector and parabolic mirror
- [x] Find interaction point between vector and hyperbolic mirror
- [x] normal vector on parabolic mirror
- [x] normal vector on hyperbolic mirror
- [x] the latter need to be normalized for further calculations