### PR TITLE
use [[(]]) instead of <<(>>) for analysis plots to correct invalid xml syntax

### DIFF
--- a/pipeline/analysisPlot/panel.xml
+++ b/pipeline/analysisPlot/panel.xml
@@ -1,15 +1,14 @@
-
 <panel font_size="0.06">
-	<label value="Run number : <<TRestRun::fRunNumber>>" x="0.25" y="0.9" />
-	<label value="Run tag : <<TRestRun::fRunTag>>" x="0.25" y="0.82" />
-	<label value="Run starts : <<startTime>>" x="0.25" y="0.74" />
-	<label value="Run ends : <<endTime>>" x="0.25" y="0.66" />
-	<label value="Entries : <<entries>>" x="0.25" y="0.58" />
-	<label value="Run duration : <<runLength>> hours" x="0.25" y="0.50" />
-	<label value="Mean rate : <<meanRate>> Hz" x="0.25" y="0.42" />
+    <label value="Run number : [[TRestRun::fRunNumber]]" x="0.25" y="0.9"/>
+    <label value="Run tag : [[TRestRun::fRunTag]]" x="0.25" y="0.82"/>
+    <label value="Run starts : [[startTime]]" x="0.25" y="0.74"/>
+    <label value="Run ends : [[endTime]]" x="0.25" y="0.66"/>
+    <label value="Entries : [[entries]]" x="0.25" y="0.58"/>
+    <label value="Run duration : [[runLength]] hours" x="0.25" y="0.50"/>
+    <label value="Mean rate : [[meanRate]] Hz" x="0.25" y="0.42"/>
 
-	<label value="Detector pressure : [TRestDetector::fPressure] bar" x="0.25" y="0.30" />
-	<label value="Mesh voltage : [TRestDetector::fAmplificationVoltage] V" x="0.25" y="0.22" />
-	<label value="Drift voltage : [TRestDetector::fDriftField] V/cm/bar" x="0.25" y="0.14" />
-	<label value="Electronics gain : [TRestDetector::fElectronicsGain]" x="0.25" y="0.06" />
+    <label value="Detector pressure : [TRestDetector::fPressure] bar" x="0.25" y="0.30"/>
+    <label value="Mesh voltage : [TRestDetector::fAmplificationVoltage] V" x="0.25" y="0.22"/>
+    <label value="Drift voltage : [TRestDetector::fDriftField] V/cm/bar" x="0.25" y="0.14"/>
+    <label value="Electronics gain : [TRestDetector::fElectronicsGain]" x="0.25" y="0.06"/>
 </panel>

--- a/source/framework/core/inc/TRestAnalysisPlot.h
+++ b/source/framework/core/inc/TRestAnalysisPlot.h
@@ -12,11 +12,11 @@
 #ifndef RestCore_TRestAnalysisPlot
 #define RestCore_TRestAnalysisPlot
 
+#include <TCanvas.h>
+#include <TH3D.h>
 #include <TLatex.h>
 #include <TRestRun.h>
 
-#include "TCanvas.h"
-#include "TH3D.h"
 #include "TRestAnalysisTree.h"
 
 const int REST_MAX_TAGS = 15;
@@ -64,7 +64,7 @@ class TRestAnalysisPlot : public TRestMetadata {
         Int_t fillStyle;
 
         TH3F* ptr = nullptr;  //!
-        TH3F* operator->() { return ptr; }
+        TH3F* operator->() const { return ptr; }
     };
 
     struct PlotInfoSet {
@@ -156,12 +156,12 @@ class TRestAnalysisPlot : public TRestMetadata {
     void AddFileFromExternalRun();
     void AddFileFromEnv();
 
-    TRestAnalysisTree* GetTree(TString fileName);
-    TRestRun* GetRunInfo(TString fileName);
-    bool IsDynamicRange(TString rangeString);
-    Int_t GetColorIDFromString(std::string in);
-    Int_t GetFillStyleIDFromString(std::string in);
-    Int_t GetLineStyleIDFromString(std::string in);
+    TRestAnalysisTree* GetTree(const TString& fileName);
+    TRestRun* GetRunInfo(const TString& fileName);
+    bool IsDynamicRange(const TString& rangeString);
+    Int_t GetColorIDFromString(const std::string& in);
+    Int_t GetFillStyleIDFromString(const std::string& in);
+    Int_t GetLineStyleIDFromString(const std::string& in);
 
    protected:
    public:
@@ -169,16 +169,16 @@ class TRestAnalysisPlot : public TRestMetadata {
 
     void PrintMetadata() override {}
 
-    void AddFile(TString fileName);
-    void SetFile(TString fileName);
+    void AddFile(const TString& fileName);
+    void SetFile(const TString& fileName);
 
-    void SaveCanvasToPDF(TString fileName);
-    void SavePlotToPDF(TString fileName, Int_t n = 0);
-    void SaveHistoToPDF(TString fileName, Int_t nPlot = 0, Int_t nHisto = 0);
+    void SaveCanvasToPDF(const TString& fileName);
+    void SavePlotToPDF(const TString& fileName, Int_t n = 0);
+    void SaveHistoToPDF(const TString& fileName, Int_t nPlot = 0, Int_t nHisto = 0);
 
-    void SetOutputPlotsFilename(TString fname) { fCanvasSave = fname; }
+    void SetOutputPlotsFilename(const TString& name) { fCanvasSave = name; }
 
-    Int_t GetPlotIndex(TString plotName);
+    Int_t GetPlotIndex(const TString& plotName);
     inline TVector2 GetCanvasSize() const { return fCanvasSize; }
     inline TVector2 GetCanvasDivisions() const { return fCanvasDivisions; }
 

--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -757,7 +757,7 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
                 RESTInfo << "AnalysisTree->Draw(\"" << plotString << ">>" << histoName << "\", \""
                          << cutString << "\", \"" << optString << "\", " << fDrawNEntries << ", "
                          << fDrawFirstEntry << ")" << RESTendl;
-                outVal = tree->Draw(plotString + "]]" + histoName, cutString, optString, fDrawNEntries,
+                outVal = tree->Draw(plotString + ">>" + histoName, cutString, optString, fDrawNEntries,
                                     fDrawFirstEntry);
                 TH3F* hh = (TH3F*)gPad->GetPrimitive(reducedHistoName);
                 if (outVal == 0) {

--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -667,15 +667,15 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
             string label = fPanels[n].label[m];
 
             size_t pos = 0;
-            label = Replace(label, "<<startTime>>", ToDateTimeString(startTime), pos);
+            label = Replace(label, "[[startTime]]", ToDateTimeString(startTime), pos);
             pos = 0;
-            label = Replace(label, "<<endTime>>", ToDateTimeString(endTime), pos);
+            label = Replace(label, "[[endTime]]", ToDateTimeString(endTime), pos);
             pos = 0;
-            label = Replace(label, "<<entries>>", Form("%d", totalEntries), pos);
+            label = Replace(label, "[[entries]]", Form("%d", totalEntries), pos);
             pos = 0;
-            label = Replace(label, "<<runLength>>", Form("%5.2lf", runLength), pos);
+            label = Replace(label, "[[runLength]]", Form("%5.2lf", runLength), pos);
             pos = 0;
-            label = Replace(label, "<<meanRate>>", Form("%5.2lf", meanRate), pos);
+            label = Replace(label, "[[meanRate]]", Form("%5.2lf", meanRate), pos);
 
             auto run = GetRunInfo(fRunInputFileName[0]);
             label = run->ReplaceMetadataMembers(label, fPanels[n].precision);

--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -44,9 +44,7 @@ void TRestAnalysisPlot::Initialize() {
     fDrawFirstEntry = 0;
 }
 
-TRestAnalysisPlot::~TRestAnalysisPlot() {
-    if (fRun != nullptr) delete fRun;
-}
+TRestAnalysisPlot::~TRestAnalysisPlot() { delete fRun; }
 
 void TRestAnalysisPlot::InitFromConfigFile() {
     if (fHostmgr->GetRunInfo() != nullptr) {
@@ -349,8 +347,8 @@ TRestAnalysisPlot::HistoInfoSet TRestAnalysisPlot::SetupHistogramFromConfigFile(
     hist.name = RemoveWhiteSpaces(GetParameter("name", histele, plot.name));
     hist.drawOption = GetParameter("option", histele, "colz");
 
-    for (unsigned int n = 0; n < fPlotNamesCheck.size(); n++)
-        if (hist.name == fPlotNamesCheck[n]) {
+    for (const auto& n : fPlotNamesCheck)
+        if (hist.name == n) {
             RESTError
                 << "Repeated plot/histo names were found! Please, use different names for different plots!"
                 << RESTendl;
@@ -487,7 +485,7 @@ TRestAnalysisPlot::HistoInfoSet TRestAnalysisPlot::SetupHistogramFromConfigFile(
         if (ToUpper(Active) == "ON") {
             TiXmlAttribute* attr = classifyele->FirstAttribute();
             while (attr != nullptr) {
-                if (attr->Value() != nullptr && string(attr->Value()) != "") {
+                if (attr->Value() != nullptr && !string(attr->Value()).empty()) {
                     hist.classifyMap[attr->Name()] = attr->Value();
                 }
                 attr = attr->Next();
@@ -506,14 +504,14 @@ TRestAnalysisPlot::HistoInfoSet TRestAnalysisPlot::SetupHistogramFromConfigFile(
     return hist;
 }
 
-void TRestAnalysisPlot::AddFile(TString fileName) {
+void TRestAnalysisPlot::AddFile(const TString& fileName) {
     RESTInfo << "TRestAnalysisPlot::AddFile. Adding file. " << RESTendl;
     RESTInfo << "File name: " << fileName << RESTendl;
-    fRunInputFileName.push_back((string)fileName);
+    fRunInputFileName.emplace_back(fileName.Data());
     fNFiles++;
 }
 
-void TRestAnalysisPlot::SetFile(TString fileName) {
+void TRestAnalysisPlot::SetFile(const TString& fileName) {
     fRunInputFileName.clear();
     fRunInputFileName = Vector_cast<string, TString>(TRestTools::GetFilesMatchingPattern((string)fileName));
     fNFiles = fRunInputFileName.size();
@@ -536,14 +534,14 @@ void TRestAnalysisPlot::AddFileFromEnv() {
         string filepattern = GetParameter("inputFileName", "");
         auto files = TRestTools::GetFilesMatchingPattern(filepattern);
 
-        for (unsigned int n = 0; n < files.size(); n++) {
-            RESTEssential << "Adding file : " << files[n] << RESTendl;
-            AddFile(files[n]);
+        for (const auto& file : files) {
+            RESTEssential << "Adding file : " << file << RESTendl;
+            AddFile(file);
         }
     }
 }
 
-Int_t TRestAnalysisPlot::GetPlotIndex(TString plotName) {
+Int_t TRestAnalysisPlot::GetPlotIndex(const TString& plotName) {
     for (unsigned int n = 0; n < fPlots.size(); n++)
         if (fPlots[n].name == plotName) return n;
 
@@ -551,7 +549,7 @@ Int_t TRestAnalysisPlot::GetPlotIndex(TString plotName) {
     return -1;
 }
 
-TRestAnalysisTree* TRestAnalysisPlot::GetTree(TString fileName) {
+TRestAnalysisTree* TRestAnalysisPlot::GetTree(const TString& fileName) {
     if (fRun->GetInputFile() != nullptr && fRun->GetInputFile()->GetName() == fileName) {
         // this means the file is already opened by TRestRun
         return fRun->GetAnalysisTree();
@@ -569,7 +567,7 @@ TRestAnalysisTree* TRestAnalysisPlot::GetTree(TString fileName) {
     return fRun->GetAnalysisTree();
 }
 
-TRestRun* TRestAnalysisPlot::GetRunInfo(TString fileName) {
+TRestRun* TRestAnalysisPlot::GetRunInfo(const TString& fileName) {
     // in any case we directly return fRun. No need to reopen the given file
     if (fRun->GetInputFile() != nullptr && fRun->GetInputFile()->GetName() == fileName) {
         return fRun;
@@ -585,11 +583,11 @@ TRestRun* TRestAnalysisPlot::GetRunInfo(TString fileName) {
     return fRun;
 }
 
-bool TRestAnalysisPlot::IsDynamicRange(TString rangeString) {
+bool TRestAnalysisPlot::IsDynamicRange(const TString& rangeString) {
     return (string(rangeString)).find(",  ") != string::npos;
 }
 
-Int_t TRestAnalysisPlot::GetColorIDFromString(string in) {
+Int_t TRestAnalysisPlot::GetColorIDFromString(const string& in) {
     if (in.find_first_not_of("0123456789") == string::npos) {
         return StringToInteger(in);
     } else if (ColorIdMap.count(in) != 0) {
@@ -600,7 +598,7 @@ Int_t TRestAnalysisPlot::GetColorIDFromString(string in) {
     return -1;
 }
 
-Int_t TRestAnalysisPlot::GetFillStyleIDFromString(string in) {
+Int_t TRestAnalysisPlot::GetFillStyleIDFromString(const string& in) {
     if (in.find_first_not_of("0123456789") == string::npos) {
         return StringToInteger(in);
     } else if (FillStyleMap.count(in) != 0) {
@@ -611,7 +609,7 @@ Int_t TRestAnalysisPlot::GetFillStyleIDFromString(string in) {
     return -1;
 }
 
-Int_t TRestAnalysisPlot::GetLineStyleIDFromString(string in) {
+Int_t TRestAnalysisPlot::GetLineStyleIDFromString(const string& in) {
     if (in.find_first_not_of("0123456789") == string::npos) {
         return StringToInteger(in);
     } else if (LineStyleMap.count(in) != 0) {
@@ -640,8 +638,8 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
     Double_t endTime = 0;
     Double_t runLength = 0;
     Int_t totalEntries = 0;
-    for (unsigned int n = 0; n < fRunInputFileName.size(); n++) {
-        auto run = GetRunInfo(fRunInputFileName[n]);
+    for (const auto& inputFilename : fRunInputFileName) {
+        auto run = GetRunInfo(inputFilename);
 
         Double_t endTimeStamp = run->GetEndTimestamp();
         Double_t startTimeStamp = run->GetStartTimestamp();
@@ -682,10 +680,10 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
             auto run = GetRunInfo(fRunInputFileName[0]);
             label = run->ReplaceMetadataMembers(label, fPanels[n].precision);
 
-            TLatex* texxt = new TLatex(fPanels[n].posX[m], fPanels[n].posY[m], label.c_str());
-            texxt->SetTextColor(1);
-            texxt->SetTextSize(fPanels[n].font_size);
-            texxt->Draw("same");
+            TLatex* textLatex = new TLatex(fPanels[n].posX[m], fPanels[n].posY[m], label.c_str());
+            textLatex->SetTextColor(1);
+            textLatex->SetTextSize(fPanels[n].font_size);
+            textLatex->Draw("same");
         }
     }
 
@@ -721,7 +719,7 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
 
             if (cutString == "")
                 cutString = hist.weight;
-            else if (hist.weight != "")
+            else if (!hist.weight.empty())
                 cutString = "(" + cutString + ") * " + hist.weight;
 
             if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) {
@@ -838,16 +836,16 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
             }
         }
 
-        bool allempty = true;
+        bool allEmpty = true;
         for (unsigned int i = 0; i < plot.histos.size(); i++) {
             if (plot.histos[i].ptr == nullptr)
                 continue;
             else {
-                allempty = false;
+                allEmpty = false;
                 break;
             }
         }
-        if (allempty) {
+        if (allEmpty) {
             RESTWarning << "TRestAnalysisPlot: pad empty for the plot: " << plot.name << RESTendl;
             continue;
         }
@@ -909,18 +907,18 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
         // save histogram to root file
         if (fRun->GetOutputFile() != nullptr) {
             fRun->GetOutputFile()->cd();
-            for (unsigned int i = 0; i < plot.histos.size(); i++) {
-                if (plot.histos[i].ptr == nullptr) continue;
-                plot.histos[i]->Write();
+            for (auto& histo : plot.histos) {
+                if (histo.ptr == nullptr) continue;
+                histo->Write();
             }
         }
 
         // draw legend
         if (plot.legendOn) {
             TLegend* legend = new TLegend(fLegendX1, fLegendY1, fLegendX2, fLegendY2);
-            for (unsigned int i = 0; i < plot.histos.size(); i++) {
-                if (plot.histos[i].ptr == nullptr) continue;
-                legend->AddEntry(plot.histos[i].ptr, plot.histos[i]->GetName(), "lf");
+            for (auto& histo : plot.histos) {
+                if (histo.ptr == nullptr) continue;
+                legend->AddEntry(histo.ptr, histo->GetName(), "lf");
             }
             legend->Draw("same");
         }
@@ -930,7 +928,7 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
         targetPad->SetLeftMargin(plot.marginLeft);
         targetPad->SetBottomMargin(plot.marginBottom);
         targetPad->Update();
-        if (plot.save != "") targetPad->Print(plot.save.c_str());
+        if (!plot.save.empty()) targetPad->Print(plot.save.c_str());
 
         fCombinedCanvas->Update();
     }
@@ -949,8 +947,8 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
         TRestRun* run = new TRestRun();
         run->SetOutputFileName((string)fCanvasSave);
         run->FormOutputFile();
-        for (unsigned int n = 0; n < histCollectionAll.size(); n++) {
-            histCollectionAll[n]->Write();
+        for (auto& h : histCollectionAll) {
+            h->Write();
         }
         delete run;
     }
@@ -964,9 +962,9 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
     delete st;
 }
 
-void TRestAnalysisPlot::SaveCanvasToPDF(TString fileName) { fCombinedCanvas->Print(fileName); }
+void TRestAnalysisPlot::SaveCanvasToPDF(const TString& fileName) { fCombinedCanvas->Print(fileName); }
 
-void TRestAnalysisPlot::SavePlotToPDF(TString fileName, Int_t n) {
+void TRestAnalysisPlot::SavePlotToPDF(const TString& fileName, Int_t n) {
     // gErrorIgnoreLevel = 10;
     fCombinedCanvas->SetBatch(kTRUE);
 
@@ -989,11 +987,9 @@ void TRestAnalysisPlot::SavePlotToPDF(TString fileName, Int_t n) {
     delete c;
 
     fCombinedCanvas->SetBatch(kFALSE);
-
-    return;
 }
 
-void TRestAnalysisPlot::SaveHistoToPDF(TString fileName, Int_t nPlot, Int_t nHisto) {
+void TRestAnalysisPlot::SaveHistoToPDF(const TString& fileName, Int_t nPlot, Int_t nHisto) {
     string name = fPlots[nPlot].histos[nHisto].name;
     TH3F* hist = (TH3F*)gPad->GetPrimitive(name.c_str());
 
@@ -1004,5 +1000,4 @@ void TRestAnalysisPlot::SaveHistoToPDF(TString fileName, Int_t nPlot, Int_t nHis
     c->Print(fileName);
 
     delete c;
-    return;
 }

--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -756,10 +756,10 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
                 int outVal;
                 TString reducedHistoName = nameString + "_" + std::to_string(j);
                 TString histoName = nameString + "_" + std::to_string(j) + rangeString;
-                RESTInfo << "AnalysisTree->Draw(\"" << plotString << ">>" << histoName << "\", \""
+                RESTInfo << "AnalysisTree->Draw(\"" << plotString << "]]" << histoName << "\", \""
                          << cutString << "\", \"" << optString << "\", " << fDrawNEntries << ", "
                          << fDrawFirstEntry << ")" << RESTendl;
-                outVal = tree->Draw(plotString + ">>" + histoName, cutString, optString, fDrawNEntries,
+                outVal = tree->Draw(plotString + "]]" + histoName, cutString, optString, fDrawNEntries,
                                     fDrawFirstEntry);
                 TH3F* hh = (TH3F*)gPad->GetPrimitive(reducedHistoName);
                 if (outVal == 0) {

--- a/source/framework/core/src/TRestAnalysisTree.cxx
+++ b/source/framework/core/src/TRestAnalysisTree.cxx
@@ -969,7 +969,7 @@ Double_t TRestAnalysisTree::GetObservableAverage(const TString& obsName, Double_
     if (xHigh == -1)
         this->Draw(obsName);
     else
-        this->Draw(obsName + "]]" + histDefinition);
+        this->Draw(obsName + ">>" + histDefinition);
     TH1F* htemp = (TH1F*)gPad->GetPrimitive("htemp");
     return htemp->GetMean();
 }
@@ -984,7 +984,7 @@ Double_t TRestAnalysisTree::GetObservableRMS(const TString& obsName, Double_t xL
     if (xHigh == -1)
         this->Draw(obsName);
     else
-        this->Draw(obsName + "]]" + histDefinition);
+        this->Draw(obsName + ">>" + histDefinition);
     TH1F* htemp = (TH1F*)gPad->GetPrimitive("htemp");
     return htemp->GetRMS();
 }
@@ -999,7 +999,7 @@ Double_t TRestAnalysisTree::GetObservableMaximum(const TString& obsName, Double_
     if (xHigh == -1)
         this->Draw(obsName);
     else
-        this->Draw(obsName + "]]" + histDefinition);
+        this->Draw(obsName + ">>" + histDefinition);
     TH1F* htemp = (TH1F*)gPad->GetPrimitive("htemp");
     return htemp->GetMaximumStored();
 }
@@ -1014,7 +1014,7 @@ Double_t TRestAnalysisTree::GetObservableMinimum(const TString& obsName, Double_
     if (xHigh == -1)
         this->Draw(obsName);
     else
-        this->Draw(obsName + "]]" + histDefinition);
+        this->Draw(obsName + ">>" + histDefinition);
     TH1F* htemp = (TH1F*)gPad->GetPrimitive("htemp");
     return htemp->GetMinimumStored();
 }

--- a/source/framework/core/src/TRestAnalysisTree.cxx
+++ b/source/framework/core/src/TRestAnalysisTree.cxx
@@ -969,7 +969,7 @@ Double_t TRestAnalysisTree::GetObservableAverage(const TString& obsName, Double_
     if (xHigh == -1)
         this->Draw(obsName);
     else
-        this->Draw(obsName + ">>" + histDefinition);
+        this->Draw(obsName + "]]" + histDefinition);
     TH1F* htemp = (TH1F*)gPad->GetPrimitive("htemp");
     return htemp->GetMean();
 }
@@ -984,7 +984,7 @@ Double_t TRestAnalysisTree::GetObservableRMS(const TString& obsName, Double_t xL
     if (xHigh == -1)
         this->Draw(obsName);
     else
-        this->Draw(obsName + ">>" + histDefinition);
+        this->Draw(obsName + "]]" + histDefinition);
     TH1F* htemp = (TH1F*)gPad->GetPrimitive("htemp");
     return htemp->GetRMS();
 }
@@ -999,7 +999,7 @@ Double_t TRestAnalysisTree::GetObservableMaximum(const TString& obsName, Double_
     if (xHigh == -1)
         this->Draw(obsName);
     else
-        this->Draw(obsName + ">>" + histDefinition);
+        this->Draw(obsName + "]]" + histDefinition);
     TH1F* htemp = (TH1F*)gPad->GetPrimitive("htemp");
     return htemp->GetMaximumStored();
 }
@@ -1014,7 +1014,7 @@ Double_t TRestAnalysisTree::GetObservableMinimum(const TString& obsName, Double_
     if (xHigh == -1)
         this->Draw(obsName);
     else
-        this->Draw(obsName + ">>" + histDefinition);
+        this->Draw(obsName + "]]" + histDefinition);
     TH1F* htemp = (TH1F*)gPad->GetPrimitive("htemp");
     return htemp->GetMinimumStored();
 }

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -1653,7 +1653,7 @@ string TRestRun::ReplaceMetadataMembers(const string& instr, Int_t precision) {
 
         if (cont < 0) RESTError << "This is a coding error at ReplaceMetadataMembers!" << RESTendl;
 
-        // We search for the enclosing ]. Since we might find a vector index inside.
+        // We search for the enclosing ']'. Since we might find a vector index inside.
         while (cont > 0) {
             endPosition = outstring.find("]", endPosition + 1);
             s = outstring.substr(startPosition + 1, endPosition - startPosition - 1);
@@ -1669,8 +1669,8 @@ string TRestRun::ReplaceMetadataMembers(const string& instr, Int_t precision) {
         endPosition = 0;
     }
 
-    outstring = Replace(outstring, "<<", "[");
-    outstring = Replace(outstring, ">>", "]");
+    outstring = Replace(outstring, "[[", "[");
+    outstring = Replace(outstring, "]]", "]");
 
     return REST_StringHelper::ReplaceMathematicalExpressions(outstring, precision);
 }
@@ -1693,7 +1693,7 @@ string TRestRun::ReplaceMetadataMembers(const string& instr, Int_t precision) {
 ///
 string TRestRun::ReplaceMetadataMember(const string& instr, Int_t precision) {
     if (instr.find("::") == string::npos && instr.find("->") == string::npos) {
-        return "<<" + instr + ">>";
+        return "[[" + instr + "]]";
     }
     vector<string> results = Split(instr, "::", false, true);
     if (results.size() == 1) results = Split(instr, "->", false, true);


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 75](https://badgen.net/badge/PR%20Size/Ok%3A%2075/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-xml/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-xml) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=lobis-xml)](https://github.com/rest-for-physics/framework/commits/lobis-xml)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

As the title says we cannot use `<<` or `>>` in the xml (or rml) files if we want it to be valid xml, even though some parsers can tolerate it.

I replaced them by square brackets but any suggestion is welcome.

This issue was discovered when running a tool to check for valid xml files.