### PR TITLE
Addressing bug in pull-submodules

### DIFF
--- a/pull-submodules.py
+++ b/pull-submodules.py
@@ -233,7 +233,7 @@ Are you sure to proceed? (y/n)
     if force:
         print("Forcing reset: ", end="")
         p = subprocess.run(
-            f"git submodule foreach --recursive 'git reset --hard'",  #
+            f"git submodule foreach --recursive 'git reset --hard || true'",  #
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -259,7 +259,7 @@ Are you sure to proceed? (y/n)
     if latest:
         print("Pulling submodules: ", end="")
         p = subprocess.run(
-            f"git submodule foreach  --recursive 'git fetch; if [ -z \"$(git ls-remote --heads origin {frameworkBranchName})\" ]; then git checkout master; else git checkout {frameworkBranchName};fi;git pull'",  #
+            f"git submodule foreach  --recursive 'git fetch; if [ -z \"$(git ls-remote --heads origin {frameworkBranchName})\" ]; then git checkout master; else git checkout {frameworkBranchName};fi;git pull || true'",  #
             shell=True,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
@@ -282,7 +282,7 @@ Are you sure to proceed? (y/n)
             print("[\033[92m OK \x1b[0m]")
     # get commit id
     p = subprocess.run(
-        f"git submodule foreach  --recursive 'git rev-parse HEAD'",  #
+        f"git submodule foreach  --recursive 'git rev-parse HEAD || true'",  #
         shell=True,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 3](https://badgen.net/badge/PR%20Size/Ok%3A%203/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/pull-submodules-bug/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/pull-submodules-bug) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=pull-submodules-bug)](https://github.com/rest-for-physics/framework/commits/pull-submodules-bug)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I noticed that some submodules were not properly updated in case some submodule failed to pull or checkout the corresponding branch. This typically happens when one submodule has unstaged changes.

The issue is fixed after appending `|| true` after `git submodule foreach` command.

However, note that the faulty submodule will remain in a bad state unless the changes are staged or removed (e.g. using --force), which I think it was the previous behaviour.