### PR TITLE
Adding foreach to pull-submodules.py

### DIFF
--- a/pull-submodules.py
+++ b/pull-submodules.py
@@ -167,7 +167,7 @@ Are you sure to proceed? (y/n)
                             if (not exclude and url.find("github") != -1) or (
                                     url.find("lfna.unizar.es") != -1 and lfna) or (
                                     url.find("gitlab.pandax.sjtu.edu.cn") != -1 and sjtu):
-                                print("Pulling: ", end="") 
+                                print("Updating submodule: ", end="") 
                                 print(fullpath.rstrip(), end='')
                                 # init
                                 p = subprocess.run(f"cd {root} && git submodule update --init {submodule}",  #
@@ -179,48 +179,55 @@ Are you sure to proceed? (y/n)
                                 if p.stdout.decode("utf-8").find("checkout") >= 0:
                                     print(p.stdout.decode("utf-8"))
                                 errorOutput = p.stderr.decode("utf-8")
-                                if errorOutput.find("failed") != -1 or errorOutput.find("error") != -1:
+                                if errorOutput.find("failed") != -1 or errorOutput.find("error") != -1 or errorOutput.find("ERROR") != -1 or errorOutput.find("fatal") != -1:
                                     print("[\033[91m Failed \x1b[0m]")
                                     if debug:
                                         print("Message: ")
                                         print(errorOutput)
+                                else:
+                                    print("[\033[92m OK \x1b[0m]")
+
     # back to the git framework directory
     p = subprocess.run(f"cd {root}",  #
                        shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
     # if 'force', override the changes with git reset
     if force:
+        print("Forcing reset: ", end="") 
         p = subprocess.run(f"git submodule foreach 'git reset --hard'",  #
                            shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if debug:
             print(p.stdout.decode("utf-8"))
             print(p.stderr.decode("utf-8"))
         errorOutput = p.stderr.decode("utf-8")
-        if errorOutput.find("failed") != -1 or errorOutput.find("error") != -1:
+        if errorOutput.find("failed") != -1 or errorOutput.find("error") != -1 or errorOutput.find("ERROR") != -1 or errorOutput.find("fatal") != -1:
             print("[\033[91m Failed \x1b[0m]")
             if debug:
                 print("Message: ")
                 print(errorOutput)
+        else:
+            print("[\033[92m OK \x1b[0m]")
 
     # if latest, pull the latest commit instead of the one recorded in the main repo
     if latest:
+        print("Pulling submodules: ", end="") 
         p = subprocess.run(f"git submodule foreach 'git fetch; if [ -z \"$(git ls-remote --heads origin {frameworkBranchName})\" ]; then git checkout master; else git checkout {frameworkBranchName};fi;git pull'",  #
                            shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if debug:
             print(p.stdout.decode("utf-8"))
             print(p.stderr.decode("utf-8"))
         errorOutput = p.stderr.decode("utf-8")
-        if errorOutput.find("failed") != -1 or errorOutput.find("error") != -1:
+        if errorOutput.find("failed") != -1 or errorOutput.find("error") != -1 or errorOutput.find("ERROR") != -1 or errorOutput.find("fatal") != -1:
             print("[\033[91m Failed \x1b[0m]")
             if debug:
                 print("Message: ")
                 print(errorOutput)
+        else:
+            print("[\033[92m OK \x1b[0m]")
     # get commit id
     p = subprocess.run(f"git submodule foreach 'git rev-parse HEAD'",  #
                            shell=True,
                            stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-
-    if errorOutput.find("failed") == -1 and errorOutput.find("error") == -1:
-        print("[\033[92m OK \x1b[0m] (" + p.stdout.decode("utf-8")[0:7] + ")")
+    print(p.stdout.decode("utf-8"))
 
     if clean:
         subprocess.run(f"git clean -xfd", shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)

--- a/pull-submodules.py
+++ b/pull-submodules.py
@@ -203,7 +203,7 @@ Are you sure to proceed? (y/n)
 
     # if latest, pull the latest commit instead of the one recorded in the main repo
     if latest:
-        p = subprocess.run(f"git submodule foreach 'git fetch; git checkout {frameworkBranchName} || git checkout master; git pull'",  #
+        p = subprocess.run(f"git submodule foreach 'git fetch; if [ -z \"$(git ls-remote --heads origin {frameworkBranchName})\" ]; then git checkout master; else git checkout {frameworkBranchName};fi;git pull'",  #
                            shell=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if debug:
             print(p.stdout.decode("utf-8"))


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 48](https://badgen.net/badge/PR%20Size/Ok%3A%2048/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/pullforeach/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/pullforeach) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=pullforeach)](https://github.com/rest-for-physics/framework/commits/pullforeach)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Added `git submodule foreach` to `pull-submodules.py` script:
- Avoids multiple request to github that might cause issues in unizar firewall
- Speed up the checkout of the submodules

Note that the overall behaviour of `pull-submodules.py` has not been significatively changed, however note that  `git submodule foreach` acts on all the submodules that have been initialized.