### PR TITLE
GetObservableValue input obs name without process name prefix

### DIFF
--- a/source/framework/core/inc/TRestAnalysisTree.h
+++ b/source/framework/core/inc/TRestAnalysisTree.h
@@ -139,7 +139,7 @@ class TRestAnalysisTree : public TTree {
             std::cout << "Error! TRestAnalysisTree::GetObservableValue(): index outside limits!" << std::endl;
             return std::numeric_limits<T>::quiet_NaN();
         }
-        if (fChain != NULL) {
+        if (fChain != nullptr) {
             return ((TRestAnalysisTree*)fChain->GetTree())->GetObservableValue<T>(n);
         }
         return fObservables[n].GetValue<T>();

--- a/source/framework/core/inc/TRestAnalysisTree.h
+++ b/source/framework/core/inc/TRestAnalysisTree.h
@@ -23,6 +23,7 @@
 #ifndef RestCore_TRestAnalysisTree
 #define RestCore_TRestAnalysisTree
 
+#include <limits>
 #include "TChain.h"
 #include "TRestEvent.h"
 #include "TRestReflector.h"
@@ -39,13 +40,14 @@ class TRestAnalysisTree : public TTree {
     Int_t fSubRunOrigin;    //!
 
     //
-    Int_t fStatus = 0;                            //!
-    Int_t fSetObservableCalls = 0;                //!
-    Int_t fSetObservableIndex = 0;                //!
-    Bool_t fQuickSetObservableValue = true;       //!
-    std::vector<RESTValue> fObservables;          //!
-    std::map<std::string, int> fObservableIdMap;  //!
-    TChain* fChain = nullptr;                     //! in case multiple files for reading
+    Int_t fStatus = 0;                                  //!
+    Int_t fSetObservableCalls = 0;                      //!
+    Int_t fSetObservableIndex = 0;                      //!
+    Bool_t fQuickSetObservableValue = true;             //!
+    std::vector<RESTValue> fObservables;                //!
+    std::map<std::string, int> fObservableIdMap;        //!
+    std::map<std::string, int> fObservableIdSearchMap;  //! used for quick search of certain observables
+    TChain* fChain = nullptr;                           //! in case multiple files for reading
 
     // for storage
     Int_t fNObservables;
@@ -99,6 +101,7 @@ class TRestAnalysisTree : public TTree {
     // Get the status of this tree. This call will not evaluate the status.
     inline int GetStatus() const { return fStatus; }
     Int_t GetObservableID(const std::string& obsName);
+    Int_t GetMatchedObservableID(const std::string& obsName);
     Bool_t ObservableExists(const std::string& obsName);
     // six basic event prameters
     Int_t GetEventID() { return fChain ? ((TRestAnalysisTree*)fChain->GetTree())->GetEventID() : fEventID; }
@@ -134,9 +137,9 @@ class TRestAnalysisTree : public TTree {
         // id check
         if (n >= fNObservables) {
             std::cout << "Error! TRestAnalysisTree::GetObservableValue(): index outside limits!" << std::endl;
-            return T();
+            return std::numeric_limits<T>::quiet_NaN();
         }
-        if (fChain != nullptr) {
+        if (fChain != NULL) {
             return ((TRestAnalysisTree*)fChain->GetTree())->GetObservableValue<T>(n);
         }
         return fObservables[n].GetValue<T>();
@@ -153,7 +156,11 @@ class TRestAnalysisTree : public TTree {
     T GetObservableValue(std::string obsName) {
         Int_t id = GetObservableID(obsName);
         if (id == -1) {
-            return T();
+            // try to find matched observables
+            id = GetMatchedObservableID(obsName);
+            if (id == -1) {
+                return std::numeric_limits<T>::quiet_NaN();
+            }
         }
         return GetObservableValue<T>(id);
     }

--- a/source/framework/core/inc/TRestEventProcess.h
+++ b/source/framework/core/inc/TRestEventProcess.h
@@ -177,7 +177,7 @@ class TRestEventProcess : public TRestMetadata {
 
     template <class T>
     T GetObservableValue(const std::string& name) {
-        if (fAnalysisTree != NULL) {
+        if (fAnalysisTree != nullptr) {
             return fAnalysisTree->GetObservableValue<T>(name);
         }
         return std::numeric_limits<T>::quiet_NaN();

--- a/source/framework/core/inc/TRestEventProcess.h
+++ b/source/framework/core/inc/TRestEventProcess.h
@@ -23,6 +23,7 @@
 #ifndef RestCore_TRestEventProcess
 #define RestCore_TRestEventProcess
 
+#include <limits>
 #include "TCanvas.h"
 #include "TNamed.h"
 #include "TRestAnalysisTree.h"
@@ -179,7 +180,7 @@ class TRestEventProcess : public TRestMetadata {
         if (fAnalysisTree != NULL) {
             return fAnalysisTree->GetObservableValue<T>(name);
         }
-        return T();
+        return std::numeric_limits<T>::quiet_NaN();
     }
 
     /// Create the canvas

--- a/source/framework/core/inc/TRestEventProcess.h
+++ b/source/framework/core/inc/TRestEventProcess.h
@@ -108,25 +108,26 @@ class TRestEventProcess : public TRestMetadata {
     inline size_t GetNumberOfParallelProcesses() const { return fParallelProcesses.size(); }
     TRestEventProcess* GetParallel(int i);
     //////////////////////////////////////////////////////////////////////////
-    /// \brief Get a list of data members from parallel processes which is same to 
+    /// \brief Get a list of data members from parallel processes which is same to
     /// this process's certain data member.
     ///
-    /// This method can be used in merging and exporting histograms at the end of the 
+    /// This method can be used in merging and exporting histograms at the end of the
     /// process, to support multi-thread run.
-    /// 
-    /// Because all the parallel processes are in same data structure, this method directly 
+    ///
+    /// Because all the parallel processes are in same data structure, this method directly
     /// gets the data members by accessing certain offset.
-    /// 
+    ///
     /// Usage: (suppose we defined fHist as data member)
     /// auto hists = this->GetParallelObjects(&fHist);
-    /// for (auto h : hists) { fHist->Add(h); } 
-    /// 
+    /// for (auto h : hists) { fHist->Add(h); }
+    ///
     template <class T>
     std::vector<T> GetParallelDataMembers(T* member_of_process) {
         std::vector<T> result;
         int offset = (int)((char*)member_of_process - (char*)this);
         if (offset <= 0 || offset > this->IsA()->GetClassSize()) {
-            std::cout << this->ClassName() << "::GetParallelDataMembers(): invalid object input!" << std::endl;
+            std::cout << this->ClassName() << "::GetParallelDataMembers(): invalid object input!"
+                      << std::endl;
             return result;
         }
         for (int i = 0; i < GetNumberOfParallelProcesses(); i++) {
@@ -171,6 +172,14 @@ class TRestEventProcess : public TRestMetadata {
                 }
             }
         }
+    }
+
+    template <class T>
+    T GetObservableValue(const std::string& name) {
+        if (fAnalysisTree != NULL) {
+            return fAnalysisTree->GetObservableValue<T>(name);
+        }
+        return T();
     }
 
     /// Create the canvas
@@ -260,7 +269,7 @@ class TRestEventProcess : public TRestMetadata {
     ClassDefOverride(TRestEventProcess, 3);  // Base class for a REST process
 };
 
-#define _ApplyCut(evt)        \
+#define _ApplyCut(evt)              \
     if (ApplyCut()) return nullptr; \
     return evt;
 

--- a/source/framework/core/src/TRestAnalysisTree.cxx
+++ b/source/framework/core/src/TRestAnalysisTree.cxx
@@ -732,12 +732,12 @@ Int_t TRestAnalysisTree::GetEntry(Long64_t entry, Int_t getall) {
 }
 
 void TRestAnalysisTree::SetEventInfo(TRestAnalysisTree* tree) {
-    if (fChain != NULL) {
+    if (fChain != nullptr) {
         cout << "Error! cannot fill tree. AnalysisTree is in chain state" << endl;
         return;
     }
 
-    if (tree != NULL) {
+    if (tree != nullptr) {
         fEventID = tree->GetEventID();
         fSubEventID = tree->GetSubEventID();
         fTimeStamp = tree->GetTimeStamp();


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![Medium: 104](https://badgen.net/badge/PR%20Size/Medium%3A%20104/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/nkx111-get-obs-value/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/nkx111-get-obs-value) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=nkx111-get-obs-value)](https://github.com/rest-for-physics/framework/commits/nkx111-get-obs-value)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This closes issue https://github.com/rest-for-physics/detectorlib/issues/47

By making TRestAnalysisTree::GetObservableValue<>() **searching** for observables, one can directly input obs names without process name prefix. It also prints message if one input observable names wrong.

Previously: 

```
root [1] ana_tree0->GetObservableValue<double>("sAna_ThresholdIntegral")
(double) 161060.00
```

Now:

```
root [0] ana_tree0->GetObservableValue<double>("ThresholdIntegral")
TRestAnalysisTree::GetObservableID(): Find observable sAna_ThresholdIntegral for obs name: ThresholdIntegral
(double) 161060.00

root [2] ana_tree0->GetObservableValue<double>("ThresholdIntegrawwl")
-- Error : TRestAnalysisTree::GetObservableID(): No Matching observable found
-- Error : did you mean "sAna_ThresholdIntegral" ?
(double) nan
```

When writing processes, if one needs to access observable values, no more hardcoded process names shall be added.