### PR TITLE
Fix macros from libraries not loading correctly

### DIFF
--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -78,14 +78,20 @@ int main(int argc, char* argv[]) {
     gROOT->ProcessLine("#include <TRestSystemOfUnits.h>");
     if (loadMacros) {
         if (!silent) printf("= Loading macros ...\n");
-        auto filesMatchingPattern = TRestTools::GetFilesMatchingPattern(REST_PATH + "/macros/*/REST_*.C");
-        for (const auto& file : filesMatchingPattern) {
-            if (file.find("swp") != string::npos || file.find("svn") != string::npos ||
-                file.find("swo") != string::npos)
-                continue;
-            if (debug) printf("Loading macro : %s\n", file.c_str());
+        vector<string> macroFiles;
+        const vector<string> patterns = {
+            REST_PATH + "/macros/REST_*.C",   // framework
+            REST_PATH + "/macros/*/REST_*.C"  // libraries
+        };
+        for (const auto& pattern : patterns) {
+            for (const auto& macroFile : TRestTools::GetFilesMatchingPattern(pattern)) {
+                macroFiles.push_back(macroFile);
+            }
+        }
 
-            gROOT->ProcessLine((".L " + file).c_str());
+        for (const auto& macroFile : macroFiles) {
+            if (debug) printf("Loading macro : %s\n", macroFile.c_str());
+            gROOT->ProcessLine((".L " + macroFile).c_str());
         }
     }
 

--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -78,7 +78,7 @@ int main(int argc, char* argv[]) {
     gROOT->ProcessLine("#include <TRestSystemOfUnits.h>");
     if (loadMacros) {
         if (!silent) printf("= Loading macros ...\n");
-        auto filesMatchingPattern = TRestTools::GetFilesMatchingPattern(REST_PATH + "/macros/*REST_*.C");
+        auto filesMatchingPattern = TRestTools::GetFilesMatchingPattern(REST_PATH + "/macros/*/REST_*.C");
         for (const auto& file : filesMatchingPattern) {
             if (file.find("swp") != string::npos || file.find("svn") != string::npos ||
                 file.find("swo") != string::npos)


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 14](https://badgen.net/badge/PR%20Size/Ok%3A%2014/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-fix-bug-macros/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-fix-bug-macros) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=lobis-fix-bug-macros)](https://github.com/rest-for-physics/framework/commits/lobis-fix-bug-macros)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes https://github.com/rest-for-physics/framework/issues/282.

Some warnings are now visible that should be addressed in a different PR.