### PR TITLE
Adding possibility to add a cut on observable parameters in TRestDataSet

### DIFF
--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -76,11 +76,14 @@ class TRestDataSet : public TRestMetadata {
     /// The properties of a relevant quantity that we want to store together with the dataset
     std::map<std::string, RelevantQuantity> fQuantity;  //<
 
+    /// Parameter cuts over the selected dataset
+    std::vector<std::pair<std::string, std::string> > fParamCut;
+
     /// The total integrated run time of selected files
     Double_t fTotalDuration = 0;  //<
 
-    /// The resulting RDataFrame object after initialization
-    ROOT::RDataFrame fDataSet = 0;  //!
+    /// The resulting RDF::RNode object after initialization
+    ROOT::RDF::RNode fDataSet = ROOT::RDataFrame(0);  //!
 
     /// A pointer to the generated tree
     TTree* fTree = nullptr;  //!
@@ -95,7 +98,7 @@ class TRestDataSet : public TRestMetadata {
 
    public:
     /// Gives access to the RDataFrame
-    ROOT::RDataFrame GetDataFrame() const {
+    ROOT::RDF::RNode GetDataFrame() const {
         if (fTree == nullptr) RESTWarning << "DataFrame has not been yet initialized" << RESTendl;
         return fDataSet;
     }

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -270,7 +270,7 @@ void TRestDataSet::Initialize() {
     if (fFileSelection.empty()) return;
 
     ///// Disentangling process observables --> producing finalList
-    TRestRun run(fFileSelection[0]);
+    TRestRun run(fFileSelection.front());
     std::vector<std::string> finalList;
     finalList.push_back("runOrigin");
     finalList.push_back("eventID");
@@ -310,7 +310,7 @@ void TRestDataSet::Initialize() {
 
     std::string user = getenv("USER");
     std::string fOutName = "/tmp/rest_output_" + user + ".root";
-    fDataSet.Snapshot("AnalysisTree", fOutName, finalList);
+    fDataSet.Snapshot("AnalysisTree", fOutName);
 
     fDataSet = ROOT::RDataFrame("AnalysisTree", fOutName);
 

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -288,7 +288,7 @@ void TRestDataSet::Initialize() {
 
     ROOT::EnableImplicitMT();
 
-    ROOT::RDataFrame df("AnalysisTree", fFileSelection, finalList);
+    ROOT::RDataFrame df("AnalysisTree", fFileSelection);
 
     std::string pCut ="";
       for(const auto& [param, cut] : fParamCut){
@@ -310,9 +310,10 @@ void TRestDataSet::Initialize() {
 
     std::string user = getenv("USER");
     std::string fOutName = "/tmp/rest_output_" + user + ".root";
-    fDataSet.Snapshot("AnalysisTree", fOutName);
+    fDataSet.Snapshot("AnalysisTree", fOutName, finalList);
 
     fDataSet = ROOT::RDataFrame("AnalysisTree", fOutName);
+
 
     TFile* f = TFile::Open(fOutName.c_str());
     fTree = (TTree*)f->Get("AnalysisTree");


### PR DESCRIPTION
Adding possibility to add a cut on observable parameters in TRestDataSet by the use of the "Filter function". Note that now the data type of ´fDataSet´ has been chaged from `ROOT::RDataFrame` to `ROOT::RDF::RNode`. However, it seems that `ROOT::RDataFrame` and `ROOT::RDF::RNode` are handled in a similar way, so it shouldn't affect any underlying code.

Contributes to https://github.com/rest-for-physics/framework/issues/346
