### PR TITLE
Automatic submodule update and PR

### DIFF
--- a/.github/actions/framework-pr-label/action.yml
+++ b/.github/actions/framework-pr-label/action.yml
@@ -1,0 +1,16 @@
+name: "Check if framework-pr label is present in a PR"
+
+runs:
+  using: 'composite'
+  steps:
+  -name: Framework-pr label is present
+   if: contains(github.event.pull_request.labels.*.name, 'framework-pr')
+   run: |
+     echo "This PR can only be merged from framework"
+     exit 1
+   shell: bash
+   -name: Framework-pr label is missing
+   if: !contains(github.event.pull_request.labels.*.name, 'framework-pr')
+   run: |
+     echo "This PR is able to be merged"
+   shell: bash

--- a/.github/actions/submodulePR/action.yml
+++ b/.github/actions/submodulePR/action.yml
@@ -1,7 +1,7 @@
 name: "Automatic PR on framework at submodule PR"
 inputs:
   branch:
-    description: "Branch to perform the PR"
+    description: "Target branch name"
     required: true
   submodule:
     description: "Relative path to the submodule"
@@ -13,11 +13,12 @@ inputs:
 runs:
   using: 'composite'
   steps:
-  - name: Checkout framework repository and branch
-    uses: rest-for-physics/framework/.github/actions/checkout@master
+  - name: Checkout framework repository
+    uses: actions/checkout@v3
     with:
-      branch: ${{ inputs.branch }}
+      token: ${{ inputs.github_token }}
       repository: rest-for-physics/framework
+      ref: master
       path: framework
   - name: Pull submodules
     run: |
@@ -31,7 +32,7 @@ runs:
       cd framework
       echo "ref=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
     shell: bash
-  - name: Commit changes
+  - name: Commit changes if branch exist
     if:  steps.frameworkBranch.outputs.ref == ${{ inputs.branch }}
     run: |
       cd framework
@@ -39,4 +40,38 @@ runs:
       git commit -am "Updating submodule ${{ inputs.submodule }}"
       git push
     shell: bash
-
+  - name: Commit changes to new branch
+    if:  steps.frameworkBranch.outputs.ref == "master"
+    run: |
+      cd framework
+      git submodule update --remote ${{ inputs.submodule }}
+      git checkout -b ${{ inputs.branch }}
+      git commit -am "Updating submodule ${{ inputs.submodule }}"
+      git push --set-upstream origin ${{ inputs.branch }}
+    shell: bash
+  - name: Checkout submodule
+    if:  steps.frameworkBranch.outputs.ref == "master"
+    uses: actions/checkout@v3
+    with:
+      ref: ${{ inputs.branch }}
+      path: submodule
+  - name: Check submodule PR
+    id: PRCheck
+    if:  steps.frameworkBranch.outputs.ref == "master"
+      run: |
+        cd submodule
+        #Check PR
+        gh auth status
+        gh pr view
+        prurl=$(gh pr view --json url -t '{{ .url }}')
+        echo "prurl=$prurl" >> $GITHUB_OUTPUT
+    env:
+      GITHUB_TOKEN: ${{ inputs.token }}
+    shell: bash
+  - name: Create PR
+    if:  steps.frameworkBranch.outputs.ref == "master"
+    run: |
+      gh pr create -B master -H ${{ inputs.branch }} --title 'Submodule Updates from ${{ inputs.submodule }} branch ${{ inputs.branch }}' --body 'Automatic PR from ${{ inputs.submodule }} branch ${{ inputs.branch }}, related PR ${{ steps.PRCheck.outputs.prurl }}'
+    env:
+      GITHUB_TOKEN: ${{ inputs.github_token }}
+    shell: bash

--- a/.github/actions/submodulePR/action.yml
+++ b/.github/actions/submodulePR/action.yml
@@ -57,7 +57,6 @@ runs:
       path: submodule
   - name: Check submodule PR
     id: PRCheck
-    if:  steps.frameworkBranch.outputs.ref == "master"
       run: |
         cd submodule
         #Check PR
@@ -65,6 +64,8 @@ runs:
         gh pr view
         prurl=$(gh pr view --json url -t '{{ .url }}')
         echo "prurl=$prurl" >> $GITHUB_OUTPUT
+        #Create label for further usage
+        gh label create framework-pr --description "This PR has to be merged from framework" --color E99695
     env:
       GITHUB_TOKEN: ${{ inputs.token }}
     shell: bash

--- a/.github/actions/submodulePR/action.yml
+++ b/.github/actions/submodulePR/action.yml
@@ -1,0 +1,42 @@
+name: "Automatic PR on framework at submodule PR"
+inputs:
+  branch:
+    description: "Branch to perform the PR"
+    required: true
+  submodule:
+    description: "Relative path to the submodule"
+    required: true
+  token:
+    description: "Authentification token"
+    required: true
+
+runs:
+  using: 'composite'
+  steps:
+  - name: Checkout framework repository and branch
+    uses: rest-for-physics/framework/.github/actions/checkout@master
+    with:
+      branch: ${{ inputs.branch }}
+      repository: rest-for-physics/framework
+      path: framework
+  - name: Pull submodules
+    run: |
+      cd framework
+      ./scripts/checkoutRemoteBranch.sh ${{ inputs.branch }}
+      python3 pull-submodules.py --force --dontask --latest:${{ inputs.branch }}
+    shell: bash
+  - name: Check if framework branch exist
+    id: frameworkBranch
+    run: |
+      cd framework
+      echo "ref=$(git rev-parse --abbrev-ref HEAD)" >> $GITHUB_OUTPUT
+    shell: bash
+  - name: Commit changes
+    if:  steps.frameworkBranch.outputs.ref == ${{ inputs.branch }}
+    run: |
+      cd framework
+      git submodule update --remote ${{ inputs.submodule }}
+      git commit -am "Updating submodule ${{ inputs.submodule }}"
+      git push
+    shell: bash
+

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -1,0 +1,101 @@
+name: "Automatic PR checks and merge"
+name: Check on submodules PR
+
+on:
+  pull_request:
+    branches: [ "master" ]
+    types: [ "opened", "reopened", "created", "closed", "synchronize"]
+
+  workflow_dispatch:
+
+#permissions: write-all
+
+env:
+  BRANCH_NAME: ${{ github.head_ref || github.ref_name }}
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  submodule-pr:
+    strategy:
+      matrix:
+        submodule: ["rest-for-physics/rawlib", "rest-for-physics/detectorlib", "rest-for-physics/geant4lib","rest-for-physics/tracklib", "rest-for-physics/connectorslib", "rest-for-physics/axionlib", "rest-for-physics/legacylib", , "rest-for-physics/wimplib", "rest-for-physics/restG4"]
+    runs-on: ubuntu-latest
+    if: github.head_ref || github.ref_name != 'master'
+    steps:
+      - name: Checkout submodule
+        uses: actions/checkout@v3
+        with:
+          repository: ${{  matrix.submodule }}
+          path: submodule
+      - name: Check submodule branch
+        id: submoduleBranch
+        run: |
+          cd submodule
+          var=$(git ls-remote --heads origin ${{ env.BRANCH_NAME }})
+          if [[ -z $var ]]; then
+            echo "Branch "${{ env.BRANCH_NAME }}" not found in " ${{ matrix.submodule }}
+            echo "exist=false" >> $GITHUB_OUTPUT
+          else
+            echo "Branch "${{ env.BRANCH_NAME }}" found in " ${{ matrix.submodule }}
+            git fetch
+            git checkout ${{ env.BRANCH_NAME }}
+            git pull
+            echo "exist=true" >> $GITHUB_OUTPUT
+          fi
+        shell: bash
+      - name: Check PR
+        id: PRCheck
+        if:  steps.submoduleBranch.outputs.exist == 'true'
+        run: |
+          cd submodule
+          #Check PR
+          gh auth status
+          gh pr view
+          prurl=$(gh pr view --json url -t '{{ .url }}')
+          echo "prurl=$prurl" >> $GITHUB_OUTPUT
+          mergeStateStatus=$(gh pr view --json mergeStateStatus -t '{{ .mergeStateStatus }}')
+          echo "MergeStateStatus " $mergeStateStatus
+          echo "mergeStateStatus=$mergeStateStatus" >> $GITHUB_OUTPUT
+          prState=$(gh pr view --json state -t '{{ .state }}')
+          echo "prState=$prState" >> $GITHUB_OUTPUT
+          echo "PullRequestState " $prState
+          review=$(gh pr view --json reviewDecision -t '{{ .reviewDecision }}')
+          echo "review=$review" >> $GITHUB_OUTPUT
+          echo "Review decision " $review
+          if [[ $prState == "MERGED" ]]; then
+            echo "PR already merged"
+          elif [[ $review == "APPROVED" ]]; then
+            echo "PR is approved and mergeStateStatus is " $mergeStateStatus
+          else
+            echo "No valid PR found for branch " ${{ env.BRANCH_NAME }} " in " ${{ matrix.submodule }}  " merge is not allowed"
+            exit 1
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.REST_TOKEN }}
+      - name: Print outputs
+        if:  steps.submoduleBranch.outputs.exist == 'true'
+        run: |
+          echo "Merge status " ${{ steps.PRCheck.outputs.mergeStateStatus }}
+          echo "PR REVIEW " ${{ steps.PRCheck.outputs.review }}
+          echo "PR url " ${{ steps.PRCheck.outputs.prurl }}
+          echo "PR state " ${{ steps.PRCheck.outputs.prState }}
+      - name: Remove label to allow merging of PR
+        if: (github.event.action == 'closed' && github.event.pull_request.merged == true && steps.PRCheck.outputs.review == 'APPROVED' && steps.PRCheck.outputs.prState != 'MERGED')
+        run: |
+          cd submodule
+          gh label delete framework-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.REST_TOKEN }}
+      - name: Merge PR
+        if: (github.event.action == 'closed' && github.event.pull_request.merged == true && steps.PRCheck.outputs.review == 'APPROVED' && steps.PRCheck.outputs.prState != 'MERGED')
+        run: |
+          cd submodule
+          gh auth status
+          echo "actor " ${{ github.actor }}
+          gh pr merge --auto --merge "$PR_URL"
+        env:
+          PR_URL: ${{ steps.PRCheck.outputs.prurl }}
+          GITHUB_TOKEN: ${{ secrets.REST_TOKEN }}


### PR DESCRIPTION
Automatic submodule update and automatic merge of `submodule` PR:

- Automatic update of `submodule` hash in `framework` which is triggered by a PR for the following submodules: https://github.com/rest-for-physics/rawlib, https://github.com/rest-for-physics/detectorlib, https://github.com/rest-for-physics/axionlib, https://github.com/rest-for-physics/geant4lib, https://github.com/rest-for-physics/connectorslib, https://github.com/rest-for-physics/wimplib, https://github.com/rest-for-physics/legacylib and https://github.com/rest-for-physics/restG4
- After the related  `framework` branch is created or updated, a related PR is created in `framework`.
- The corresponding `submodule` PR is labeled as `framework-pr` so the PR is blocked inside the `submodule` PR. Therefore, the `submodule` PR can be only merged from `framework` once the related `submodule` PR has been approved.
- Once the `framework` PR is merged the  `framework-pr` label at the `submodule` is removed and the related `submodule` branch can be merged.

Closes https://github.com/rest-for-physics/framework/issues/404