### PR TITLE
Upgrading root installation to root-6.26.10

### DIFF
--- a/scripts/installation/installGarfield.sh
+++ b/scripts/installation/installGarfield.sh
@@ -6,53 +6,39 @@ if [ $(root-config --version | grep "6.") ];then
 
 
 if [ $GARFIELD_HOME ]; then
-    echo Found defined garfield env: $GARFIELD_HOME
-else
-    echo Creating garfield env: GARFIELD_HOME=~/apps/garfield6
-    export GARFIELD_HOME=~/apps/garfield6
-    echo " ++++ GARFIELD_HOME has been added to your .bashrc"
-    echo " " >> ~/.bashrc
-    echo "#Added by REST installGarfield.sh script to setup garfield++ environment" >> ~/.bashrc
-    echo "export GARFIELD_HOME=~/apps/garfield6" >> ~/.bashrc
+    echo "Found defined garfield env: $GARFIELD_HOME"
+    echo "GARFIELD_HOME should not be defined anymore."
+    echo "We now use GARFIELD_INSTALL"
+    echo "Please execute \"unset GARFIELD_HOME\"."
+    echo "And try again!"
+    exit 0
 fi
 
-
-
-if [ $HEED_DATABASE ]; then
-    echo Find defined garfield env: $HEED_DATABASE
+if [ $GARFIELD_INSTALL ]; then
+    echo Found defined garfield env: $GARFIELD_INSTALL
+    echo "It seems that a previous intallation of garfield already exists"
+    echo "If you want to overwrite the installation, just unset GARFIELD_INSTALL"
+    echo "Please execute \"unset GARFIELD_INSTALL\"."
+    echo "The re-launch this script"
+    exit 0
 else
-    echo Creating garfield env: HEED_DATABASE=$GARFIELD_HOME/Heed/heed++/database
-    export HEED_DATABASE=$GARFIELD_HOME/Heed/heed++/database
-    echo " ++++ HEED_DATABASE has been added to your .bashrc"
-    echo "export HEED_DATABASE=\$GARFIELD_HOME/Heed/heed++/database" >> ~/.bashrc
+    echo Creating garfield env: GARFIELD_INSTALL=~/apps/garfield6
+    export GARFIELD_INSTALL=~/apps/garfield6
 fi
 
-
-if [[ $LD_LIBRARY_PATH =~ "$GARFIELD_HOME/lib" ]]; then
-    echo Find garfield lib path $GARFIELD_HOME/lib in LD_LIBRARY_PATH
-else
-    echo Adding garfield lib path into env
-    export LD_LIBRARY_PATH=$LD_LIBRARY_PATH:$GARFIELD_HOME/lib
-    echo " ++++ LD_LIBRARY_PATH has been added to your .bashrc"
-    echo "export LD_LIBRARY_PATH=\$GARFIELD_HOME/lib:\$LD_LIBRARY_PATH" >> ~/.bashrc
-fi
-echo " " >> ~/.bashrc
-
-
-rm -rf $GARFIELD_HOME/build
+rm -rf $GARFIELD_INSTALL/build
 
 echo checkout the code...
-#svn co http://svn.cern.ch/guest/garfield/tags/v1r0 $GARFIELD_HOME
-git clone https://gitlab.cern.ch/garfield/garfieldpp.git $GARFIELD_HOME
-cd $GARFIELD_HOME
-git checkout d9a5bbf0
-
+git clone https://gitlab.cern.ch/garfield/garfieldpp.git $GARFIELD_INSTALL
+cd $GARFIELD_INSTALL
+git checkout tags/4.0
+git checkout -b v4.0
 
 echo building...
 mkdir -p build
 cd build
 
-cmake -DWITH_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=$GARFIELD_HOME ../
+cmake -DWITH_EXAMPLES=OFF -DCMAKE_INSTALL_PREFIX=$GARFIELD_INSTALL ../
 make -j2 install
 
 # I add || true so that the script continues in case the pcm is not inside
@@ -65,9 +51,17 @@ cd $WP
 echo ""
 echo "----------------------------------------------------------------------"
 echo ""
-echo "Garfield has been installed at $GARFIELD_HOME"
+echo "Garfield has been installed at $GARFIELD_INSTALL"
 echo ""
-echo " -- Few lines were added to your .bashrc. Check them out! "
+echo " -- You will need to load Garfield just before compiling REST         "
+echo " "
+echo " Executing: source ~/apps/garfield6/share/Garfield/setupGarfield.sh     "
+echo " "
+echo " "
+echo " -- When you launch cmake during the REST compilation remember to enable Garfield"
+echo " "
+echo " Executing: cmake -DREST_GARFIELD=ON .."
+echo " "
 echo "----------------------------------------------------------------------"
 echo ""
 

--- a/scripts/installation/installGeant4.sh
+++ b/scripts/installation/installGeant4.sh
@@ -32,8 +32,9 @@ tar xvf $G4_FILE
 mkdir -p $G4_ROOT-build
 cd $G4_ROOT-build
 cmake ../$G4_ROOT -DGEANT4_USE_GDML=ON -DGEANT4_USE_QT=OFF -DCMAKE_INSTALL_PREFIX=$HOME/apps/$G4_ROOT-install -DGEANT4_INSTALL_DATA=ON -DGEANT4_INSTALL_DATA_TIMEOUT=7200 -DCMAKE_CXX_STANDARD=17
-make -j30
+make -j8
 make install
+
 cd $WP
 echo ""
 echo "---------------------------------------------------------"

--- a/scripts/installation/installROOT.sh
+++ b/scripts/installation/installROOT.sh
@@ -12,7 +12,7 @@ case "${unameOut}" in
     *)          machine="UNKNOWN:${unameOut}"
 esac
 
-ROOT_VERSION=6.24.02
+ROOT_VERSION=6.26.10
 ROOT_DIR=$HOME/apps/root-$ROOT_VERSION
 
 mkdir -p ${ROOT_DIR}
@@ -34,12 +34,11 @@ tar -xvzf $f
 rm -rf source
 mv root-$ROOT_VERSION source
 
-mkdir -p ${ROOT_DIR}/build
-cd ${ROOT_DIR}/build
+mkdir -p ${ROOT_DIR}/root_build
+cd ${ROOT_DIR}/root_build
 
-cmake -Wno-dev -Dbuiltin_glew=ON -DCMAKE_CXX_STANDARD=17 -Dgdml=ON -DCMAKE_INSTALL_PREFIX=${ROOT_DIR}/install  ../source
-make -j30
-make install
+cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${ROOT_DIR}/install  ../source
+make -j8 install
 
 cd ${CURRENT_DIR}
 

--- a/scripts/installation/installROOT.sh
+++ b/scripts/installation/installROOT.sh
@@ -37,7 +37,7 @@ mv root-$ROOT_VERSION source
 mkdir -p ${ROOT_DIR}/root_build
 cd ${ROOT_DIR}/root_build
 
-cmake -DCMAKE_CXX_STANDARD=17 -DCMAKE_INSTALL_PREFIX=${ROOT_DIR}/install  ../source
+cmake -Wno-dev -Dbuiltin_glew=ON -DCMAKE_CXX_STANDARD=17 -Dgdml=ON -DCMAKE_INSTALL_PREFIX=${ROOT_DIR}/install  ../source
 make -j8 install
 
 cd ${CURRENT_DIR}

--- a/scripts/installation/installROOT.sh
+++ b/scripts/installation/installROOT.sh
@@ -35,7 +35,7 @@ rm -rf source
 mv root-$ROOT_VERSION source
 
 mkdir -p ${ROOT_DIR}/root_build
-cd ${ROOT_DIR}/root_build
+cd ${ROOT_DIR}/build
 
 cmake -Wno-dev -Dbuiltin_glew=ON -DCMAKE_CXX_STANDARD=17 -Dgdml=ON -DCMAKE_INSTALL_PREFIX=${ROOT_DIR}/install  ../source
 make -j8 install


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 36](https://badgen.net/badge/PR%20Size/Ok%3A%2036/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/root-6.26.10/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/root-6.26.10) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=root-6.26.10)](https://github.com/rest-for-physics/framework/commits/root-6.26.10)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- [x] Upgrading installation from root-6.24.2 to root-6.26.10, minor changes added on cmake flags
- [x] `scripts/installation/installGarfield.sh` updated to tags/4.0. Also reviewed and removed GARFIELD_HOME which is obsolete now.