### PR TITLE
Update restG4 framework validation to point to master

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -660,4 +660,4 @@ jobs:
     uses: rest-for-physics/wimplib/.github/workflows/validation.yml@master
 
   restG4-validation:
-    uses: rest-for-physics/restG4/.github/workflows/validation.yml@validation_framework
+    uses: rest-for-physics/restG4/.github/workflows/validation.yml@master


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/g4_validation_master/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/g4_validation_master) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=g4_validation_master)](https://github.com/rest-for-physics/framework/commits/g4_validation_master)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now `restG4` framework validation is pointing to master branch.

Related PR https://github.com/rest-for-physics/restG4/pull/107