### PR TITLE
Fixes replicated backup entries appearing on output file

### DIFF
--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -1038,8 +1038,8 @@ TFile* TRestRun::FormOutputFile() {
     fAnalysisTree = new TRestAnalysisTree("AnalysisTree", "AnalysisTree");
     fEventTree = new TTree("EventTree", "EventTree");
 
-    fAnalysisTree->Write();
-    fEventTree->Write();
+    fAnalysisTree->Write(nullptr, TObject::kOverwrite);
+    fEventTree->Write(nullptr, TObject::kOverwrite);
     this->WriteWithDataBase();
 
     RESTcout << "TRestRun: Output File Created." << RESTendl;
@@ -1152,6 +1152,7 @@ void TRestRun::CloseFile() {
         fEntriesSaved = fAnalysisTree->GetEntries();
         if (fAnalysisTree->GetEntries() > 0 && fInputFile == nullptr) {
             if (fOutputFile != nullptr) {
+                fOutputFile->cd();
                 fAnalysisTree->Write(nullptr, kOverwrite);
                 this->Write(nullptr, kOverwrite);
             }
@@ -1179,6 +1180,7 @@ void TRestRun::CloseFile() {
     }
 
     if (fOutputFile != nullptr) {
+        fOutputFile->Write(0, TObject::kOverwrite);
         fOutputFile->Close();
         delete fOutputFile;
         fOutputFile = nullptr;


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 17](https://badgen.net/badge/PR%20Size/Ok%3A%2017/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_replica_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_replica_fix) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_replica_fix)](https://github.com/rest-for-physics/framework/commits/jgalan_replica_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR should solve issue #338 

I believe the trick was to add `fOutputFile->Write(0, TObject::kOverwrite)`, this fixes additional entries appearing when using `.ls`.

However, I believe that when opening the file using `restRoot`, since we create a new instance, two versions of the object will appear. One it is the instance of the object, the other is the key stored in file.


In reality this is not a 100% fix. The point is that when we open the file using `restRoot file.root` and then use the `TBrowser` the browser shows a replicated object because one is the `key` and the other is the `pointer`. 

If we just do open it using `TFile` then replicated entries will not appear.