### PR TITLE
Update pre-commit check script to work for auto-updates

### DIFF
--- a/scripts/validatePreCommitConfig.py
+++ b/scripts/validatePreCommitConfig.py
@@ -1,12 +1,11 @@
 # This script should be run from the root of a submodule repository.
 # It will check that the pre-commit config file matches the one in the framework repository (master branch).
-# TODO: if a branch with the same name as the current branch exists in the framework repository, use that instead of master.
 # It will also check other files related to the pre-commit such as .clang-format and .cmake-format.yaml.
 
 import os
 
 
-def check_files(base_directory, file_name) -> bool:
+def check_files(base_directory, file_name, branch) -> bool:
     # Check that the pre-commit config file is the same as the one in the framework repository.
     # If not, print a warning and exit with a non-zero exit code.
     # base_directory: the directory where the file is located.
@@ -14,9 +13,8 @@ def check_files(base_directory, file_name) -> bool:
     # Returns: True if the files are the same, False otherwise.
     # Note: this function will exit the script if the files are not the same.
 
-    branch_name = "master"
     github_prefix = (
-        f"https://raw.githubusercontent.com/rest-for-physics/framework/{branch_name}/"
+        f"https://raw.githubusercontent.com/rest-for-physics/framework/{branch}/"
     )
 
     with open(os.path.join(base_directory, file_name), "r") as f:
@@ -36,9 +34,35 @@ if __name__ == "__main__":
     # check pre-commit config file
     files = [".pre-commit-config.yaml", ".clang-format", ".cmake-format.yaml"]
 
+    # if the cwd is a git repository, get the branch name
+    branch_name = "master"
+    if os.path.exists(".git"):
+        this_branch_name = os.popen("git rev-parse --abbrev-ref HEAD").read().strip()
+        # Check this branch name also exists in framework
+        if (
+            len(
+                os.popen(
+                    f"git ls-remote --heads https://github.com/rest-for-physics/framework.git {this_branch_name}"
+                )
+                .read()
+                .strip()
+            )
+            != 0
+        ):
+            branch_name = this_branch_name
+        else:
+            print(
+                f"WARNING: The branch '{this_branch_name}' does not exist in the framework repository."
+            )
+
+    print(f"Comparing files with branch={branch_name} in the framework repository.")
+
     status = True  # OK
     for file in files:
-        status = check_files(base_directory=".", file_name=file) and status
+        status = (
+            check_files(base_directory=".", file_name=file, branch=branch_name)
+            and status
+        )
 
     if not status:
         exit(1)  # ERROR


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 29](https://badgen.net/badge/PR%20Size/Ok%3A%2029/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/lobis-pre-commit-script/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/lobis-pre-commit-script) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=lobis-pre-commit-script)](https://github.com/rest-for-physics/framework/commits/lobis-pre-commit-script)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now the script will compare files to the branch with the same name as the current working directory branch name in framework if it exists, otherwise it will just use master as before.

This will prevent PR such as https://github.com/rest-for-physics/axionlib/pull/50 to begin as failing.

This PR was triggered by https://github.com/rest-for-physics/framework/pull/375