### PR TITLE
TRestAnalysisTree: recover GetHistogram() for splitted files

### DIFF
--- a/source/framework/core/inc/TRestAnalysisTree.h
+++ b/source/framework/core/inc/TRestAnalysisTree.h
@@ -330,6 +330,7 @@ class TRestAnalysisTree : public TTree {
     }
     Long64_t GetReadEntry() const { return fChain ? fChain->GetReadEntry() : TTree::GetReadEntry(); }
 
+    TH1* GetHistogram() { return fChain ? fChain->GetHistogram() : TTree::GetHistogram(); }
     TLeaf* GetLeaf(const char* branchname, const char* leafname) {
         return fChain ? fChain->GetLeaf(branchname, leafname) : TTree::GetLeaf(branchname, leafname);
     }


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/nkx111-patch-2/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/nkx111-patch-2) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=nkx111-patch-2)](https://github.com/rest-for-physics/framework/commits/nkx111-patch-2)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

just a quick fix for https://github.com/rest-for-physics/framework/issues/316#event-7584532451