### PR TITLE
Revert "use [[(]]) instead of <<(>>) for analysis plots to correct invalid xml syntax"

### DIFF
--- a/pipeline/analysisPlot/panel.xml
+++ b/pipeline/analysisPlot/panel.xml
@@ -1,14 +1,15 @@
-<panel font_size="0.06">
-    <label value="Run number : [[TRestRun::fRunNumber]]" x="0.25" y="0.9"/>
-    <label value="Run tag : [[TRestRun::fRunTag]]" x="0.25" y="0.82"/>
-    <label value="Run starts : [[startTime]]" x="0.25" y="0.74"/>
-    <label value="Run ends : [[endTime]]" x="0.25" y="0.66"/>
-    <label value="Entries : [[entries]]" x="0.25" y="0.58"/>
-    <label value="Run duration : [[runLength]] hours" x="0.25" y="0.50"/>
-    <label value="Mean rate : [[meanRate]] Hz" x="0.25" y="0.42"/>
 
-    <label value="Detector pressure : [TRestDetector::fPressure] bar" x="0.25" y="0.30"/>
-    <label value="Mesh voltage : [TRestDetector::fAmplificationVoltage] V" x="0.25" y="0.22"/>
-    <label value="Drift voltage : [TRestDetector::fDriftField] V/cm/bar" x="0.25" y="0.14"/>
-    <label value="Electronics gain : [TRestDetector::fElectronicsGain]" x="0.25" y="0.06"/>
+<panel font_size="0.06">
+	<label value="Run number : <<TRestRun::fRunNumber>>" x="0.25" y="0.9" />
+	<label value="Run tag : <<TRestRun::fRunTag>>" x="0.25" y="0.82" />
+	<label value="Run starts : <<startTime>>" x="0.25" y="0.74" />
+	<label value="Run ends : <<endTime>>" x="0.25" y="0.66" />
+	<label value="Entries : <<entries>>" x="0.25" y="0.58" />
+	<label value="Run duration : <<runLength>> hours" x="0.25" y="0.50" />
+	<label value="Mean rate : <<meanRate>> Hz" x="0.25" y="0.42" />
+
+	<label value="Detector pressure : [TRestDetector::fPressure] bar" x="0.25" y="0.30" />
+	<label value="Mesh voltage : [TRestDetector::fAmplificationVoltage] V" x="0.25" y="0.22" />
+	<label value="Drift voltage : [TRestDetector::fDriftField] V/cm/bar" x="0.25" y="0.14" />
+	<label value="Electronics gain : [TRestDetector::fElectronicsGain]" x="0.25" y="0.06" />
 </panel>

--- a/source/framework/core/inc/TRestAnalysisPlot.h
+++ b/source/framework/core/inc/TRestAnalysisPlot.h
@@ -12,11 +12,11 @@
 #ifndef RestCore_TRestAnalysisPlot
 #define RestCore_TRestAnalysisPlot
 
-#include <TCanvas.h>
-#include <TH3D.h>
 #include <TLatex.h>
 #include <TRestRun.h>
 
+#include "TCanvas.h"
+#include "TH3D.h"
 #include "TRestAnalysisTree.h"
 
 const int REST_MAX_TAGS = 15;
@@ -64,7 +64,7 @@ class TRestAnalysisPlot : public TRestMetadata {
         Int_t fillStyle;
 
         TH3F* ptr = nullptr;  //!
-        TH3F* operator->() const { return ptr; }
+        TH3F* operator->() { return ptr; }
     };
 
     struct PlotInfoSet {
@@ -156,12 +156,12 @@ class TRestAnalysisPlot : public TRestMetadata {
     void AddFileFromExternalRun();
     void AddFileFromEnv();
 
-    TRestAnalysisTree* GetTree(const TString& fileName);
-    TRestRun* GetRunInfo(const TString& fileName);
-    bool IsDynamicRange(const TString& rangeString);
-    Int_t GetColorIDFromString(const std::string& in);
-    Int_t GetFillStyleIDFromString(const std::string& in);
-    Int_t GetLineStyleIDFromString(const std::string& in);
+    TRestAnalysisTree* GetTree(TString fileName);
+    TRestRun* GetRunInfo(TString fileName);
+    bool IsDynamicRange(TString rangeString);
+    Int_t GetColorIDFromString(std::string in);
+    Int_t GetFillStyleIDFromString(std::string in);
+    Int_t GetLineStyleIDFromString(std::string in);
 
    protected:
    public:
@@ -169,16 +169,16 @@ class TRestAnalysisPlot : public TRestMetadata {
 
     void PrintMetadata() override {}
 
-    void AddFile(const TString& fileName);
-    void SetFile(const TString& fileName);
+    void AddFile(TString fileName);
+    void SetFile(TString fileName);
 
-    void SaveCanvasToPDF(const TString& fileName);
-    void SavePlotToPDF(const TString& fileName, Int_t n = 0);
-    void SaveHistoToPDF(const TString& fileName, Int_t nPlot = 0, Int_t nHisto = 0);
+    void SaveCanvasToPDF(TString fileName);
+    void SavePlotToPDF(TString fileName, Int_t n = 0);
+    void SaveHistoToPDF(TString fileName, Int_t nPlot = 0, Int_t nHisto = 0);
 
-    void SetOutputPlotsFilename(const TString& name) { fCanvasSave = name; }
+    void SetOutputPlotsFilename(TString fname) { fCanvasSave = fname; }
 
-    Int_t GetPlotIndex(const TString& plotName);
+    Int_t GetPlotIndex(TString plotName);
     inline TVector2 GetCanvasSize() const { return fCanvasSize; }
     inline TVector2 GetCanvasDivisions() const { return fCanvasDivisions; }
 

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -1653,7 +1653,7 @@ string TRestRun::ReplaceMetadataMembers(const string& instr, Int_t precision) {
 
         if (cont < 0) RESTError << "This is a coding error at ReplaceMetadataMembers!" << RESTendl;
 
-        // We search for the enclosing ']'. Since we might find a vector index inside.
+        // We search for the enclosing ]. Since we might find a vector index inside.
         while (cont > 0) {
             endPosition = outstring.find("]", endPosition + 1);
             s = outstring.substr(startPosition + 1, endPosition - startPosition - 1);
@@ -1669,8 +1669,8 @@ string TRestRun::ReplaceMetadataMembers(const string& instr, Int_t precision) {
         endPosition = 0;
     }
 
-    outstring = Replace(outstring, "[[", "[");
-    outstring = Replace(outstring, "]]", "]");
+    outstring = Replace(outstring, "<<", "[");
+    outstring = Replace(outstring, ">>", "]");
 
     return REST_StringHelper::ReplaceMathematicalExpressions(outstring, precision);
 }
@@ -1693,7 +1693,7 @@ string TRestRun::ReplaceMetadataMembers(const string& instr, Int_t precision) {
 ///
 string TRestRun::ReplaceMetadataMember(const string& instr, Int_t precision) {
     if (instr.find("::") == string::npos && instr.find("->") == string::npos) {
-        return "[[" + instr + "]]";
+        return "<<" + instr + ">>";
     }
     vector<string> results = Split(instr, "::", false, true);
     if (results.size() == 1) results = Split(instr, "->", false, true);


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 81](https://badgen.net/badge/PR%20Size/Ok%3A%2081/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/revert-362-lobis-xml/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/revert-362-lobis-xml) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=revert-362-lobis-xml)](https://github.com/rest-for-physics/framework/commits/revert-362-lobis-xml)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Reverts rest-for-physics/framework#362

This PR broke the rawlib pipeline as we can see at the following PR. 

https://github.com/rest-for-physics/rawlib/pull/95

@juanangp it would be easy to introduce key validation pipelines into the framework pipeline?