### PR TITLE
TRestPatternMask is not pure virtual anymore

### DIFF
--- a/source/framework/core/inc/TRestEventProcess.h
+++ b/source/framework/core/inc/TRestEventProcess.h
@@ -213,6 +213,8 @@ class TRestEventProcess : public TRestMetadata {
 
     inline void SetObservableValidation(bool validate) { fValidateObservables = validate; }
 
+    inline void RegisterAllObservables(Bool_t value = true) { fDynamicObs = value; }
+
     // process running methods
     /// To be executed at the beginning of the run (outside event loop)
     virtual void InitProcess() {}

--- a/source/framework/masks/inc/TRestPatternMask.h
+++ b/source/framework/masks/inc/TRestPatternMask.h
@@ -54,9 +54,6 @@ class TRestPatternMask : public TRestMetadata {
 
     Int_t ApplyCommonMaskTransformation(Double_t& x, Double_t& y);
 
-    TRestPatternMask();
-    TRestPatternMask(const char* cfgFileName, std::string name = "");
-
    public:
     Int_t GetMaxRegions() { return fMaxRegions; }
 
@@ -100,6 +97,8 @@ class TRestPatternMask : public TRestMetadata {
 
     TCanvas* DrawMonteCarlo(Int_t nSamples = 10000);
 
+    TRestPatternMask();
+    TRestPatternMask(const char* cfgFileName, std::string name = "");
     ~TRestPatternMask();
 
     ClassDefOverride(TRestPatternMask, 1);

--- a/source/framework/masks/inc/TRestPatternMask.h
+++ b/source/framework/masks/inc/TRestPatternMask.h
@@ -36,8 +36,8 @@ class TRestPatternMask : public TRestMetadata {
     /// An angle (in radians) used to introduce a rotation to the pattern
     Double_t fRotationAngle = 0;  //<
 
-    /// The pattern type (Stripped/Grid/Spider/Rings)
-    std::string fPatternType = "";  //<
+    /// The pattern type (None/Stripped/Grid/Spider/Rings)
+    std::string fPatternType = "None";  //<
 
     /// A canvas for drawing
     TCanvas* fCanvas = nullptr;  //!

--- a/source/framework/masks/inc/TRestPatternMask.h
+++ b/source/framework/masks/inc/TRestPatternMask.h
@@ -63,8 +63,8 @@ class TRestPatternMask : public TRestMetadata {
 
     /// To be implemented at the inherited class with the pattern and region identification logic
     virtual Int_t GetRegion(Double_t x, Double_t y) {
-        if (ApplyCommonMaskTransformation(x, y) == 0) return 0;
-        return 1;
+        if (ApplyCommonMaskTransformation(x, y) == 0) return 1;
+        return 0;
     }
 
     /// It returns the mask pattern type

--- a/source/framework/masks/inc/TRestPatternMask.h
+++ b/source/framework/masks/inc/TRestPatternMask.h
@@ -65,7 +65,10 @@ class TRestPatternMask : public TRestMetadata {
     Bool_t HitsPattern(Double_t x, Double_t y);
 
     /// To be implemented at the inherited class with the pattern and region identification logic
-    virtual Int_t GetRegion(Double_t x, Double_t y) = 0;
+    virtual Int_t GetRegion(Double_t x, Double_t y) {
+        if (ApplyCommonMaskTransformation(x, y) == 0) return 0;
+        return 1;
+    }
 
     /// It returns the mask pattern type
     std::string GetType() { return fPatternType; }
@@ -90,8 +93,8 @@ class TRestPatternMask : public TRestMetadata {
 
     void PrintCommonPatternMembers();
 
-    virtual void PrintMaskMembers() = 0;
-    virtual void PrintMask() = 0;
+    virtual void PrintMaskMembers() {}
+    virtual void PrintMask() { PrintCommonPatternMembers(); }
 
     void PrintMetadata() override;
 

--- a/source/framework/masks/src/TRestGridMask.cxx
+++ b/source/framework/masks/src/TRestGridMask.cxx
@@ -159,7 +159,7 @@ void TRestGridMask::Initialize() {
 /// rotation using the method TRestPatternMask::ApplyCommonMaskTransformation
 ///
 Int_t TRestGridMask::GetRegion(Double_t x, Double_t y) {
-    if (ApplyCommonMaskTransformation(x, y) == 0) return 0;
+    if (TRestPatternMask::GetRegion(x, y) == 0) return 0;
 
     Double_t xEval = fGridThickness / 2. + x;
 

--- a/source/framework/masks/src/TRestGridMask.cxx
+++ b/source/framework/masks/src/TRestGridMask.cxx
@@ -159,7 +159,7 @@ void TRestGridMask::Initialize() {
 /// rotation using the method TRestPatternMask::ApplyCommonMaskTransformation
 ///
 Int_t TRestGridMask::GetRegion(Double_t x, Double_t y) {
-    if (TRestPatternMask::GetRegion(x, y) == 0) return 0;
+    if (TRestPatternMask::GetRegion(x, y)) return 0;
 
     Double_t xEval = fGridThickness / 2. + x;
 

--- a/source/framework/masks/src/TRestPatternMask.cxx
+++ b/source/framework/masks/src/TRestPatternMask.cxx
@@ -142,11 +142,7 @@ bool TRestPatternMask::HitsPattern(Double_t x, Double_t y) {
 void TRestPatternMask::PrintMetadata() {
     TRestMetadata::PrintMetadata();
 
-    RESTMetadata << " - Pattern type : " << fPatternType << RESTendl;
-    RESTMetadata << " - Mask radius : " << fMaskRadius << " mm" << RESTendl;
-    RESTMetadata << " - Max regions : " << fMaxRegions << RESTendl;
-    RESTMetadata << " - Offset : (" << fOffset.X() << ", " << fOffset.Y() << ") mm" << RESTendl;
-    RESTMetadata << " - Rotation angle : " << fRotationAngle * 180. / TMath::Pi() << " degrees" << RESTendl;
+    PrintCommonPatternMembers();
     RESTMetadata << "----" << RESTendl;
 }
 

--- a/source/framework/masks/src/TRestRingsMask.cxx
+++ b/source/framework/masks/src/TRestRingsMask.cxx
@@ -166,7 +166,7 @@ void TRestRingsMask::Initialize() {
 /// using the method TRestPatternMask::RotateAndTranslate.
 ///
 Int_t TRestRingsMask::GetRegion(Double_t x, Double_t y) {
-    if (TRestPatternMask::GetRegion(x, y) == 0) return 0;
+    if (TRestPatternMask::GetRegion(x, y)) return 0;
 
     Double_t r = TMath::Sqrt(x * x + y * y);
     int cont = 0;

--- a/source/framework/masks/src/TRestRingsMask.cxx
+++ b/source/framework/masks/src/TRestRingsMask.cxx
@@ -166,7 +166,7 @@ void TRestRingsMask::Initialize() {
 /// using the method TRestPatternMask::RotateAndTranslate.
 ///
 Int_t TRestRingsMask::GetRegion(Double_t x, Double_t y) {
-    if (ApplyCommonMaskTransformation(x, y) == 0) return 0;
+    if (TRestPatternMask::GetRegion(x, y) == 0) return 0;
 
     Double_t r = TMath::Sqrt(x * x + y * y);
     int cont = 0;

--- a/source/framework/masks/src/TRestSpiderMask.cxx
+++ b/source/framework/masks/src/TRestSpiderMask.cxx
@@ -168,7 +168,7 @@ void TRestSpiderMask::Initialize() {
 /// using the method TRestPatternMask::ApplyCommonMaskTransformation
 ///
 Int_t TRestSpiderMask::GetRegion(Double_t x, Double_t y) {
-    if (ApplyCommonMaskTransformation(x, y) == 0) return 0;
+    if (TRestPatternMask::GetRegion(x, y) == 0) return 0;
 
     Double_t d = TMath::Sqrt(x * x + y * y);
 

--- a/source/framework/masks/src/TRestSpiderMask.cxx
+++ b/source/framework/masks/src/TRestSpiderMask.cxx
@@ -168,7 +168,7 @@ void TRestSpiderMask::Initialize() {
 /// using the method TRestPatternMask::ApplyCommonMaskTransformation
 ///
 Int_t TRestSpiderMask::GetRegion(Double_t x, Double_t y) {
-    if (TRestPatternMask::GetRegion(x, y) == 0) return 0;
+    if (TRestPatternMask::GetRegion(x, y)) return 0;
 
     Double_t d = TMath::Sqrt(x * x + y * y);
 

--- a/source/framework/masks/src/TRestStrippedMask.cxx
+++ b/source/framework/masks/src/TRestStrippedMask.cxx
@@ -161,7 +161,7 @@ void TRestStrippedMask::Initialize() {
 /// using the method TRestPatternMask::ApplyCommonMaskTransformation
 ///
 Int_t TRestStrippedMask::GetRegion(Double_t x, Double_t y) {
-    if (TRestPatternMask::GetRegion(x, y) == 0) return 0;
+    if (TRestPatternMask::GetRegion(x, y)) return 0;
 
     Double_t xEval = fStripsThickness / 2. + x;
 

--- a/source/framework/masks/src/TRestStrippedMask.cxx
+++ b/source/framework/masks/src/TRestStrippedMask.cxx
@@ -161,7 +161,7 @@ void TRestStrippedMask::Initialize() {
 /// using the method TRestPatternMask::ApplyCommonMaskTransformation
 ///
 Int_t TRestStrippedMask::GetRegion(Double_t x, Double_t y) {
-    if (ApplyCommonMaskTransformation(x, y) == 0) return 0;
+    if (TRestPatternMask::GetRegion(x, y) == 0) return 0;
 
     Double_t xEval = fStripsThickness / 2. + x;
 

--- a/source/framework/tools/inc/TRestSystemOfUnits.h
+++ b/source/framework/tools/inc/TRestSystemOfUnits.h
@@ -112,6 +112,7 @@ AddUnit(mon, REST_Units::Time, 3.85e-13);
 AddUnit(yr, REST_Units::Time, 3.17e-14);
 
 // length unit multiplier
+AddUnit(nm, REST_Units::Length, 1e6);
 AddUnit(um, REST_Units::Length, 1e3);
 AddUnit(mm, REST_Units::Length, 1.);
 AddUnit(cm, REST_Units::Length, 1e-1);


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 18](https://badgen.net/badge/PR%20Size/Ok%3A%2018/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_new_masks/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_new_masks) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_new_masks)](https://github.com/rest-for-physics/framework/commits/jgalan_new_masks)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`TRestPatternMask` defines common members for any `TRestPatternMask`. `TRestPatternMask` was pure virtual so in order to use one had to chose a particular pattern (Grid/Stripped/../Combined).

Now it is also possible to do not define a pattern, and thus there will be no pattern, the only selection will be the limits of the pattern defined by `fMaxRadius` and `fOffset`.