### PR TITLE
Implementing TRestCut inside TRestDataSet

### DIFF
--- a/source/framework/core/inc/TRestCut.h
+++ b/source/framework/core/inc/TRestCut.h
@@ -36,7 +36,7 @@ class TRestCut : public TRestMetadata {
     // Vector of cut strings e.g. when you use a complex cut
     std::vector<std::string> fCutStrings;
 
-    // Vector of parameter cat, first item is parameter and second is the condition
+    // Vector of parameter cuts, first item is parameter and second is the condition
     std::vector<std::pair<std::string, std::string> > fParamCut;
 
    protected:

--- a/source/framework/core/inc/TRestCut.h
+++ b/source/framework/core/inc/TRestCut.h
@@ -47,8 +47,8 @@ class TRestCut : public TRestMetadata {
     void AddCut(TCut cut);
     TCut GetCut(std::string name);
 
-    auto GetCutStrings() const {return fCutStrings;}
-    auto GetParamCut() const {return fParamCut;}
+    auto GetCutStrings() const { return fCutStrings; }
+    auto GetParamCut() const { return fParamCut; }
 
     void PrintMetadata() override;
 

--- a/source/framework/core/inc/TRestCut.h
+++ b/source/framework/core/inc/TRestCut.h
@@ -30,7 +30,14 @@
 //! A class to help on cuts definitions. To be used with TRestAnalysisTree
 class TRestCut : public TRestMetadata {
    private:
+    // Vector of TCuts
     std::vector<TCut> fCuts;
+
+    // Vector of cut strings e.g. when you use a complex cut
+    std::vector<std::string> fCutStrings;
+
+    // Vector of parameter cat, first item is parameter and second is the condition
+    std::vector<std::pair<std::string, std::string> > fParamCut;
 
    protected:
     void Initialize() override;
@@ -39,6 +46,9 @@ class TRestCut : public TRestMetadata {
    public:
     void AddCut(TCut cut);
     TCut GetCut(std::string name);
+
+    auto GetCutStrings() const {return fCutStrings;}
+    auto GetParamCut() const {return fParamCut;}
 
     void PrintMetadata() override;
 
@@ -49,7 +59,7 @@ class TRestCut : public TRestMetadata {
     // Destructor
     ~TRestCut() {}
 
-    ClassDefOverride(TRestCut, 1);  // Template for a REST "event process" class inherited from
+    ClassDefOverride(TRestCut, 2);  // Template for a REST "event process" class inherited from
                                     // TRestEventProcess
 };
 #endif

--- a/source/framework/core/inc/TRestCut.h
+++ b/source/framework/core/inc/TRestCut.h
@@ -47,8 +47,11 @@ class TRestCut : public TRestMetadata {
     void AddCut(TCut cut);
     TCut GetCut(std::string name);
 
-    auto GetCutStrings() const { return fCutStrings; }
-    auto GetParamCut() const { return fParamCut; }
+    inline auto GetCutStrings() const {return fCutStrings;}
+    inline auto GetParamCut() const {return fParamCut;}
+    inline auto GetCuts() const {return fCuts;}
+
+    TRestCut& operator=(TRestCut& cut);
 
     void PrintMetadata() override;
 

--- a/source/framework/core/inc/TRestCut.h
+++ b/source/framework/core/inc/TRestCut.h
@@ -47,9 +47,9 @@ class TRestCut : public TRestMetadata {
     void AddCut(TCut cut);
     TCut GetCut(std::string name);
 
-    inline auto GetCutStrings() const {return fCutStrings;}
-    inline auto GetParamCut() const {return fParamCut;}
-    inline auto GetCuts() const {return fCuts;}
+    inline auto GetCutStrings() const { return fCutStrings; }
+    inline auto GetParamCut() const { return fParamCut; }
+    inline auto GetCuts() const { return fCuts; }
 
     TRestCut& operator=(TRestCut& cut);
 

--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -28,6 +28,7 @@
 #include <ROOT/RDataFrame.hxx>
 
 #include "TRestMetadata.h"
+#include "TRestCut.h"
 
 struct RelevantQuantity {
     /// The associated metadata member used to register the relevant quantity
@@ -77,7 +78,7 @@ class TRestDataSet : public TRestMetadata {
     std::map<std::string, RelevantQuantity> fQuantity;  //<
 
     /// Parameter cuts over the selected dataset
-    std::vector<std::pair<std::string, std::string> > fParamCut;
+    TRestCut *fCut = nullptr;
 
     /// The total integrated run time of selected files
     Double_t fTotalDuration = 0;  //<

--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -27,8 +27,8 @@
 
 #include <ROOT/RDataFrame.hxx>
 
-#include "TRestMetadata.h"
 #include "TRestCut.h"
+#include "TRestMetadata.h"
 
 struct RelevantQuantity {
     /// The associated metadata member used to register the relevant quantity
@@ -78,7 +78,7 @@ class TRestDataSet : public TRestMetadata {
     std::map<std::string, RelevantQuantity> fQuantity;  //<
 
     /// Parameter cuts over the selected dataset
-    TRestCut *fCut = nullptr;
+    TRestCut* fCut = nullptr;
 
     /// The total integrated run time of selected files
     Double_t fTotalDuration = 0;  //<

--- a/source/framework/core/src/TRestCut.cxx
+++ b/source/framework/core/src/TRestCut.cxx
@@ -26,6 +26,7 @@
 /// <TRestCut/>
 ///   <cut name="cc1" value="XX>10 AND XX<90"/>
 ///   <cut name="cc2" value="sAna_ThresholdIntegral<100e3"/>
+///   <cut name="cc3" variable="sAna_ThresholdIntegral" condition=">0">
 /// </TRestCut>
 ///
 /// Note that the notations " AND " and " OR " will be replaced by " && " and " || "
@@ -44,6 +45,9 @@
 /// 2021-dec: First concept.
 ///           Ni Kaixiang
 ///
+/// 2023-March: 
+///
+/// 
 /// \class TRestCut
 ///
 /// <hr>
@@ -67,11 +71,33 @@ void TRestCut::Initialize() { fCuts.clear(); }
 void TRestCut::InitFromConfigFile() {
     auto ele = GetElement("cut");
     while (ele != nullptr) {
+
         string name = GetParameter("name", ele, "");
+          if (name.empty() || name == "Not defined") {
+            RESTError << "< cut does not contain a name!" << RESTendl;
+            exit(1);
+          }
+
         string cutStr = GetParameter("value", ele, "");
-        cutStr = Replace(cutStr, " AND ", " && ");
-        cutStr = Replace(cutStr, " OR ", " || ");
-        AddCut(TCut(name.c_str(), cutStr.c_str()));
+        string variable = GetParameter("variable", ele, "");
+        string condition = GetParameter("condition", ele, "");
+
+        if(!cutStr.empty()){
+          cutStr = Replace(cutStr, " AND ", " && ");
+          cutStr = Replace(cutStr, " OR ", " || ");
+          fCutStrings.push_back(cutStr);
+          AddCut(TCut(name.c_str(), cutStr.c_str()));
+        } else if (!variable.empty() && !condition.empty()){
+           fParamCut.push_back(std::make_pair(variable, condition));
+           string cutVar = variable + condition;
+           AddCut(TCut(name.c_str(), cutVar.c_str()));
+        } else {
+          RESTError << "TRestCut does not contain a valid parameter/condition or cut string!" << RESTendl;
+          RESTError << "<cut name='cc1' value='XX>10 AND XX<90'/>" << RESTendl;
+          RESTError << "<cut name='cc3' variable='sAna_ThresholdIntegral' condition='>0'" << RESTendl;
+          exit(1);
+        }
+
         ele = GetNextElement(ele);
     }
 }
@@ -105,8 +131,10 @@ TCut TRestCut::GetCut(string name) {
 void TRestCut::PrintMetadata() {
     TRestMetadata::PrintMetadata();
     RESTMetadata << " " << RESTendl;
-    RESTMetadata << "Number of TCut objects added: " << fCuts.size() << RESTendl;
-    RESTMetadata << " " << RESTendl;
+    RESTMetadata << "Cuts added: " << RESTendl;
+      for(const auto& cut : fCuts){
+         RESTMetadata << cut.GetName() << " " << cut.GetTitle() << RESTendl;
+      }
     RESTMetadata << "+++" << RESTendl;
 }
 

--- a/source/framework/core/src/TRestCut.cxx
+++ b/source/framework/core/src/TRestCut.cxx
@@ -102,12 +102,12 @@ void TRestCut::InitFromConfigFile() {
 }
 
 TRestCut& TRestCut::operator=(TRestCut& cut) {
-   SetName(cut.GetName());
-   SetTitle(cut.GetTitle());
-   fCuts = cut.GetCuts();
-   fCutStrings = cut.GetCutStrings();
-   fParamCut = cut. GetParamCut();
-   return *this;
+    SetName(cut.GetName());
+    SetTitle(cut.GetTitle());
+    fCuts = cut.GetCuts();
+    fCutStrings = cut.GetCutStrings();
+    fParamCut = cut.GetParamCut();
+    return *this;
 }
 
 void TRestCut::AddCut(TCut cut) {

--- a/source/framework/core/src/TRestCut.cxx
+++ b/source/framework/core/src/TRestCut.cxx
@@ -45,9 +45,9 @@
 /// 2021-dec: First concept.
 ///           Ni Kaixiang
 ///
-/// 2023-March: 
+/// 2023-March:
 ///
-/// 
+///
 /// \class TRestCut
 ///
 /// <hr>
@@ -71,31 +71,30 @@ void TRestCut::Initialize() { fCuts.clear(); }
 void TRestCut::InitFromConfigFile() {
     auto ele = GetElement("cut");
     while (ele != nullptr) {
-
         string name = GetParameter("name", ele, "");
-          if (name.empty() || name == "Not defined") {
+        if (name.empty() || name == "Not defined") {
             RESTError << "< cut does not contain a name!" << RESTendl;
             exit(1);
-          }
+        }
 
         string cutStr = GetParameter("value", ele, "");
         string variable = GetParameter("variable", ele, "");
         string condition = GetParameter("condition", ele, "");
 
-        if(!cutStr.empty()){
-          cutStr = Replace(cutStr, " AND ", " && ");
-          cutStr = Replace(cutStr, " OR ", " || ");
-          fCutStrings.push_back(cutStr);
-          AddCut(TCut(name.c_str(), cutStr.c_str()));
-        } else if (!variable.empty() && !condition.empty()){
-           fParamCut.push_back(std::make_pair(variable, condition));
-           string cutVar = variable + condition;
-           AddCut(TCut(name.c_str(), cutVar.c_str()));
+        if (!cutStr.empty()) {
+            cutStr = Replace(cutStr, " AND ", " && ");
+            cutStr = Replace(cutStr, " OR ", " || ");
+            fCutStrings.push_back(cutStr);
+            AddCut(TCut(name.c_str(), cutStr.c_str()));
+        } else if (!variable.empty() && !condition.empty()) {
+            fParamCut.push_back(std::make_pair(variable, condition));
+            string cutVar = variable + condition;
+            AddCut(TCut(name.c_str(), cutVar.c_str()));
         } else {
-          RESTError << "TRestCut does not contain a valid parameter/condition or cut string!" << RESTendl;
-          RESTError << "<cut name='cc1' value='XX>10 AND XX<90'/>" << RESTendl;
-          RESTError << "<cut name='cc3' variable='sAna_ThresholdIntegral' condition='>0'" << RESTendl;
-          exit(1);
+            RESTError << "TRestCut does not contain a valid parameter/condition or cut string!" << RESTendl;
+            RESTError << "<cut name='cc1' value='XX>10 AND XX<90'/>" << RESTendl;
+            RESTError << "<cut name='cc3' variable='sAna_ThresholdIntegral' condition='>0'" << RESTendl;
+            exit(1);
         }
 
         ele = GetNextElement(ele);
@@ -132,9 +131,9 @@ void TRestCut::PrintMetadata() {
     TRestMetadata::PrintMetadata();
     RESTMetadata << " " << RESTendl;
     RESTMetadata << "Cuts added: " << RESTendl;
-      for(const auto& cut : fCuts){
-         RESTMetadata << cut.GetName() << " " << cut.GetTitle() << RESTendl;
-      }
+    for (const auto& cut : fCuts) {
+        RESTMetadata << cut.GetName() << " " << cut.GetTitle() << RESTendl;
+    }
     RESTMetadata << "+++" << RESTendl;
 }
 

--- a/source/framework/core/src/TRestCut.cxx
+++ b/source/framework/core/src/TRestCut.cxx
@@ -101,6 +101,15 @@ void TRestCut::InitFromConfigFile() {
     }
 }
 
+TRestCut& TRestCut::operator=(TRestCut& cut) {
+   SetName(cut.GetName());
+   SetTitle(cut.GetTitle());
+   fCuts = cut.GetCuts();
+   fCutStrings = cut.GetCutStrings();
+   fParamCut = cut. GetParamCut();
+   return *this;
+}
+
 void TRestCut::AddCut(TCut cut) {
     if ((string)cut.GetName() == "") {
         RESTWarning << "TRestCut::AddCut: cannot add cut without name!" << RESTendl;

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -292,35 +292,37 @@ void TRestDataSet::Initialize() {
     ROOT::RDataFrame df("AnalysisTree", fFileSelection);
     fDataSet = df;
 
-    if(fCut) {
-      auto paramCut = fCut->GetParamCut();
-        for(const auto& [param, condition] : paramCut){
-          if(std::find(finalList.begin(), finalList.end(), param) != finalList.end()){
-            std::string pCut =param + condition;
-            RESTDebug << "Applying cut " << pCut << RESTendl;
-            fDataSet = fDataSet.Filter(pCut);
-          } else {
-            RESTWarning << " Cut observable " << param << " not found in observable list, skipping..." << RESTendl;
-          }
-        }
-
-      auto cutString = fCut->GetCutStrings();
-        for(const auto& pCut : cutString){
-          bool added = false;
-          for (const auto& obs : finalList) {
-            if(pCut.find(obs) != std::string::npos){
-              RESTDebug << "Applying cut " << pCut << RESTendl;
-              fDataSet = fDataSet.Filter(pCut);
-              added = true;
-              break;
+    if (fCut) {
+        auto paramCut = fCut->GetParamCut();
+        for (const auto& [param, condition] : paramCut) {
+            if (std::find(finalList.begin(), finalList.end(), param) != finalList.end()) {
+                std::string pCut = param + condition;
+                RESTDebug << "Applying cut " << pCut << RESTendl;
+                fDataSet = fDataSet.Filter(pCut);
+            } else {
+                RESTWarning << " Cut observable " << param << " not found in observable list, skipping..."
+                            << RESTendl;
             }
-          }
-
-          if(!added){
-            RESTWarning << " Cut string " << pCut << " not found in observable list, skipping..." << RESTendl;
-          }
         }
-     }
+
+        auto cutString = fCut->GetCutStrings();
+        for (const auto& pCut : cutString) {
+            bool added = false;
+            for (const auto& obs : finalList) {
+                if (pCut.find(obs) != std::string::npos) {
+                    RESTDebug << "Applying cut " << pCut << RESTendl;
+                    fDataSet = fDataSet.Filter(pCut);
+                    added = true;
+                    break;
+                }
+            }
+
+            if (!added) {
+                RESTWarning << " Cut string " << pCut << " not found in observable list, skipping..."
+                            << RESTendl;
+            }
+        }
+    }
 
     std::string user = getenv("USER");
     std::string fOutName = "/tmp/rest_output_" + user + ".root";
@@ -600,7 +602,6 @@ void TRestDataSet::InitFromConfigFile() {
     }
 
     fCut = (TRestCut*)InstantiateChildMetadata("TRestCut");
-
 }
 
 ///////////////////////////////////////////////

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -104,9 +104,10 @@
 ///    <observables list="g4Ana_totalEdep:hitsAna_energy" />
 ///
 ///    // Will apply a cut to the observables
-///    <cut variable="rawAna_NumberOfGoodSignals" condition=">10" />
-///    <cut variable="rawAna_NumberOfGoodSignals" condition="<100" />
-///
+///    <TRestCut>
+///      <cut name="c1" variable="rawAna_NumberOfGoodSignals" condition=">10" />
+///      <cut name="c1" variable="rawAna_NumberOfGoodSignals" condition="<100" />
+///    </TRestCut>
 ///    // Will add all the observables from the process `rawAna`
 ///    <processObservables list="rate:rawAna" />
 ///
@@ -289,24 +290,37 @@ void TRestDataSet::Initialize() {
     ROOT::EnableImplicitMT();
 
     ROOT::RDataFrame df("AnalysisTree", fFileSelection);
+    fDataSet = df;
 
-    std::string pCut = "";
-    for (const auto& [param, cut] : fParamCut) {
-        if (std::find(finalList.begin(), finalList.end(), param) != finalList.end()) {
-            if (!pCut.empty()) pCut += " && ";
-            pCut += param + cut;
-        } else {
-            RESTWarning << " Cut observable " << param << " not found in observable list, skipping..."
-                        << RESTendl;
+    if(fCut) {
+      auto paramCut = fCut->GetParamCut();
+        for(const auto& [param, condition] : paramCut){
+          if(std::find(finalList.begin(), finalList.end(), param) != finalList.end()){
+            std::string pCut =param + condition;
+            RESTDebug << "Applying cut " << pCut << RESTendl;
+            fDataSet = fDataSet.Filter(pCut);
+          } else {
+            RESTWarning << " Cut observable " << param << " not found in observable list, skipping..." << RESTendl;
+          }
         }
-    }
 
-    if (!pCut.empty()) {
-        RESTDebug << "Applying cut " << pCut << RESTendl;
-        fDataSet = df.Filter(pCut);
-    } else {
-        fDataSet = df;
-    }
+      auto cutString = fCut->GetCutStrings();
+        for(const auto& pCut : cutString){
+          bool added = false;
+          for (const auto& obs : finalList) {
+            if(pCut.find(obs) != std::string::npos){
+              RESTDebug << "Applying cut " << pCut << RESTendl;
+              fDataSet = fDataSet.Filter(pCut);
+              added = true;
+              break;
+            }
+          }
+
+          if(!added){
+            RESTWarning << " Cut string " << pCut << " not found in observable list, skipping..." << RESTendl;
+          }
+        }
+     }
 
     std::string user = getenv("USER");
     std::string fOutName = "/tmp/rest_output_" + user + ".root";
@@ -585,24 +599,8 @@ void TRestDataSet::InitFromConfigFile() {
         quantityDefinition = GetNextElement(quantityDefinition);
     }
 
-    TiXmlElement* cutDefinition = GetElement("cut");
-    while (cutDefinition != nullptr) {
-        std::string variable = GetFieldValue("variable", cutDefinition);
-        if (variable.empty() || variable == "Not defined") {
-            RESTError << "< paramCut variable key does not contain a name!" << RESTendl;
-            exit(1);
-        }
+    fCut = (TRestCut*)InstantiateChildMetadata("TRestCut");
 
-        std::string condition = GetFieldValue("condition", cutDefinition);
-        if (condition.empty() || condition == "Not defined") {
-            RESTError << "< paramCut condition key does not contain a metadata value!" << RESTendl;
-            exit(1);
-        }
-
-        fParamCut.push_back(std::make_pair(variable, condition));
-
-        cutDefinition = GetNextElement(cutDefinition);
-    }
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 92](https://badgen.net/badge/PR%20Size/Ok%3A%2092/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/trestcut/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/trestcut) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=trestcut)](https://github.com/rest-for-physics/framework/commits/trestcut)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`TRestCut` now is implemented inside `TRestDataSet` to avoid code duplication.

See https://github.com/rest-for-physics/framework/pull/386 for more details