### PR TITLE
update main CMakeLists to set mpfr optional

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Build and install
         uses: rest-for-physics/framework/.github/actions/build@master
         with:
-          cmake-flags: "-DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }} -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_PREFIX_PATH=$GARFIELD_INSTALL -DREST_ALL_LIBS=ON -DREST_G4=ON -DREST_GARFIELD=ON -DTEST=ON"
+          cmake-flags: "-DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }} -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_PREFIX_PATH=$GARFIELD_INSTALL -DREST_ALL_LIBS=ON -DREST_G4=ON -DREST_GARFIELD=ON -DREST_MPFR=ON -DTEST=ON"
           branch: ${{ env.BRANCH_NAME }}
           build-path: build
       - name: Test
@@ -54,7 +54,7 @@ jobs:
       - name: Build and install
         uses: rest-for-physics/framework/.github/actions/build@master
         with:
-          cmake-flags: "-DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }} -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_PREFIX_PATH=$GARFIELD_INSTALL -DREST_ALL_LIBS=ON -DREST_G4=ON -DREST_GARFIELD=ON"
+          cmake-flags: "-DCMAKE_INSTALL_PREFIX=${{ env.REST_PATH }} -DCMAKE_BUILD_TYPE=${{ env.CMAKE_BUILD_TYPE }} -DCMAKE_PREFIX_PATH=$GARFIELD_INSTALL -DREST_ALL_LIBS=ON -DREST_G4=ON -DREST_GARFIELD=ON -DREST_MPFR=ON"
           branch: ${{ env.BRANCH_NAME }}
       - name: Test REST
         run: |

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,7 +104,7 @@ Build and Install:
     - rm -rf ${CI_PROJECT_DIR}/build && mkdir ${CI_PROJECT_DIR}/build && cd ${CI_PROJECT_DIR}/build
     - rm -rf ${CI_PROJECT_DIR}/install
     - cmake ${CI_PROJECT_DIR} -DCMAKE_INSTALL_PREFIX=${CI_PROJECT_DIR}/install
-      -DREST_ALL_LIBS=ON -DREST_GARFIELD=ON -DREST_G4=ON -DREST_WELCOME=OFF
+      -DREST_ALL_LIBS=ON -DREST_GARFIELD=ON -DREST_G4=ON -DREST_WELCOME=OFF -DREST_MPFR=ON
     - make install -j2
 
   artifacts:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,10 +114,10 @@ set(external_include_dirs ${external_include_dirs} ${ROOT_INCLUDE_DIRS})
 
 #####  mySQL  #####
 # This is to enable linking of SQL libraries. I.e. for process TRestSQLToAnalysisProcess.
-if (NOT DEFINED SQL)
-    set(SQL OFF)
+if (NOT DEFINED REST_SQL)
+    set(REST_SQL OFF)
 endif ()
-if (${SQL} MATCHES "ON")
+if (${REST_SQL} MATCHES "ON")
     list(APPEND rest_features "mySQL")
     add_definitions(-DUSE_SQL)
     include(FindSQL)
@@ -126,14 +126,14 @@ if (${SQL} MATCHES "ON")
     message(STATUS "SQL include directory: " ${SQL_INCLUDE_DIR})
     set(SQL ON)
 else ()
-    set(SQL OFF)
-endif (${SQL} MATCHES "ON")
+    set(REST_SQL OFF)
+endif (${REST_SQL} MATCHES "ON")
 
 #####  MPFR  #####
-if (NOT DEFINED MPFR)
-    set(MPFR OFF)
+if (NOT DEFINED REST_MPFR)
+    set(REST_MPFR OFF)
 endif ()
-if (${MPFR} MATCHES "ON")
+if (${REST_MPFR} MATCHES "ON")
     find_path(MPFR_INCLUDE mpfr.h HINTS ${MPFR_PATH} ${MPFR_PATH}/include) # path to include directory
     find_path(MPFR_LIB_PATH libmpfr.so HINTS ${MPFR_PATH} ${MPFR_PATH}/lib)
     find_library(MPFR_LIB mpfr HINTS ${MPFR_PATH} ${MPFR_PATH}/lib) # path to .so file
@@ -149,9 +149,9 @@ if (${MPFR} MATCHES "ON")
         message(ERROR "MPFR library was not found. Adding the location to the installation path may solve this problem.\n Use -DMPFR_PATH=/path/to/mpfr/")
     endif ()
 else ()
-    set(MPFR OFF)
+    set(REST_MPFR OFF)
     set(excludes ${excludes} TRestComplex)
-endif (${MPFR} MATCHES "ON")
+endif (${REST_MPFR} MATCHES "ON")
 
 #####  CURL  #####
 find_library(CURL_LIB curl)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,16 +39,6 @@ if (NOT DEFINED CMAKE_INSTALL_PREFIX)
     set(CMAKE_INSTALL_PREFIX ${INSTALL_PREFIX_ABSOLUTE})
 endif ()
 
-if (NOT DEFINED RESTLIB_MODEL)
-    set(RESTLIB_MODEL OFF)
-endif ()
-
-# Auto schema evolution for ROOT
-if (NOT DEFINED REST_SE)
-    set(REST_SE ON)
-endif ()
-set(SCHEMA_EVOLUTION ${REST_SE})
-
 # Welcome message
 if (NOT DEFINED REST_WELCOME)
     set(REST_WELCOME ON)
@@ -60,11 +50,16 @@ set(external_libs)
 set(CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake ${DECAY_PATH}/cmake ${CMAKE_MODULE_PATH})
 set(CMAKE_MACOSX_RPATH 1)
 
-# ROOT libs and includes
-
+#####  ROOT libs and includes  #####
 find_package(ROOT REQUIRED)
-
 set(ROOT_REQUIRED_LIBRARIES Core RIO Geom Gdml Minuit Spectrum XMLIO)
+
+# Auto schema evolution for ROOT
+if (NOT DEFINED REST_SE)
+    set(REST_SE ON)
+endif ()
+set(SCHEMA_EVOLUTION ${REST_SE})
+
 # Switch to enable ROOT Eve functionality.
 if (NOT DEFINED REST_EVE)
     set(REST_EVE ON)
@@ -111,18 +106,19 @@ else ()
                 C++ standard, check root-config --cflags ${ROOT_CFLAGS}"
                 )
     endif ()
-
 endif ()
 
 set(external_include_dirs ${external_include_dirs} ${ROOT_INCLUDE_DIRS})
 
+
+
+#####  mySQL  #####
 # This is to enable linking of SQL libraries. I.e. for process TRestSQLToAnalysisProcess.
 if (NOT DEFINED SQL)
     set(SQL OFF)
 endif ()
-
 if (${SQL} MATCHES "ON")
-    list(APPEND rest_features "SQL")
+    list(APPEND rest_features "mySQL")
     add_definitions(-DUSE_SQL)
     include(FindSQL)
     set(external_include_dirs ${external_include_dirs} ${SQL_INCLUDE_DIR})
@@ -133,21 +129,42 @@ else ()
     set(SQL OFF)
 endif (${SQL} MATCHES "ON")
 
-#### MPFR
-find_path(MPFR_INCLUDE mpfr.h HINTS ${MPFR_PATH} ${MPFR_PATH}/include) # path to include directory
-find_path(MPFR_LIB_PATH libmpfr.so HINTS ${MPFR_PATH} ${MPFR_PATH}/lib) # path to include directory
-find_library(MPFR_LIB mpfr HINTS ${MPFR_PATH} ${MPFR_PATH}/lib) # path to .so file
-
-if (NOT MPFR_INCLUDE MATCHES "MPFR_INCLUDE-NOTFOUND" AND NOT MPFR_LIB MATCHES "MPFR_LIB-NOTFOUND")
-    # MPFR is found
-    add_compile_definitions(USE_MPFR)
-    set(external_include_dirs ${external_include_dirs} ${MPFR_INCLUDE})
-    set(external_libs "${external_libs};${MPFR_LIB}")
-    link_directories(${MPFR_LIB})
-    message( STATUS "MPFR library : ${MPFR_LIB}" )
-else ()
-    message(WARNING "MPFR library was not found. Adding the location to the installation path may solve this problem.\n Use -DMPFR_PATH=/path/to/mpfr/")
+#####  MPFR  #####
+if (NOT DEFINED MPFR)
+    set(MPFR OFF)
 endif ()
+if (${MPFR} MATCHES "ON")
+    find_path(MPFR_INCLUDE mpfr.h HINTS ${MPFR_PATH} ${MPFR_PATH}/include) # path to include directory
+    find_path(MPFR_LIB_PATH libmpfr.so HINTS ${MPFR_PATH} ${MPFR_PATH}/lib)
+    find_library(MPFR_LIB mpfr HINTS ${MPFR_PATH} ${MPFR_PATH}/lib) # path to .so file
+    if (NOT MPFR_INCLUDE MATCHES "MPFR_INCLUDE-NOTFOUND" AND NOT MPFR_LIB MATCHES "MPFR_LIB-NOTFOUND")
+        # MPFR is found
+        list(APPEND rest_features "MPFR")
+        add_compile_definitions(USE_MPFR)
+        set(external_include_dirs ${external_include_dirs} ${MPFR_INCLUDE})
+        set(external_libs "${external_libs};${MPFR_LIB}")
+        link_directories(${MPFR_LIB})
+        message( STATUS "MPFR library : ${MPFR_LIB}" )
+    else ()
+        message(ERROR "MPFR library was not found. Adding the location to the installation path may solve this problem.\n Use -DMPFR_PATH=/path/to/mpfr/")
+    endif ()
+else ()
+    set(MPFR OFF)
+    set(excludes ${excludes} TRestComplex)
+endif (${MPFR} MATCHES "ON")
+
+#####  CURL  #####
+find_library(CURL_LIB curl)
+if (NOT ${CURL_LIB} STREQUAL "CURL_LIB-NOTFOUND")
+    list(APPEND rest_features "CURL")
+    add_compile_definitions(USE_Curl)
+    message(STATUS "Found curl library: ${CURL_LIB}")
+    set(external_libs "${external_libs};-lcurl")
+else ()
+    message(WARNING "CURL library was not found. ")
+endif ()
+
+
 
 # Include directories for compilation
 include_directories(${external_include_dirs})

--- a/source/framework/CMakeLists.txt
+++ b/source/framework/CMakeLists.txt
@@ -21,12 +21,6 @@ endif (CMAKE_SYSTEM_NAME MATCHES "Windows")
 
 set(external_libs "${external_libs};-lstdc++fs") # sometimes needed for <filesystem>
 
-find_library(CURL_LIB curl)
-if (NOT ${CURL_LIB} STREQUAL "CURL_LIB-NOTFOUND")
-    add_compile_definitions(USE_Curl)
-    message(STATUS "Found curl library: ${CURL_LIB}")
-    set(external_libs "${external_libs};-lcurl")
-endif ()
 
 COMPILEDIR(RestFramework)
 


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![Ok: 55](https://badgen.net/badge/PR%20Size/Ok%3A%2055/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/nkx111-optional-MPFR/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/nkx111-optional-MPFR) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=nkx111-optional-MPFR)](https://github.com/rest-for-physics/framework/commits/nkx111-optional-MPFR)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR clarified some optional dependencies for the framework: `curl`, `mpfr`, `mySQL`, and `ROOT eve library`. Those items will contribute to "REST Features" output when configuring cmake:

```
...
REST will be installed in: xxxx
===========================================================
System is: Linux
Packages: restG4 
Libraries: RestFramework;RestConnectors;RestDetector;RestGeant4;RestLegacy;RestRaw;RestTrack
Features: Eve;CURL,Garfield
===========================================================
```

**mpfr library is made optional**. A new cmake flag is introduced. By setting `-DREST_MPFR=OFF` one can exclude the compilation of the class `TRestComplex`. By default mpfr is OFF.

curl library finding is moved to main CMakeLists.