### PR TITLE
Addressing compilation issue in macOS introduced on TRestDataSetOdds

### DIFF
--- a/source/framework/analysis/src/TRestDataSetOdds.cxx
+++ b/source/framework/analysis/src/TRestDataSetOdds.cxx
@@ -239,7 +239,7 @@ void TRestDataSetOdds::ComputeLogOdds() {
     std::string totName = "";
     for (const auto& [obsName, histo] : fHistos) {
         const std::string oddsName = "odds_" + obsName;
-        auto GetLogOdds = [&histo](double val) {
+        auto GetLogOdds = [&histo = histo](double val) {
             double odds = histo->GetBinContent(histo->GetXaxis()->FindBin(val));
             if (odds == 0) return 1000.;
             return log(1. - odds) - log(odds);


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/mac_clang/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/mac_clang) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=mac_clang)](https://github.com/rest-for-physics/framework/commits/mac_clang)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR try to address a compilation issue on macOS reported here https://rest-forum.unizar.es/t/macos-compilation-errors-restframework-trestdatasetodds-cxx/582

Note that this compilation failure is related with abug in clang, in which structure bindings are not captured in lambda expressions https://stackoverflow.com/questions/46114214/lambda-implicit-capture-fails-with-variable-declared-from-structured-binding