### PR TITLE
Few minor fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -164,7 +164,6 @@ if (${REST_MPFR} MATCHES "ON")
     endif ()
 else ()
     set(REST_MPFR OFF)
-    set(excludes ${excludes} TRestComplex)
 endif (${REST_MPFR} MATCHES "ON")
 
 #####  CURL  #####

--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -149,10 +149,10 @@ int main(int argc, char* argv[]) {
             }
 
             printf("\n%s\n", "Attaching metadata structures...");
-            Int_t numberOfMetadataStructures = runTmp->GetNumberOfMetadataStructures();
+            Int_t numberOfMetadata = runTmp->GetNumberOfMetadata();
             map<string, int> metanames;
-            for (int n = 0; n < numberOfMetadataStructures; n++) {
-                string metaName = runTmp->GetMetadataStructureNames()[n];
+            for (int n = 0; n < numberOfMetadata; n++) {
+                string metaName = runTmp->GetMetadataNames()[n];
                 if (metaName.find("Historic") != string::npos) {
                     continue;
                 }

--- a/source/framework/CMakeLists.txt
+++ b/source/framework/CMakeLists.txt
@@ -15,6 +15,10 @@ if (NOT ${REST_EVE} MATCHES "ON")
     set(excludes TRestEveEventViewer)
 endif (NOT ${REST_EVE} MATCHES "ON")
 
+if (NOT ${REST_MPFR} MATCHES "ON")
+	set(excludes TRestComplex)
+endif (NOT ${REST_MPFR} MATCHES "ON")
+
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(excludes TRestBenchMarkProcess TRestRealTimeAddInputFileProcess TRestRealTimeDrawingProcess TRestMessenger ${excludes})
 endif (CMAKE_SYSTEM_NAME MATCHES "Windows")

--- a/source/framework/analysis/src/TRestSummaryProcess.cxx
+++ b/source/framework/analysis/src/TRestSummaryProcess.cxx
@@ -170,7 +170,7 @@ TRestEvent* TRestSummaryProcess::ProcessEvent(TRestEvent* inputEvent) {
 /// \brief Function to use when all events have been processed
 ///
 void TRestSummaryProcess::EndProcess() {
-    Int_t nEntries = fRunInfo->GetEntries();
+    Int_t nEntries = GetFullAnalysisTree()->GetEntries();
     Double_t startTime = fRunInfo->GetStartTimestamp();
     Double_t endTime = fRunInfo->GetEndTimestamp();
 

--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -102,7 +102,11 @@ class TRestDataSet : public TRestMetadata {
 
     /// Gives access to the tree
     TTree* GetTree() const {
-        if (fTree == nullptr) RESTWarning << "Tree has not been yet initialized" << RESTendl;
+        if (fTree == nullptr) {
+            RESTError << "Tree has not been yet initialized" << RESTendl;
+            RESTError << "You should invoke TRestDataSet::Initialize() before trying to access the tree"
+                      << RESTendl;
+        }
         return fTree;
     }
 

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -169,9 +169,9 @@ class TRestRun : public TRestMetadata {
 
     TRestMetadata* GetMetadata(const TString& name, TFile* file = nullptr);
     TRestMetadata* GetMetadataClass(const TString& type, TFile* file = nullptr);
-    std::vector<std::string> GetMetadataStructureNames();
-    std::vector<std::string> GetMetadataStructureTitles();
-    inline int GetNumberOfMetadataStructures() const { return fMetadata.size(); }
+    std::vector<std::string> GetMetadataNames();
+    std::vector<std::string> GetMetadataTitles();
+    inline int GetNumberOfMetadata() const { return fMetadata.size(); }
 
     inline std::string GetMetadataMember(const std::string& instr) { return ReplaceMetadataMember(instr); }
     std::string ReplaceMetadataMembers(const std::string& instr, Int_t precision = 2);

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -19,6 +19,7 @@ class TRestRun : public TRestMetadata {
    protected:
     // run info
     Int_t fRunNumber;  //< first identification number
+                       /// It can be used as parent number of subrun number
     Int_t fParentRunNumber;
     TString fRunClassName;
     TString fRunType;  //< Stores bit by bit the type of run. e.g. calibration, background, pedestal,
@@ -120,6 +121,7 @@ class TRestRun : public TRestMetadata {
 
     // Getters
     inline Int_t GetParentRunNumber() const { return fParentRunNumber; }
+    inline Int_t GetSubRunNumber() const { return fParentRunNumber; }
     inline Int_t GetRunNumber() const { return fRunNumber; }
     inline TString GetRunType() const { return fRunType; }
     inline TString GetRunUser() const { return fRunUser; }

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -339,7 +339,7 @@ std::vector<std::string> TRestDataSet::FileSelection() {
         double runStart = run.GetStartTimestamp();
         double runEnd = run.GetEndTimestamp();
 
-        if (runStart < time_stamp_start && runEnd > time_stamp_end) {
+        if (runStart < time_stamp_start || runEnd > time_stamp_end) {
             continue;
         }
 

--- a/source/framework/core/src/TRestMetadataPlot.cxx
+++ b/source/framework/core/src/TRestMetadataPlot.cxx
@@ -574,7 +574,7 @@ void TRestMetadataPlot::AddFileFromExternalRun() {
 /// \brief We can add input file from parameter "inputFile"
 ///
 void TRestMetadataPlot::AddFileFromEnv() {
-    string filepattern = GetParameter("inputFile", "");
+    string filepattern = GetParameter("inputFileName", "");
     auto files = TRestTools::GetFilesMatchingPattern(filepattern);
 
     for (unsigned int n = 0; n < files.size(); n++) {
@@ -768,6 +768,9 @@ void TRestMetadataPlot::GenerateCanvas() {
                 // We reject runs with unexpected zero y-data
                 Double_t yVal = StringToDouble(run->GetMetadataMember(graph.yVariable));
                 if (yVal == 0 && skipZeroData) {
+                    RESTWarning
+                        << "Ignoring zero data. This message could be disabled with variable skipZeroData"
+                        << RESTendl;
                     delete run;
                     continue;
                 }

--- a/source/framework/core/src/TRestMetadataPlot.cxx
+++ b/source/framework/core/src/TRestMetadataPlot.cxx
@@ -746,7 +746,7 @@ void TRestMetadataPlot::GenerateCanvas() {
             std::map<Double_t, Int_t> dataMapN;
 
             // TODO Here we open the file for each graph construction. This might slowdown these
-            // drawing routnes when we load thousands of files and we have many graphs. It could be
+            // drawing routines when we load thousands of files and we have many graphs. It could be
             // optimized for the case of many graphs by preloading TGraph data into a dedicated
             // structure at Graph_Info_Set
 

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -1786,7 +1786,7 @@ Bool_t TRestRun::EvaluateMetadataMember(const string& instr) {
     }
 
     if (!isANumber(results[1])) {
-        if (ReplaceMetadataMember(results[0]) == results[1])
+        if (ReplaceMetadataMember(results[0]).find(results[1]) != string::npos)
             return true;
         else
             return false;

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -1618,18 +1618,18 @@ TRestMetadata* TRestRun::GetMetadata(const TString& name, TFile* file) {
     return nullptr;
 }
 
-std::vector<std::string> TRestRun::GetMetadataStructureNames() {
+std::vector<std::string> TRestRun::GetMetadataNames() {
     std::vector<std::string> strings;
 
-    for (int n = 0; n < GetNumberOfMetadataStructures(); n++) strings.push_back(fMetadata[n]->GetName());
+    for (int n = 0; n < GetNumberOfMetadata(); n++) strings.push_back(fMetadata[n]->GetName());
 
     return strings;
 }
 
-std::vector<std::string> TRestRun::GetMetadataStructureTitles() {
+std::vector<std::string> TRestRun::GetMetadataTitles() {
     std::vector<std::string> strings;
 
-    for (int n = 0; n < GetNumberOfMetadataStructures(); n++) strings.push_back(fMetadata[n]->GetTitle());
+    for (int n = 0; n < GetNumberOfMetadata(); n++) strings.push_back(fMetadata[n]->GetTitle());
 
     return strings;
 }


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 29](https://badgen.net/badge/PR%20Size/Ok%3A%2029/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_summary_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_summary_fix) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_summary_fix)](https://github.com/rest-for-physics/framework/commits/jgalan_summary_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- Introduces a fix at `TRestSummaryProcess::EndProcess`. Entries were not properly retrieved from `fRunInfo`.
- Adding a fix in `TRestDataSet` logic to fix problem with file selection by date.
- `TRestRun::GetSubRunNumber` method added.
- `CMakeLists.txt` fixing a bug where excluding `TRestComplex` was not properly implemented.
