### PR TITLE
TRestAnalysisTree::GetIntegral method added

### DIFF
--- a/source/framework/core/inc/TRestAnalysisTree.h
+++ b/source/framework/core/inc/TRestAnalysisTree.h
@@ -279,6 +279,29 @@ class TRestAnalysisTree : public TTree {
     void EnableQuickObservableValueSetting();
     void DisableQuickObservableValueSetting();
 
+    Double_t GetIntegral(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1,
+                         Int_t nBins = 1000) {
+        GetObservableIntegral(obsName, xLow, xHigh, nBins);
+    }
+
+    Double_t GetAverage(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1, Int_t nBins = 1000) {
+        GetObservableAverage(obsName, xLow, xHigh, nBins);
+    }
+
+    Double_t GetRMS(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1, Int_t nBins = 1000) {
+        GetObservableRMS(obsName, xLow, xHigh, nBins);
+    }
+
+    Double_t GetMinimum(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1, Int_t nBins = 1000) {
+        GetObservableMinimum(obsName, xLow, xHigh, nBins);
+    }
+    Double_t GetMaximum(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1, Int_t nBins = 1000) {
+        GetObservableMaximum(obsName, xLow, xHigh, nBins);
+    }
+
+    Double_t GetObservableIntegral(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1,
+                                   Int_t nBins = 1000);
+
     Double_t GetObservableAverage(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1,
                                   Int_t nBins = 1000);
 

--- a/source/framework/core/src/TRestAnalysisTree.cxx
+++ b/source/framework/core/src/TRestAnalysisTree.cxx
@@ -960,6 +960,21 @@ void TRestAnalysisTree::EnableQuickObservableValueSetting() { this->fQuickSetObs
 void TRestAnalysisTree::DisableQuickObservableValueSetting() { this->fQuickSetObservableValue = false; }
 
 ///////////////////////////////////////////////
+/// \brief It returns the integral of the observable considering the given range. If no range is given
+/// the full histogram range will be considered.
+///
+Double_t TRestAnalysisTree::GetObservableIntegral(const TString& obsName, Double_t xLow, Double_t xHigh,
+                                                  Int_t nBins) {
+    TString histDefinition = Form("htemp(%5d,%lf,%lf)", nBins, xLow, xHigh);
+    if (xHigh == -1)
+        this->Draw(obsName);
+    else
+        this->Draw(obsName + ">>" + histDefinition);
+    TH1F* htemp = (TH1F*)gPad->GetPrimitive("htemp");
+    return htemp->Integral();
+}
+
+///////////////////////////////////////////////
 /// \brief It returns the average of the observable considering the given range. If no range is given
 /// the full histogram range will be considered.
 ///


### PR DESCRIPTION
- Added a method `TRestAnalysisTree::GetObservableIntegral`.
- Adding methods `TRestAnalysisTree::GetMax,Min,Average` that invoke the corresponding `GetObservableMax,Min,Average`.