### PR TITLE
Writing objects with `kOverwrite` flag instead of `kWriteDelete`

### DIFF
--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -943,8 +943,8 @@ void TRestProcessRunner::ConfigOutputFile() {
 #endif
     // write tree
     fOutputDataFile->cd();
-    if (fEventTree != nullptr) fEventTree->Write(0, kWriteDelete);
-    if (fAnalysisTree != nullptr) fAnalysisTree->Write(0, kWriteDelete);
+    if (fEventTree != nullptr) fEventTree->Write(nullptr, kOverwrite);
+    if (fAnalysisTree != nullptr) fAnalysisTree->Write(nullptr, kOverwrite);
 
     // go back to the first file
     if (fOutputDataFile->GetName() != fOutputDataFileName) {
@@ -962,11 +962,11 @@ void TRestProcessRunner::WriteMetadata() {
     char tmpString[256];
     if (fRunInfo->GetFileProcess() != nullptr) {
         // sprintf(tmpString, "Process-%d. %s", 0, fRunInfo->GetFileProcess()->GetName());
-        fRunInfo->GetFileProcess()->Write(0, kWriteDelete);
+        fRunInfo->GetFileProcess()->Write(nullptr, kOverwrite);
     }
     for (int i = 0; i < fProcessNumber; i++) {
         // sprintf(tmpString, "Process-%d. %s", i + 1, fThreads[0]->GetProcess(i)->GetName());
-        fThreads[0]->GetProcess(i)->Write(0, kWriteDelete);
+        fThreads[0]->GetProcess(i)->Write(nullptr, kOverwrite);
     }
 }
 

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -1057,8 +1057,8 @@ TFile* TRestRun::UpdateOutputFile() {
         }
 
         fOutputFile->cd();
-        fAnalysisTree->Write(0, kWriteDelete);
-        fEventTree->Write(0, kWriteDelete);
+        fAnalysisTree->Write(nullptr, kOverwrite);
+        fEventTree->Write(nullptr, kOverwrite);
         this->WriteWithDataBase();
 
         RESTcout << "TRestRun: Output File Updated." << RESTendl;
@@ -1107,8 +1107,8 @@ void TRestRun::WriteWithDataBase() {
     fRunUser = REST_USER;
 
     // save metadata objects in file
-    RESTDebug << "TRestRun::WriteWithDataBase. Calling this->Write(0,kWriteDelete)" << RESTendl;
-    this->Write(0, kWriteDelete);
+    RESTDebug << "TRestRun::WriteWithDataBase. Calling this->Write(0,kOverwrite)" << RESTendl;
+    this->Write(nullptr, kOverwrite);
     RESTDebug << "TRestRun::WriteWithDataBase. Succeed" << RESTendl;
     RESTDebug << "TRestRun::WriteWithDataBase. fMetadata.size() == " << fMetadata.size() << RESTendl;
     for (int i = 0; i < fMetadata.size(); i++) {
@@ -1125,10 +1125,10 @@ void TRestRun::WriteWithDataBase() {
 
         if (!historic) {
             RESTDebug << "NO historic" << RESTendl;
-            fMetadata[i]->Write(fMetadata[i]->GetName(), kWriteDelete);
+            fMetadata[i]->Write(fMetadata[i]->GetName(), kOverwrite);
         } else {
             RESTDebug << "IS historic" << RESTendl;
-            if (fSaveHistoricData) fMetadata[i]->Write(fMetadata[i]->GetName(), kWriteDelete);
+            if (fSaveHistoricData) fMetadata[i]->Write(fMetadata[i]->GetName(), kOverwrite);
         }
     }
 
@@ -1149,8 +1149,8 @@ void TRestRun::CloseFile() {
         fEntriesSaved = fAnalysisTree->GetEntries();
         if (fAnalysisTree->GetEntries() > 0 && fInputFile == nullptr) {
             if (fOutputFile != nullptr) {
-                fAnalysisTree->Write(0, kWriteDelete);
-                this->Write(0, kWriteDelete);
+                fAnalysisTree->Write(nullptr, kOverwrite);
+                this->Write(nullptr, kOverwrite);
             }
         }
         delete fAnalysisTree;
@@ -1158,7 +1158,7 @@ void TRestRun::CloseFile() {
     }
 
     if (fEventTree != nullptr) {
-        if (fEventTree->GetEntries() > 0 && fInputFile == nullptr) fEventTree->Write(0, kWriteDelete);
+        if (fEventTree->GetEntries() > 0 && fInputFile == nullptr) fEventTree->Write(nullptr, kOverwrite);
         delete fEventTree;
         fEventTree = nullptr;
     }


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 13](https://badgen.net/badge/PR%20Size/Ok%3A%2013/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-overwrite/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-overwrite) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=lobis-overwrite)](https://github.com/rest-for-physics/framework/commits/lobis-overwrite)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Changed all the occurences of `kWriteDelete` for `kOverwrite`.

This avoids having random numbers after keys in the root file, such as:

```
root [1] .ls
TFile**         /tmp/tmp.NR4gQ6jbwZ/source/packages/restG4/examples/04.MuonScan/muons.root
 TFile*         /tmp/tmp.NR4gQ6jbwZ/source/packages/restG4/examples/04.MuonScan/muons.root
  KEY: TRestAnalysisTree        AnalysisTree;4  AnalysisTree
  KEY: TTree    EventTree;4     TRestGeant4EventTree
  KEY: TRestRun CosmicMuonRun;4 A basic muon test with 2 active volumes
  KEY: TRestGeant4Metadata      restG4 run;3    MuonsFromWall
  KEY: TRestGeant4PhysicsLists  default;3       First physics list implementation.
  KEY: TGeoManager      Geometry;1      Geometry imported from GDML
```

Not sure if there was a reason to use `kWriteDelete` in the first place @nkx111 @jgalan .