### PR TITLE
Fix not ignoring `restG4` library on `restRoot`

### DIFF
--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -115,14 +115,14 @@ void TRestTools::LoadRESTLibrary(bool silent) {
             }
             const TString pathRootString = it.path().string();
             TString libName = TRestTools::SeparatePathAndName((std::string)pathRootString).second;
-            if (!libName.Contains("Rest")) {
+            if (!libName.Contains("Rest", TString::kExact)) {
                 // e.g. "libRestFramework.so"
                 continue;
             }
             // Check if library is excluded from loading e.g. is from a package
             bool excluded = false;
             for (const TString excludedLibrary : excludedLibraries) {
-                if (libName.Contains(excludedLibrary)) {
+                if (libName.Contains(excludedLibrary, TString::kIgnoreCase)) {
                     excluded = true;
                     // RESTWarning << "Library '" << pathRootString << "' excluded from loading" << RESTendl;
                     break;

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -89,7 +89,7 @@ std::vector<string> TRestTools::GetOptions(string optionsStr) { return Split(opt
 void TRestTools::LoadRESTLibrary(bool silent) {
     const set<string> libraryExtension{".so", ".dylib", ".dll"};
     const set<string> excludedLibraries{
-        "restG4"};  // Ignoring package libraries if they exist. TODO: do not hardcode this
+        "RestG4"};  // Ignoring package libraries if they exist. TODO: do not hardcode this
 
     vector<string> ldPaths;
 #ifdef WIN32
@@ -122,7 +122,7 @@ void TRestTools::LoadRESTLibrary(bool silent) {
             // Check if library is excluded from loading e.g. is from a package
             bool excluded = false;
             for (const TString excludedLibrary : excludedLibraries) {
-                if (libName.Contains(excludedLibrary, TString::kIgnoreCase)) {
+                if (libName.Contains(excludedLibrary, TString::kExact)) {
                     excluded = true;
                     // RESTWarning << "Library '" << pathRootString << "' excluded from loading" << RESTendl;
                     break;


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 3](https://badgen.net/badge/PR%20Size/Ok%3A%203/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-ignore-library-fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-ignore-library-fix) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=lobis-ignore-library-fix)](https://github.com/rest-for-physics/framework/commits/lobis-ignore-library-fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Recently `TRestTools` was mofidied (https://github.com/rest-for-physics/framework/pull/295) to fix an error on the GitLab pipeline. The fix removed the case insensitive flag for the comparison of the ignored libraries (since we didn't remember why it was there in the first place) but this breaks the ignore of `restG4` library.

The library is being loaded (altought it doesn't seem to cause any issue, just a warning).

This is because the library name contains `RestG4`, not `restG4`. This name is generated from the package name (`restG4`) which is hardcoded into `TRestTools`. We could just use `RestG4` instead of `restG4` but I think we should instead use the case insensitive comparison so in the future if we can get all the package names automatically instead of hardcoding this will work without modifications.