### PR TITLE
TRestTools::ReadASCIITable upgraded to allow csv files reading

### DIFF
--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -60,9 +60,9 @@ class TRestTools {
     static void LoadRESTLibrary(bool silent = false);
 
     static int ReadASCIITable(std::string fName, std::vector<std::vector<Double_t>>& data,
-                              Int_t skipLines = 0);
+                              std::string separator = "\t", Int_t skipLines = 0);
     static int ReadASCIITable(std::string fName, std::vector<std::vector<Float_t>>& data,
-                              Int_t skipLines = 0);
+                              std::string separator = "\t", Int_t skipLines = 0);
 
     template <typename T>
     static void TransposeTable(std::vector<std::vector<T>>& data);

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -64,6 +64,9 @@ class TRestTools {
     static int ReadASCIITable(std::string fName, std::vector<std::vector<Float_t>>& data,
                               std::string separator = "\t", Int_t skipLines = 0);
 
+    static int ReadCSVTable(std::string fName, std::vector<std::vector<Double_t>>& data, Int_t skipLines = 0);
+    static int ReadCSVTable(std::string fName, std::vector<std::vector<Float_t>>& data, Int_t skipLines = 0);
+
     template <typename T>
     static void TransposeTable(std::vector<std::vector<T>>& data);
 

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -60,12 +60,12 @@ class TRestTools {
     static void LoadRESTLibrary(bool silent = false);
 
     static int ReadASCIITable(std::string fName, std::vector<std::vector<Double_t>>& data,
-                              std::string separator = "\t", Int_t skipLines = 0);
-    static int ReadASCIITable(std::string fName, std::vector<std::vector<Float_t>>& data,
-                              std::string separator = "\t", Int_t skipLines = 0);
+                              Int_t skipLines = 0, std::string separator = "\t");
+    static int ReadASCIITable(std::string fName, std::vector<std::vector<Float_t>>& data, Int_t skipLines = 0,
+                              std::string separator = "\t");
 
-    static int ReadCSVTable(std::string fName, std::vector<std::vector<Double_t>>& data, Int_t skipLines = 0);
-    static int ReadCSVTable(std::string fName, std::vector<std::vector<Float_t>>& data, Int_t skipLines = 0);
+    static int ReadCSVFile(std::string fName, std::vector<std::vector<Double_t>>& data, Int_t skipLines = 0);
+    static int ReadCSVFile(std::string fName, std::vector<std::vector<Float_t>>& data, Int_t skipLines = 0);
 
     template <typename T>
     static void TransposeTable(std::vector<std::vector<T>>& data);

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -509,7 +509,8 @@ template std::vector<Double_t> TRestTools::GetColumnFromTable<Double_t>(
 ///
 /// Only works with Double_t vector since we use StringToDouble method.
 ///
-int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>& data, Int_t skipLines) {
+int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>& data, std::string separator,
+                               Int_t skipLines) {
     if (!TRestTools::isValidFile((string)fName)) {
         cout << "TRestTools::ReadASCIITable. Error" << endl;
         cout << "Cannot open file : " << fName << endl;
@@ -531,8 +532,13 @@ int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>&
 
         if (line.find("#") == string::npos) {
             std::istringstream in(line);
-            values.push_back(
-                std::vector<string>(std::istream_iterator<string>(in), std::istream_iterator<string>()));
+
+            std::string token;
+            std::vector<std::string> tokens;
+            while (std::getline(in, token, (char)separator[0])) {
+                tokens.push_back(token);
+            }
+            values.push_back(tokens);
         }
     }
 
@@ -559,7 +565,8 @@ int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>&
 ///
 /// This version works with Float_t vector since we use StringToFloat method.
 ///
-int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& data, Int_t skipLines) {
+int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& data, std::string separator,
+                               Int_t skipLines) {
     if (!TRestTools::isValidFile((string)fName)) {
         cout << "TRestTools::ReadASCIITable. Error" << endl;
         cout << "Cannot open file : " << fName << endl;
@@ -581,13 +588,17 @@ int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& 
 
         if (line.find("#") == string::npos) {
             std::istringstream in(line);
-            values.push_back(
-                std::vector<string>(std::istream_iterator<string>(in), std::istream_iterator<string>()));
+
+            std::string token;
+            std::vector<std::string> tokens;
+            while (std::getline(in, token, (char)separator[0])) {
+                tokens.push_back(token);
+            }
+            values.push_back(tokens);
         }
     }
 
-    // Filling the float values table (TODO error handling in case ToFloat
-    // conversion fails)
+    // Filling the float values table (TODO error handling in case ToFloat conversion fails)
     for (int n = 0; n < values.size(); n++) {
         std::vector<Float_t> dblTmp;
         dblTmp.clear();

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -507,6 +507,9 @@ template std::vector<Double_t> TRestTools::GetColumnFromTable<Double_t>(
 /// loaded in the matrix provided through the argument `data`. The content of
 /// `data` will be cleared in this method.
 ///
+/// If any header in the file is present, it should be skipped using the argument `skipLines`
+/// or preceding any line inside the header using `#`.
+///
 /// Only works with Double_t vector since we use StringToDouble method.
 ///
 int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>& data, std::string separator,
@@ -563,6 +566,9 @@ int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>&
 /// loaded in the matrix provided through the argument `data`. The content of
 /// `data` will be cleared in this method.
 ///
+/// If any header in the file is present, it should be skipped using the argument `skipLines`
+/// or preceding any line inside the header using `#`.
+///
 /// This version works with Float_t vector since we use StringToFloat method.
 ///
 int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& data, std::string separator,
@@ -609,6 +615,40 @@ int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& 
     }
 
     return 1;
+}
+
+///////////////////////////////////////////////
+/// \brief Reads a CSV file containing a table with comma separated values
+///
+/// This method will open the file fName. This file should contain a comma
+/// separated table containing numeric values. The values on the table will be
+/// loaded in the matrix provided through the argument `data`. The content of
+/// `data` will be cleared in this method.
+///
+/// If any header in the file is present, it should be skipped using the argument `skipLines`
+/// or preceding any line inside the header using `#`.
+///
+/// Only works with Double_t vector since we use StringToDouble method.
+///
+int TRestTools::ReadCSVTable(std::string fName, std::vector<std::vector<Double_t>>& data, Int_t skipLines) {
+    return ReadASCIITable(fName, data, ",", skipLines);
+}
+
+///////////////////////////////////////////////
+/// \brief Reads a CSV file containing a table with comma separated values
+///
+/// This method will open the file fName. This file should contain a comma
+/// separated table containing numeric values. The values on the table will be
+/// loaded in the matrix provided through the argument `data`. The content of
+/// `data` will be cleared in this method.
+///
+/// If any header in the file is present, it should be skipped using the argument `skipLines`
+/// or preceding any line inside the header using `#`.
+///
+/// Only works with Float_t vector since we use StringToFloat method.
+///
+int TRestTools::ReadCSVTable(std::string fName, std::vector<std::vector<Float_t>>& data, Int_t skipLines) {
+    return ReadASCIITable(fName, data, ",", skipLines);
 }
 
 ///////////////////////////////////////////////

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -512,8 +512,8 @@ template std::vector<Double_t> TRestTools::GetColumnFromTable<Double_t>(
 ///
 /// Only works with Double_t vector since we use StringToDouble method.
 ///
-int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>& data, std::string separator,
-                               Int_t skipLines) {
+int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>& data, Int_t skipLines,
+                               std::string separator) {
     if (!TRestTools::isValidFile((string)fName)) {
         cout << "TRestTools::ReadASCIITable. Error" << endl;
         cout << "Cannot open file : " << fName << endl;
@@ -571,8 +571,8 @@ int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Double_t>>&
 ///
 /// This version works with Float_t vector since we use StringToFloat method.
 ///
-int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& data, std::string separator,
-                               Int_t skipLines) {
+int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& data, Int_t skipLines,
+                               std::string separator) {
     if (!TRestTools::isValidFile((string)fName)) {
         cout << "TRestTools::ReadASCIITable. Error" << endl;
         cout << "Cannot open file : " << fName << endl;
@@ -630,8 +630,8 @@ int TRestTools::ReadASCIITable(string fName, std::vector<std::vector<Float_t>>& 
 ///
 /// Only works with Double_t vector since we use StringToDouble method.
 ///
-int TRestTools::ReadCSVTable(std::string fName, std::vector<std::vector<Double_t>>& data, Int_t skipLines) {
-    return ReadASCIITable(fName, data, ",", skipLines);
+int TRestTools::ReadCSVFile(std::string fName, std::vector<std::vector<Double_t>>& data, Int_t skipLines) {
+    return ReadASCIITable(fName, data, skipLines, ",");
 }
 
 ///////////////////////////////////////////////
@@ -647,8 +647,8 @@ int TRestTools::ReadCSVTable(std::string fName, std::vector<std::vector<Double_t
 ///
 /// Only works with Float_t vector since we use StringToFloat method.
 ///
-int TRestTools::ReadCSVTable(std::string fName, std::vector<std::vector<Float_t>>& data, Int_t skipLines) {
-    return ReadASCIITable(fName, data, ",", skipLines);
+int TRestTools::ReadCSVFile(std::string fName, std::vector<std::vector<Float_t>>& data, Int_t skipLines) {
+    return ReadASCIITable(fName, data, skipLines, ",");
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 66](https://badgen.net/badge/PR%20Size/Ok%3A%2066/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_tools_upgrade/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_tools_upgrade) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_tools_upgrade)](https://github.com/rest-for-physics/framework/commits/jgalan_tools_upgrade)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now `TRestTools::ReadASCIITable` allows to specify the separator, so that now we are able to read `csv` files by indicating the `comma` separator.

I.e.

```
std::vector<std::vector <Double_t> > d;
TRestTools::ReadASCIITable("myFile.csv", d, 0, "," );
```

Then, the table values will be loaded inside the `d` vector.


- [x] Implemented a `separator` argument inside the method `ReadtASCIITable` to define how data is formatted inside the table
- [x] Implemented a `ReadCSVFile` that is simply `ReadASCIITable` but using `,` separator as default.