### PR TITLE
Updating installROOT.sh

### DIFF
--- a/scripts/installation/installROOT.sh
+++ b/scripts/installation/installROOT.sh
@@ -12,7 +12,7 @@ case "${unameOut}" in
     *)          machine="UNKNOWN:${unameOut}"
 esac
 
-ROOT_VERSION=6.26.10
+ROOT_VERSION=6.28.02
 ROOT_DIR=$HOME/apps/root-$ROOT_VERSION
 
 mkdir -p ${ROOT_DIR}
@@ -34,10 +34,10 @@ tar -xvzf $f
 rm -rf source
 mv root-$ROOT_VERSION source
 
-mkdir -p ${ROOT_DIR}/root_build
+mkdir -p ${ROOT_DIR}/build
 cd ${ROOT_DIR}/build
 
-cmake -Wno-dev -Dbuiltin_glew=ON -DCMAKE_CXX_STANDARD=17 -Dgdml=ON -DCMAKE_INSTALL_PREFIX=${ROOT_DIR}/install  ../source
+cmake -Wno-dev -Dbuiltin_glew=ON -DCMAKE_CXX_STANDARD=17 -Dxrootd=OFF -Dbuiltin_xrootd=OFF -Dgdml=ON -DCMAKE_INSTALL_PREFIX=${ROOT_DIR}/install  ../source
 make -j8 install
 
 cd ${CURRENT_DIR}


### PR DESCRIPTION
![raulena333](https://badgen.net/badge/PR%20submitted%20by%3A/raulena333/blue) ![Ok: 3](https://badgen.net/badge/PR%20Size/Ok%3A%203/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/rena_root_install/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/rena_root_install) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=rena_root_install)](https://github.com/rest-for-physics/framework/commits/rena_root_install)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- Fixing typo in installROOT.sh. 
- Disabling xrootd and upgrading ROOT to 6.28.02