### PR TITLE
Do not throw error if TRestRun is opened in a non writeable path

### DIFF
--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -261,9 +261,8 @@ void TRestRun::InitFromConfigFile() {
         system((TString) "mkdir -p " + outputdir);
     }
     if (!TRestTools::isPathWritable(outputdir)) {
-        RESTError << "TRestRun: Output path does not exist or it is not writable." << RESTendl;
-        RESTError << "Path : " << outputdir << RESTendl;
-        exit(1);
+        RESTWarning << "TRestRun: Output path '" << outputdir << "' does not exist or it is not writable."
+                    << RESTendl;
     }
 
     // 4. Loop over sections to initialize metadata


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-trestrun/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-trestrun) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=lobis-trestrun)](https://github.com/rest-for-physics/framework/commits/lobis-trestrun)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Should close https://github.com/rest-for-physics/restG4/issues/73

Now the check returns a warning instead.