### PR TITLE
TRestRun::OpenInputFile. Preventing segmentation fault

### DIFF
--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -470,7 +470,8 @@ void TRestRun::ReadInputFileMetadata() {
             RESTDebug << "Reading key with name : " << key->GetName() << RESTendl;
             RESTDebug << "Key type (class) : " << key->GetClassName() << RESTendl;
 
-            if (!TClass::GetClass(key->GetClassName())->IsLoaded()) {
+            if (!TClass::GetClass(key->GetClassName()) ||
+                !TClass::GetClass(key->GetClassName())->IsLoaded()) {
                 RESTError << "-- Class " << key->GetClassName() << " has no dictionary!" << RESTendl;
                 RESTError << "- Any relevant REST library missing? " << RESTendl;
                 RESTError << "- File reading will continue without loading key: " << key->GetName()


### PR DESCRIPTION
Just preventing seg.fault when a class definition is not found.