### PR TITLE
Adding uninstall target and proper handling of pcm files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,12 +213,23 @@ include(Testing)
 # Start compile
 include(MacroRootDict)
 
+# uninstall target
+if(NOT TARGET uninstall)
+  configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/cmake/cmake_uninstall.cmake.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake"
+    IMMEDIATE @ONLY)
+
+  add_custom_target(uninstall
+    COMMAND ${CMAKE_COMMAND} -P ${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake)
+endif()
+
 # Clear the install dir
 if (NOT DEFINED INSTALL_CLEARDIR)
     set(INSTALL_CLEARDIR ON)
 endif ()
 if (${INSTALL_CLEARDIR} MATCHES "ON")
-    install(CODE "execute_process(COMMAND rm -r ${CMAKE_INSTALL_PREFIX})")
+    install(CODE "execute_process(COMMAND \"${CMAKE_COMMAND}\" -P \"${CMAKE_CURRENT_BINARY_DIR}/cmake_uninstall.cmake\")" )
 endif ()
 
 # Compile and install for each subdir
@@ -287,30 +298,18 @@ if (CMAKE_SYSTEM_NAME MATCHES "Windows") # we must call library install here in
     endforeach ()
 
     # Copy pcm files to bin
-    install(
-        CODE "
-    file(GLOB PCMFiles \"\${CMAKE_CURRENT_SOURCE_DIR}/rootdict/*.pcm\")
-    file(COPY \${PCMFiles} DESTINATION \${CMAKE_INSTALL_PREFIX}/bin)
-    ")
+    file(GLOB PCMFILES "${CMAKE_BINARY_DIR}/rootdict/*.pcm")
+    install( FILES ${PCMFILES} DESTINATION bin COMPONENT install)
 
 else ()
     # Copy pcm files to lib
-    install(
-        CODE "
-    file(GLOB PCMFiles \"\${CMAKE_CURRENT_SOURCE_DIR}/rootdict/*.pcm\")
-    file(COPY \${PCMFiles} DESTINATION \${CMAKE_INSTALL_PREFIX}/lib)
-    ")
+    file(GLOB PCMFILES "${CMAKE_BINARY_DIR}/rootdict/*.pcm")
+    install( FILES ${PCMFILES} DESTINATION lib COMPONENT install)
 
     add_subdirectory(python-bindings)
 
     # Create thisREST.sh
     include(thisREST)
-
-    # Add permissions
-    install(
-        CODE "execute_process(COMMAND chmod 755 ${CMAKE_INSTALL_PREFIX}/bin/rest-config)"
-    )
-    install(CODE "execute_process(COMMAND chmod 755 ${CMAKE_INSTALL_PREFIX})")
 
 endif ()
 
@@ -333,10 +332,7 @@ if (CMAKE_SYSTEM_NAME MATCHES "Darwin") # we must call library install here in
     endforeach ()
 
     # Copy pcm files to bin
-    install(
-        CODE "
-    file(GLOB PCMFiles \"\${CMAKE_CURRENT_SOURCE_DIR}/rootdict/*.pcm\")
-    file(COPY \${PCMFiles} DESTINATION \${CMAKE_INSTALL_PREFIX}/bin)
-    ")
+    file(GLOB PCMFILES "${CMAKE_BINARY_DIR}/rootdict/*.pcm")
+    install( FILES ${PCMFILES} DESTINATION bin COMPONENT install)
 
 endif ()

--- a/cmake/cmake_uninstall.cmake.in
+++ b/cmake/cmake_uninstall.cmake.in
@@ -1,0 +1,23 @@
+if(NOT EXISTS "${CMAKE_BINARY_DIR}/install_manifest.txt")
+  message(WARNING "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
+  return()
+endif()
+
+file(READ "${CMAKE_BINARY_DIR}/install_manifest.txt" files)
+string(REGEX REPLACE "\n" ";" files "${files}")
+foreach(file ${files})
+  message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
+  if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    exec_program(
+      "${CMAKE_COMMAND}" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE rm_out
+      RETURN_VALUE rm_retval
+      )
+    if(NOT "${rm_retval}" STREQUAL 0)
+      message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
+    endif()
+  else(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
+    message(STATUS "File $ENV{DESTDIR}${file} does not exist.")
+  endif()
+endforeach()
+


### PR DESCRIPTION
Uninstall target has been added to cmake, following https://gitlab.kitware.com/cmake/community/-/wikis/FAQ#can-i-do-make-uninstall-with-cmake, to clean up install directories `make uninstall` can be used.

Moreover, different features have been added:
- Removal of installation files before install using `install_manifest`, same as `make uninstall` instead of removing entire `install` folder
- Proper handling of PCM files, which now are added to `install_manifest`, therefore can be clean up properly

Files left in the install directory after doing `make uninstall`: `rest-config`, `thisREST.sh` and `thisREST.csh`

Closes https://github.com/rest-for-physics/framework/issues/395