### PR TITLE
Adding an internal circular region inside a spider mask

### DIFF
--- a/examples/masks.rml
+++ b/examples/masks.rml
@@ -47,6 +47,15 @@
         <parameter name="armsSeparationAngle" value="60degrees"/>
         <parameter name="initialRadius" value="6cm"/>
     </TRestSpiderMask>
+    <TRestSpiderMask name="spider4" verboseLevel="info">
+        <parameter name="maskRadius" value="20cm"/>
+        <parameter name="offset" value="(0,0)cm"/>
+        <parameter name="rotationAngle" value="30deg"/>
+        <parameter name="armsWidth" value="5deg"/>
+        <parameter name="armsSeparationAngle" value="60degrees"/>
+        <parameter name="initialRadius" value="6cm"/>
+        <parameter name="internalRegionRadius" value="5cm"/>
+    </TRestSpiderMask>
     <TRestCombinedMask name="combined" verboseLevel="warning">
         <TRestSpiderMask name="spider1" verboseLevel="warning">
             <parameter name="maskRadius" value="20cm"/>

--- a/source/framework/masks/inc/TRestSpiderMask.h
+++ b/source/framework/masks/inc/TRestSpiderMask.h
@@ -38,6 +38,9 @@ class TRestSpiderMask : public TRestPatternMask {
     /// The spider structure will be effective from this radius, in mm. Default is from 20 mm.
     Double_t fInitialRadius = 20.;  //<
 
+    /// Radius of an internal circular region defined inside the fInitialRadius. If 0, there will be no region
+    Double_t fInternalRegionRadius = 0.;  //<
+
     /// Used internally to define the forbidden (cosine) angular ranges imposed by the spider structure (0,Pi)
     std::vector<std::pair<Double_t, Double_t>> fPositiveRanges;  //!
 

--- a/source/framework/masks/inc/TRestSpiderMask.h
+++ b/source/framework/masks/inc/TRestSpiderMask.h
@@ -69,6 +69,6 @@ class TRestSpiderMask : public TRestPatternMask {
     TRestSpiderMask(const char* cfgFileName, std::string name = "");
     ~TRestSpiderMask();
 
-    ClassDefOverride(TRestSpiderMask, 1);
+    ClassDefOverride(TRestSpiderMask, 2);
 };
 #endif


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 25](https://badgen.net/badge/PR%20Size/Ok%3A%2025/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_spider_mask/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_spider_mask) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_spider_mask)](https://github.com/rest-for-physics/framework/commits/jgalan_spider_mask)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- A new member `fInternalRegionRadius` has been added to `TRestSpiderMask` to allow the definition of a internal circular region to generate a Tie-fighter like structure.

![NewSpider](https://user-images.githubusercontent.com/12447509/202538733-e86c2821-eb9a-4e40-811a-6001d011985a.png)