### PR TITLE
clear-install-dir is performed before add-subdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -212,6 +212,16 @@ include(Testing)
 
 # Start compile
 include(MacroRootDict)
+
+# Clear the install dir
+if (NOT DEFINED INSTALL_CLEARDIR)
+    set(INSTALL_CLEARDIR ON)
+endif ()
+if (${INSTALL_CLEARDIR} MATCHES "ON")
+    install(CODE "execute_process(COMMAND rm -r ${CMAKE_INSTALL_PREFIX})")
+endif ()
+
+# Compile and install for each subdir
 add_subdirectory(source)
 
 message("")
@@ -235,14 +245,6 @@ message(
 message("")
 
 file(GLOB_RECURSE Headers "${CMAKE_CURRENT_SOURCE_DIR}/source/framework/*.h")
-
-# Clear the install dir
-if (NOT DEFINED INSTALL_CLEARDIR)
-    set(INSTALL_CLEARDIR ON)
-endif ()
-if (${INSTALL_CLEARDIR} MATCHES "ON")
-    install(CODE "execute_process(COMMAND rm -r ${CMAKE_INSTALL_PREFIX})")
-endif ()
 
 # Install the files of the main framework
 install(FILES ${Headers} DESTINATION include)


### PR DESCRIPTION
With the latest version of cmake I found the binary files are not appearing after installation. I found it is caused by clear-install-dir action which is executed now after subdir installation. So I move forward the lines for clearing the directory.