### PR TITLE
TRestAnalysisPlot. Fixing conflict between batch and previewPlot

### DIFF
--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -940,7 +940,7 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
     }
 
     // Preview plot. User can make some changed before saving
-    if (StringToBool(GetParameter("previewPlot", "TRUE"))) {
+    if (!REST_Display_CompatibilityMode && StringToBool(GetParameter("previewPlot", "TRUE"))) {
         GetChar();
     }
 


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_plot_batch_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_plot_batch_fix) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_plot_batch_fix)](https://github.com/rest-for-physics/framework/commits/jgalan_plot_batch_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes the error reported at https://rest-forum.unizar.es/t/seg-fault-when-running-in-batch-mode-with-plotting/558