### PR TITLE
TRestRun::SetInputEvent now updates the content inside the new event

### DIFF
--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -1260,6 +1260,7 @@ void TRestRun::SetInputEvent(TRestEvent* event) {
         } else {
             fInputEvent = event;
         }
+        this->GetEntry(fCurrentEvent);
     }
 }
 


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_run_patch/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_run_patch) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_run_patch)](https://github.com/rest-for-physics/framework/commits/jgalan_run_patch)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

A minor patch to avoid having to manually call to `GetEntry` to fill the new event pointer. It will just fill using the current entry.