### PR TITLE
Cpp11

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,12 +120,19 @@ else ()
         if (NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
             set(external_libs "${external_libs};stdc++fs")
         endif ()
+    elseif (${HASCXX14} MATCHES "yes")
+        set(CMAKE_CXX_STANDARD 14)
+        message(WARNING "ROOT is compiled with a rather old c++ standard(14). When compiling REST under this standard, some of the libraries might issue errors."
+                )
+    elseif (${HASCXX11} MATCHES "yes")
+        set(CMAKE_CXX_STANDARD 11)
+        message(WARNING "ROOT is compiled with a rather old c++ standard(11). When compiling REST under this standard, some of the libraries might issue errors."
+                )
     else ()
-        message(WARNING "Minimum C++ standard version is 17,
+        message(FATAL_ERROR "Minimum C++ standard version is 17,
                 while the root version is compiled with an older
                 C++ standard, check root-config --cflags ${ROOT_CFLAGS}"
                 )
-        set(CMAKE_CXX_STANDARD 11)
     endif ()
 endif ()
 
@@ -201,6 +208,18 @@ include(GitHooks)
 
 # Start compile
 include(MacroRootDict)
+
+
+# Clear the install dir
+if (NOT DEFINED INSTALL_CLEARDIR)
+    set(INSTALL_CLEARDIR ON)
+endif ()
+# nkx: Call the rm command before add_subdictory, otherwise the installed libraries will be removed
+if (${INSTALL_CLEARDIR} MATCHES "ON")
+    install(CODE "execute_process(COMMAND rm -r ${CMAKE_INSTALL_PREFIX})")
+endif ()
+
+
 add_subdirectory(source)
 
 message("")
@@ -223,13 +242,7 @@ message("")
 
 file(GLOB_RECURSE Headers "${CMAKE_CURRENT_SOURCE_DIR}/source/framework/*.h")
 
-# Clear the install dir
-if (NOT DEFINED INSTALL_CLEARDIR)
-    set(INSTALL_CLEARDIR ON)
-endif ()
-if (${INSTALL_CLEARDIR} MATCHES "ON")
-    install(CODE "execute_process(COMMAND rm -r ${CMAKE_INSTALL_PREFIX})")
-endif ()
+
 
 # Install the files of the main framework
 install(FILES ${Headers} DESTINATION include)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ endif ()
 if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
     SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
 else ()
-    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -lstdc++fs")
+    SET(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS}")
 endif (CMAKE_SYSTEM_NAME MATCHES "Darwin")
 
 if ( CMAKE_BUILD_TYPE MATCHES "Release" )
@@ -98,10 +98,6 @@ if (CMAKE_SYSTEM_NAME MATCHES "Windows")
     add_definitions(-D_HAS_STD_BYTE=0)
 else ()
 
-    if (NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
-        set(external_libs "${external_libs};stdc++fs")
-    endif ()
-
     execute_process(COMMAND root-config --has-cxx20 OUTPUT_VARIABLE HASCXX20)
     execute_process(COMMAND root-config --has-cxx17 OUTPUT_VARIABLE HASCXX17)
     execute_process(COMMAND root-config --has-cxx14 OUTPUT_VARIABLE HASCXX14)
@@ -113,13 +109,23 @@ else ()
 
     if (${HASCXX20} MATCHES "yes")
         set(CMAKE_CXX_STANDARD 20)
+
+        if (NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
+            set(external_libs "${external_libs};stdc++fs")
+        endif ()
+
     elseif (${HASCXX17} MATCHES "yes")
         set(CMAKE_CXX_STANDARD 17)
+
+        if (NOT CMAKE_SYSTEM_NAME MATCHES "Darwin")
+            set(external_libs "${external_libs};stdc++fs")
+        endif ()
     else ()
-        message(FATAL_ERROR "Minimum C++ standard version is 17,
+        message(WARNING "Minimum C++ standard version is 17,
                 while the root version is compiled with an older
                 C++ standard, check root-config --cflags ${ROOT_CFLAGS}"
                 )
+        set(CMAKE_CXX_STANDARD 11)
     endif ()
 endif ()
 

--- a/scripts/installation/installROOT.sh
+++ b/scripts/installation/installROOT.sh
@@ -38,7 +38,7 @@ mkdir -p ${ROOT_DIR}/build
 cd ${ROOT_DIR}/build
 
 cmake -Wno-dev -Dbuiltin_glew=ON -DCMAKE_CXX_STANDARD=17 -Dgdml=ON -DCMAKE_INSTALL_PREFIX=${ROOT_DIR}/install  ../source
-make -j30
+make -j4
 make install
 
 cd ${CURRENT_DIR}

--- a/source/framework/CMakeLists.txt
+++ b/source/framework/CMakeLists.txt
@@ -11,10 +11,6 @@ file(GLOB_RECURSE addon_src
         "tiny*cpp"
         "startup.cpp")
 
-if (NOT ${REST_EVE} MATCHES "ON")
-    set(excludes TRestEveEventViewer)
-endif (NOT ${REST_EVE} MATCHES "ON")
-
 if (CMAKE_SYSTEM_NAME MATCHES "Windows")
     set(excludes TRestBenchMarkProcess TRestRealTimeAddInputFileProcess TRestRealTimeDrawingProcess TRestMessenger ${excludes})
 endif (CMAKE_SYSTEM_NAME MATCHES "Windows")

--- a/source/framework/core/src/TRestAnalysisPlot.cxx
+++ b/source/framework/core/src/TRestAnalysisPlot.cxx
@@ -740,7 +740,9 @@ void TRestAnalysisPlot::PlotCombinedCanvas() {
                 auto run = GetRunInfo(fRunInputFileName[j]);
                 // apply "classify" condition
                 bool flag = true;
-                for (const auto& [inputFile, info] : hist.classifyMap) {
+                for (const auto& pair : hist.classifyMap) {
+                    auto& inputFile = pair.first;
+                    auto& info = pair.second;
                     if (run->GetRunInformation(inputFile).find(info) == string::npos) {
                         flag = false;
                         break;

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -363,7 +363,9 @@ std::vector<std::string> TRestDataSet::FileSelection() {
 
         if (!accept) continue;
 
-        for (auto& [name, properties] : fQuantity) {
+        for (auto& item : fQuantity) {
+            auto& name = item.first;
+            auto& properties = item.second;
             Double_t value =
                 REST_StringHelper::StringToDouble(run.ReplaceMetadataMembers(properties.metadata));
 
@@ -455,7 +457,9 @@ void TRestDataSet::PrintMetadata() {
         RESTMetadata << " -------------------- " << RESTendl;
 
         int n = 0;
-        for (auto const& [name, properties] : fQuantity) {
+        for (auto const& item : fQuantity) {
+            auto& name = item.first;
+            auto& properties = item.second;
             RESTMetadata << " - Name : " << name << ". Value : " << properties.value
                          << ". Strategy: " << properties.strategy << RESTendl;
             RESTMetadata << " - Metadata: " << properties.metadata << RESTendl;
@@ -623,7 +627,9 @@ void TRestDataSet::Export(const std::string& filename) {
         }
         fprintf(f, "###\n");
         fprintf(f, "### Relevant quantities: \n");
-        for (auto& [name, properties] : fQuantity) {
+        for (auto& item : fQuantity) {
+            auto& name = item.first;
+            auto& properties = item.second;
             fprintf(f, "### - %s : %lf - %s\n", name.c_str(), properties.value,
                     properties.description.c_str());
         }

--- a/source/framework/core/src/TRestEveEventViewer.cxx
+++ b/source/framework/core/src/TRestEveEventViewer.cxx
@@ -37,7 +37,9 @@ void InitializePerspectiveView() {
         {"Projection XZ", TGLViewer::kCameraOrthoXnOZ},  //
         {"Projection YZ", TGLViewer::kCameraOrthoZOY}    //
     };
-    for (const auto& [name, cameraType] : projectionsMap) {
+    for (const auto& item : projectionsMap) {
+        auto& name = item.first;
+        auto& cameraType = item.second;
         auto slot = TEveWindow::CreateWindowInTab(gEve->GetBrowser()->GetTabRight());
         auto pack = slot->MakePack();
         pack->SetElementName(name);

--- a/source/framework/core/src/TRestGDMLParser.cxx
+++ b/source/framework/core/src/TRestGDMLParser.cxx
@@ -1,6 +1,5 @@
 #include "TRestGDMLParser.h"
 
-#include <filesystem>
 #ifdef __APPLE__
 #include <unistd.h>
 #endif
@@ -8,7 +7,9 @@
 using namespace std;
 
 string TRestGDMLParser::GetEntityVersion(const string& name) const {
-    for (auto& [entityName, entityVersion] : fEntityVersionMap) {
+    for (auto& item : fEntityVersionMap) {
+        auto& entityName = item.first;
+        auto& entityVersion = item.second;
         if (entityName == name) {
             return entityVersion;
         }
@@ -70,7 +71,11 @@ void TRestGDMLParser::Load(const string& filename) {
     fOutputGdmlFilename = fOutputGdmlDirectory + "PID" + std::to_string(getpid()) + "_" + filenameNoPath;
     cout << "TRestGDMLParser: Creating temporary file at: \"" << fOutputGdmlFilename << "\"" << endl;
 
-    filesystem::create_directories(fOutputGdmlDirectory);
+    int status = TRestTools::CreateDirectory(fOutputGdmlDirectory);
+    if (status!=0){
+        std::cerr << "mkdir failed to create directory: " << fOutputGdmlDirectory << std::endl;
+        exit(1);
+    }
 
     ofstream outputFile;
     outputFile.open(fOutputGdmlFilename, ios::trunc);
@@ -87,11 +92,11 @@ void TRestGDMLParser::Load(const string& filename) {
 TGeoManager* TRestGDMLParser::CreateGeoManager() {
     // We must change to the gdml file directory, otherwise ROOT cannot load.
     if (!fOutputGdmlFilename.empty()) {
-        const auto currentPath = filesystem::current_path();
-        filesystem::current_path(fOutputGdmlDirectory);
+        const auto currentPath = TRestTools::GetCurrentDirectory();
+        TRestTools::ChangeDirectory(fOutputGdmlDirectory);
         auto geoManager = new TGeoManager();
         geoManager->Import(fOutputGdmlFilename.c_str());
-        filesystem::current_path(currentPath);
+        TRestTools::ChangeDirectory(currentPath);
         return geoManager;
     }
     return nullptr;

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -36,8 +36,6 @@
 #include <unistd.h>
 #endif  // !WIN32
 
-#include <filesystem>
-
 #include "TRestDataBase.h"
 #include "TRestEventProcess.h"
 #include "TRestManager.h"
@@ -1033,7 +1031,7 @@ TFile* TRestRun::FormOutputFile() {
 
     fOutputFileName = FormFormat(fOutputFileName);
     // remove unwanted "./" etc. from the path while resolving them
-    fOutputFileName = std::filesystem::weakly_canonical(fOutputFileName.Data());
+    fOutputFileName = TRestTools::ToAbsoluteName(fOutputFileName.Data());
 
     fOutputFile = new TFile(fOutputFileName, "recreate");
     fAnalysisTree = new TRestAnalysisTree("AnalysisTree", "AnalysisTree");

--- a/source/framework/core/src/startup.cpp
+++ b/source/framework/core/src/startup.cpp
@@ -1,11 +1,13 @@
-#include <filesystem>
-
 #ifdef WIN32
 #include <Windows.h>
 #endif  // WIN32
 
 #ifdef __APPLE__
 #include <unistd.h>
+#endif
+
+#if __cplusplus>=201703L
+#include <filesystem>
 #endif
 
 #include "RVersion.h"
@@ -125,14 +127,26 @@ struct __REST_CONST_INIT {
             auto lsresolve = Split(lsresult, "->", true, true);
             if (lsresolve.size() == 2) {
                 if (lsresolve[1].find("bin")) {
-                    std::filesystem::path path(lsresolve[1]);
-                    REST_PATH = path.parent_path().parent_path().string();
+                    int pos = lsresolve[1].rfind("bin");
+                    if(pos!=string::npos){
+                        REST_PATH = lsresolve[1].substr(0,pos);
+                    }
+                    else{
+                        REST_PATH = lsresolve[1];
+                    }
+
                     RESTWarning << "Lacking system env \"REST_PATH\"!" << RESTendl;
                     RESTWarning << "You need to source \"thisREST.sh\" first!" << RESTendl;
                     RESTWarning << "Setting REST path to the executable path: " << REST_PATH << RESTendl;
                 } else {
-                    std::filesystem::path path(lsresolve[1]);
-                    REST_PATH = path.parent_path().string();
+                    int pos = lsresolve[1].find_last_of("/");
+                    if(pos!=string::npos){
+                        REST_PATH = lsresolve[1].substr(0,pos);
+                    }
+                    else{
+                        REST_PATH = lsresolve[1];
+                    }
+
                     RESTWarning << "Lacking system env \"REST_PATH\"!" << RESTendl;
                     RESTWarning << "REST not installed? Setting to path: " << REST_PATH << RESTendl;
                 }
@@ -185,7 +199,7 @@ struct __REST_CONST_INIT {
         if (REST_USER_PATH != "") {
             // check the data directories
             if (!TRestTools::fileExists(REST_USER_PATH)) {
-                std::filesystem::create_directory(REST_USER_PATH);
+                TRestTools::CreateDirectory(REST_USER_PATH);
             }
             // check the runNumber file
             if (!TRestTools::fileExists(REST_USER_PATH + "/runNumber")) {
@@ -197,11 +211,11 @@ struct __REST_CONST_INIT {
             //}
             // check the download directory
             if (!TRestTools::fileExists(REST_USER_PATH + "/download")) {
-                std::filesystem::create_directory(REST_USER_PATH + "/download");
+                TRestTools::CreateDirectory(REST_USER_PATH + "/download");
             }
             // check the gdml directory
             if (!TRestTools::fileExists(REST_USER_PATH + "/gdml")) {
-                std::filesystem::create_directory(REST_USER_PATH + "/gdml");
+                TRestTools::CreateDirectory(REST_USER_PATH + "/gdml");
             }
         }
     }

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -129,6 +129,8 @@ class TRestTools {
 
     static std::string POSTRequest(const std::string& url, const std::map<std::string, std::string>& keys);
     static void ChangeDirectory(const std::string& toDirectory);
+    static int CreateDirectory(const std::string& dirname);
+    static std::string GetCurrentDirectory();
 };
 
 namespace REST_InitTools {


### PR DESCRIPTION
I still think we should retain c++11 compatibility for REST. At least for the framework. **Otherwise it would be less acceptable by other collaborations**. With this PR we can install REST under gcc 4.8.5. (Also the latest ROOT could be compiled with that gcc, why shouldn't us?)

