### PR TITLE
TRestAnalysisTree fixing observable estimators 

### DIFF
--- a/source/framework/core/inc/TRestAnalysisTree.h
+++ b/source/framework/core/inc/TRestAnalysisTree.h
@@ -279,25 +279,24 @@ class TRestAnalysisTree : public TTree {
     void EnableQuickObservableValueSetting();
     void DisableQuickObservableValueSetting();
 
-    Double_t GetIntegral(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1,
-                         Int_t nBins = 1000) {
-        return GetObservableIntegral(obsName, xLow, xHigh, nBins);
+    Double_t GetIntegral(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1) {
+        return GetObservableIntegral(obsName, xLow, xHigh);
     }
 
     Double_t GetAverage(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1) {
         return GetObservableAverage(obsName, xLow, xHigh);
     }
 
-    Double_t GetRMS(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1, Int_t nBins = 1000) {
-        return GetObservableRMS(obsName, xLow, xHigh, nBins);
+    Double_t GetRMS(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1) {
+        return GetObservableRMS(obsName, xLow, xHigh);
     }
 
-    Double_t GetMinimum(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1, Int_t nBins = 1000) {
-        return GetObservableMinimum(obsName, xLow, xHigh, nBins);
+    Double_t GetMinimum(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1) {
+        return GetObservableMinimum(obsName, xLow, xHigh);
     }
 
-    Double_t GetMaximum(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1, Int_t nBins = 1000) {
-        return GetObservableMaximum(obsName, xLow, xHigh, nBins);
+    Double_t GetMaximum(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1) {
+        return GetObservableMaximum(obsName, xLow, xHigh);
     }
 
     Double_t GetContour(const TString& obsName, const TString& obsIndexer, Double_t level = 0.5,
@@ -305,18 +304,14 @@ class TRestAnalysisTree : public TTree {
         return GetObservableContour(obsName, obsIndexer, level, nBins, xLow, xHigh);
     }
 
-    Double_t GetObservableIntegral(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1,
-                                   Int_t nBins = 1000);
+    Double_t GetObservableIntegral(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1);
 
     Double_t GetObservableAverage(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1);
 
-    Double_t GetObservableRMS(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1,
-                              Int_t nBins = 1000);
+    Double_t GetObservableRMS(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1);
 
-    Double_t GetObservableMinimum(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1,
-                                  Int_t nBins = 1000);
-    Double_t GetObservableMaximum(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1,
-                                  Int_t nBins = 1000);
+    Double_t GetObservableMinimum(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1);
+    Double_t GetObservableMaximum(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1);
 
     Double_t GetObservableContour(const TString& obsName, const TString& obsIndexer, Double_t level = 0.5,
                                   Int_t nBins = -1, Double_t xLow = -1, Double_t xHigh = -1);

--- a/source/framework/core/inc/TRestAnalysisTree.h
+++ b/source/framework/core/inc/TRestAnalysisTree.h
@@ -284,8 +284,8 @@ class TRestAnalysisTree : public TTree {
         return GetObservableIntegral(obsName, xLow, xHigh, nBins);
     }
 
-    Double_t GetAverage(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1, Int_t nBins = 1000) {
-        return GetObservableAverage(obsName, xLow, xHigh, nBins);
+    Double_t GetAverage(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1) {
+        return GetObservableAverage(obsName, xLow, xHigh);
     }
 
     Double_t GetRMS(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1, Int_t nBins = 1000) {
@@ -308,8 +308,7 @@ class TRestAnalysisTree : public TTree {
     Double_t GetObservableIntegral(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1,
                                    Int_t nBins = 1000);
 
-    Double_t GetObservableAverage(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1,
-                                  Int_t nBins = 1000);
+    Double_t GetObservableAverage(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1);
 
     Double_t GetObservableRMS(const TString& obsName, Double_t xLow = -1, Double_t xHigh = -1,
                               Int_t nBins = 1000);

--- a/source/framework/core/src/TRestAnalysisTree.cxx
+++ b/source/framework/core/src/TRestAnalysisTree.cxx
@@ -1008,13 +1008,16 @@ Double_t TRestAnalysisTree::GetObservableIntegral(const TString& obsName, Double
 ///
 Double_t TRestAnalysisTree::GetObservableAverage(const TString& obsName, Double_t xLow, Double_t xHigh,
                                                  Int_t nBins) {
-    TString histDefinition = Form("havg(%5d,%lf,%lf)", nBins, xLow, xHigh);
-    if (xHigh == -1)
-        this->Draw(obsName + ">>havg");
-    else
-        this->Draw(obsName + ">>" + histDefinition);
-    TH1F* htemp = (TH1F*)gPad->GetPrimitive("havg");
-    return htemp->GetMean();
+    Int_t id = GetObservableID((std::string)obsName);
+
+    Double_t sum = 0;
+    for (Int_t n = 0; n < TTree::GetEntries(); n++) {
+        TTree::GetEntry(n);
+        sum += GetDblObservableValue(id);
+    }
+    if (TTree::GetEntries() <= 0) return 0;
+
+    return sum / TTree::GetEntries();
 }
 
 ///////////////////////////////////////////////

--- a/source/framework/core/src/TRestAnalysisTree.cxx
+++ b/source/framework/core/src/TRestAnalysisTree.cxx
@@ -1006,18 +1006,23 @@ Double_t TRestAnalysisTree::GetObservableIntegral(const TString& obsName, Double
 /// \brief It returns the average of the observable considering the given range. If no range is given
 /// the full histogram range will be considered.
 ///
-Double_t TRestAnalysisTree::GetObservableAverage(const TString& obsName, Double_t xLow, Double_t xHigh,
-                                                 Int_t nBins) {
+Double_t TRestAnalysisTree::GetObservableAverage(const TString& obsName, Double_t xLow, Double_t xHigh) {
     Int_t id = GetObservableID((std::string)obsName);
 
     Double_t sum = 0;
+    Int_t N = 0;
     for (Int_t n = 0; n < TTree::GetEntries(); n++) {
         TTree::GetEntry(n);
+        Double_t value = GetDblObservableValue(id);
+
+        if (xLow != -1 && xHigh != -1 && (value < xLow || value > xHigh)) continue;
+        N++;
         sum += GetDblObservableValue(id);
     }
-    if (TTree::GetEntries() <= 0) return 0;
 
-    return sum / TTree::GetEntries();
+    if (N <= 0) return 0;
+
+    return sum / N;
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Medium: 115](https://badgen.net/badge/PR%20Size/Medium%3A%20115/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_fix_restG4/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_fix_restG4) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_fix_restG4)](https://github.com/rest-for-physics/framework/commits/jgalan_fix_restG4)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

TRestAnalysisTree::GetObservableAverage. Changing the way average is calculated



Other similar methods `GetObservableMax/Min/RMS` have been updated too