### PR TITLE
Fix on TRestMetadata and TRestDataSet add-ons

### DIFF
--- a/macros/REST_GenerateDataSet.C
+++ b/macros/REST_GenerateDataSet.C
@@ -22,7 +22,7 @@ Int_t REST_GenerateDataSet(std::string inputRML, std::string datasets) {
         std::cout << "Set : " << set << std::endl;
         TRestDataSet d(inputRML.c_str(), set.c_str());
         d.GenerateDataSet();
-        d.Export("dataset_" + set + ".root");
+        d.Export("Dataset_" + set + ".root");
     }
     return 0;
 }

--- a/macros/REST_GenerateDataSet.C
+++ b/macros/REST_GenerateDataSet.C
@@ -1,0 +1,32 @@
+#include "TRestTask.h"
+#include "TRestDataSet.h"
+
+#ifndef RestTask_GenerateDataSet
+#define RestTask_GenerateDataSet
+
+//*******************************************************************************************************
+//*** Description: This macro will launch the generation of datasets defined
+//*** inside a particular RML file `datasets.rml` that contains the dataset
+//*** definitions. The second argument will allow to specify the datasets
+//*** to be generated from the existing ones inside `dataset.rml`.
+//***
+//*** --------------
+//*** Usage: restManager GenerateDataSet datasets.rml set1,set2,set3
+//***
+//*******************************************************************************************************
+
+Int_t REST_GenerateDataSet( std::string inputRML, std::string datasets )
+{
+
+	std::vector<std::string> sets = REST_StringHelper::Split( datasets, "," );
+
+	for( const auto &set: sets ) {
+		std::cout << "Set : " << set << std::endl;
+		TRestDataSet d( inputRML.c_str(), set.c_str() ); 
+		d.GenerateDataSet();
+		d.Export( "dataset_" + set + ".root" );
+	}
+	return 0;
+
+}
+#endif

--- a/macros/REST_GenerateDataSet.C
+++ b/macros/REST_GenerateDataSet.C
@@ -1,5 +1,5 @@
-#include "TRestTask.h"
 #include "TRestDataSet.h"
+#include "TRestTask.h"
 
 #ifndef RestTask_GenerateDataSet
 #define RestTask_GenerateDataSet
@@ -15,18 +15,15 @@
 //***
 //*******************************************************************************************************
 
-Int_t REST_GenerateDataSet( std::string inputRML, std::string datasets )
-{
+Int_t REST_GenerateDataSet(std::string inputRML, std::string datasets) {
+    std::vector<std::string> sets = REST_StringHelper::Split(datasets, ",");
 
-	std::vector<std::string> sets = REST_StringHelper::Split( datasets, "," );
-
-	for( const auto &set: sets ) {
-		std::cout << "Set : " << set << std::endl;
-		TRestDataSet d( inputRML.c_str(), set.c_str() ); 
-		d.GenerateDataSet();
-		d.Export( "dataset_" + set + ".root" );
-	}
-	return 0;
-
+    for (const auto& set : sets) {
+        std::cout << "Set : " << set << std::endl;
+        TRestDataSet d(inputRML.c_str(), set.c_str());
+        d.GenerateDataSet();
+        d.Export("dataset_" + set + ".root");
+    }
+    return 0;
 }
 #endif

--- a/macros/REST_GenerateDataSets.C
+++ b/macros/REST_GenerateDataSets.C
@@ -15,7 +15,7 @@
 //***
 //*******************************************************************************************************
 
-Int_t REST_GenerateDataSet(std::string inputRML, std::string datasets) {
+Int_t REST_GenerateDataSets(std::string inputRML, std::string datasets) {
     std::vector<std::string> sets = REST_StringHelper::Split(datasets, ",");
 
     for (const auto& set : sets) {

--- a/macros/REST_GenerateDataSets.C
+++ b/macros/REST_GenerateDataSets.C
@@ -11,11 +11,11 @@
 //*** to be generated from the existing ones inside `dataset.rml`.
 //***
 //*** --------------
-//*** Usage: restManager GenerateDataSet datasets.rml set1,set2,set3
+//*** Usage: restManager GenerateDataSets datasets.rml set1,set2,set3
 //***
 //*******************************************************************************************************
 
-Int_t REST_GenerateDataSets(std::string inputRML, std::string datasets) {
+Int_t REST_GenerateDataSets(const std::string& inputRML, const std::string& datasets) {
     std::vector<std::string> sets = REST_StringHelper::Split(datasets, ",");
 
     for (const auto& set : sets) {

--- a/macros/REST_GenerateDataSets.C
+++ b/macros/REST_GenerateDataSets.C
@@ -1,8 +1,8 @@
 #include "TRestDataSet.h"
 #include "TRestTask.h"
 
-#ifndef RestTask_GenerateDataSet
-#define RestTask_GenerateDataSet
+#ifndef RestTask_GenerateDataSets
+#define RestTask_GenerateDataSets
 
 //*******************************************************************************************************
 //*** Description: This macro will launch the generation of datasets defined

--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -90,13 +90,16 @@ class TRestDataSet : public TRestMetadata {
     std::vector<std::string> fFileSelection;  //<
 
     /// TimeStamp for the start time of the first file
-    Double_t fStartTime = REST_StringHelper::StringToTimeStamp(fFilterEndTime);
+    Double_t fStartTime = REST_StringHelper::StringToTimeStamp(fFilterEndTime);  //<
 
     /// TimeStamp for the end time of the last file
-    Double_t fEndTime = REST_StringHelper::StringToTimeStamp(fFilterStartTime);
+    Double_t fEndTime = REST_StringHelper::StringToTimeStamp(fFilterStartTime);  //<
 
     /// It keeps track if the generated dataset is a pure dataset or a merged one
-    Bool_t fMergedDataset = false;
+    Bool_t fMergedDataset = false;  //<
+
+    /// The list of dataset files imported
+    std::vector<std::string> fImportedFiles;  //<
 
     /// The resulting RDF::RNode object after initialization
     ROOT::RDF::RNode fDataSet = ROOT::RDataFrame(0);  //!

--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -160,6 +160,8 @@ class TRestDataSet : public TRestMetadata {
 
     ROOT::RDF::RNode MakeCut(const TRestCut* cut);
 
+    ROOT::RDF::RNode Define(const std::string& columnName, const std::string& formula);
+
     void PrintMetadata() override;
     void Initialize() override;
 

--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -95,11 +95,14 @@ class TRestDataSet : public TRestMetadata {
     /// TimeStamp for the end time of the last file
     Double_t fEndTime = REST_StringHelper::StringToTimeStamp(fFilterStartTime);
 
+    /// It keeps track if the generated dataset is a pure dataset or a merged one
+    Bool_t fMergedDataset = false;
+
     /// The resulting RDF::RNode object after initialization
     ROOT::RDF::RNode fDataSet = ROOT::RDataFrame(0);  //!
 
     /// A pointer to the generated tree
-    TTree* fTree = nullptr;  //!
+    TChain* fTree = nullptr;  //!
 
     void InitFromConfigFile() override;
 
@@ -151,11 +154,13 @@ class TRestDataSet : public TRestMetadata {
     inline auto GetFilterEqualsTo() const { return fFilterEqualsTo; }
     inline auto GetQuantity() const { return fQuantity; }
     inline auto GetCut() const { return fCut; }
+    inline auto IsMergedDataSet() const { return fMergedDataset; }
 
     inline void SetFilePattern(const std::string& pattern) { fFilePattern = pattern; }
 
     TRestDataSet& operator=(TRestDataSet& dS);
     void Import(const std::string& fileName);
+    void Import(std::vector<std::string> fileNames);
     void Export(const std::string& filename);
 
     ROOT::RDF::RNode MakeCut(const TRestCut* cut);
@@ -171,6 +176,6 @@ class TRestDataSet : public TRestMetadata {
     TRestDataSet(const char* cfgFileName, const std::string& name = "");
     ~TRestDataSet();
 
-    ClassDefOverride(TRestDataSet, 2);
+    ClassDefOverride(TRestDataSet, 3);
 };
 #endif

--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -65,7 +65,7 @@ class TRestDataSet : public TRestMetadata {
     /// A list of metadata members where filters will be applied
     std::vector<std::string> fFilterMetadata;  //<
 
-    /// If not empty it will check if the metadata member contains the value
+    /// If not empty it will check if the metadata member contains the string
     std::vector<std::string> fFilterContains;  //<
 
     /// If the corresponding element is not empty it will check if the metadata member is greater
@@ -73,6 +73,9 @@ class TRestDataSet : public TRestMetadata {
 
     /// If the corresponding element is not empty it will check if the metadata member is lower
     std::vector<Double_t> fFilterLowerThan;  //<
+
+    /// If the corresponding element is not empty it will check if the metadata member is equal
+    std::vector<Double_t> fFilterEqualsTo;  //<
 
     /// The properties of a relevant quantity that we want to store together with the dataset
     std::map<std::string, RelevantQuantity> fQuantity;  //<
@@ -145,6 +148,7 @@ class TRestDataSet : public TRestMetadata {
     inline auto GetFilterContains() const { return fFilterContains; }
     inline auto GetFilterGreaterThan() const { return fFilterGreaterThan; }
     inline auto GetFilterLowerThan() const { return fFilterLowerThan; }
+    inline auto GetFilterEqualsTo() const { return fFilterEqualsTo; }
     inline auto GetQuantity() const { return fQuantity; }
     inline auto GetCut() const { return fCut; }
 

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -575,6 +575,19 @@ void TRestDataSet::PrintMetadata() {
         }
     }
 
+    if (fMergedDataset) {
+        RESTMetadata << " " << RESTendl;
+        RESTMetadata << "This is a combined dataset." << RESTendl;
+        RESTMetadata << " -------------------- " << RESTendl;
+        RESTMetadata << " - Relevant quantities have been removed!" << RESTendl;
+        RESTMetadata << " - Dataset metadata properties correspond to the first file in the list."
+                     << RESTendl;
+        RESTMetadata << " " << RESTendl;
+        RESTMetadata << "List of imported files: " << RESTendl;
+        RESTMetadata << " -------------------- " << RESTendl;
+        for (const auto& fn : fImportedFiles) RESTMetadata << " - " << fn << RESTendl;
+    }
+
     RESTMetadata << "----" << RESTendl;
 }
 
@@ -899,6 +912,7 @@ void TRestDataSet::Import(std::vector<std::string> fileNames) {
     for (const auto& fN : fileNames) fTree->Add((TString)fN);
 
     fMergedDataset = true;
+    fImportedFiles = fileNames;
 
     fQuantity.clear();
 }

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -209,6 +209,18 @@
 /// - **last**: It will simply register the value of the metadata member
 /// from the last file in the list of selected files.
 ///
+/// ### Adding a new column based on relevant quantities
+///
+/// Using the method TRestDataSet::Define method we can implement a
+/// formula based on column names and relevant quantities. Then, the
+/// relevant quantities will be sustituted by their dataset value.
+///
+/// \code
+/// dataset.GetColumnNames()
+/// dataset.Define("newColumnName", "QuantityName * column1" )
+/// dataset.GetColumnNames()
+/// dataset.GetDataFrame().Display({"column1", "newColumnName"})->Print();
+/// \endcode
 ///
 ///----------------------------------------------------------------------
 ///

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -379,6 +379,9 @@ std::vector<std::string> TRestDataSet::FileSelection() {
             if (fFilterLowerThan[n] != -1)
                 if (StringToDouble(mdValue) >= fFilterLowerThan[n]) accept = false;
 
+            if (fFilterEqualsTo[n] != -1)
+                if (StringToDouble(mdValue) != fFilterEqualsTo[n]) accept = false;
+
             n++;
         }
 
@@ -512,6 +515,7 @@ void TRestDataSet::PrintMetadata() {
             if (!fFilterContains[n].empty()) RESTMetadata << " Contains: " << fFilterContains[n];
             if (fFilterGreaterThan[n] != -1) RESTMetadata << " Greater than: " << fFilterGreaterThan[n];
             if (fFilterLowerThan[n] != -1) RESTMetadata << " Lower than: " << fFilterLowerThan[n];
+            if (fFilterEqualsTo[n] != -1) RESTMetadata << " Equals to: " << fFilterEqualsTo[n];
 
             RESTMetadata << RESTendl;
             n++;
@@ -560,10 +564,12 @@ void TRestDataSet::InitFromConfigFile() {
         if (contains == "Not defined") contains = "";
         Double_t greaterThan = StringToDouble(GetFieldValue("greaterThan", filterDefinition));
         Double_t lowerThan = StringToDouble(GetFieldValue("lowerThan", filterDefinition));
+        Double_t equalsTo = StringToDouble(GetFieldValue("equalsTo", filterDefinition));
 
         fFilterContains.push_back(contains);
         fFilterGreaterThan.push_back(greaterThan);
         fFilterLowerThan.push_back(lowerThan);
+        fFilterEqualsTo.push_back(equalsTo);
 
         filterDefinition = GetNextElement(filterDefinition);
     }
@@ -689,6 +695,7 @@ void TRestDataSet::Export(const std::string& filename) {
                 if (!fFilterContains[n].empty()) fprintf(f, " Contains: %s.", fFilterContains[n].c_str());
                 if (fFilterGreaterThan[n] != -1) fprintf(f, " Greater than: %6.3lf.", fFilterGreaterThan[n]);
                 if (fFilterLowerThan[n] != -1) fprintf(f, " Lower than: %6.3lf.", fFilterLowerThan[n]);
+                if (fFilterEqualsTo[n] != -1) fprintf(f, " Equals to: %6.3lf.", fFilterLowerThan[n]);
                 fprintf(f, "\n");
                 n++;
             }
@@ -764,6 +771,7 @@ TRestDataSet& TRestDataSet::operator=(TRestDataSet& dS) {
     fFilterContains = dS.GetFilterContains();
     fFilterGreaterThan = dS.GetFilterGreaterThan();
     fFilterLowerThan = dS.GetFilterLowerThan();
+    fFilterEqualsTo = dS.GetFilterEqualsTo();
     fQuantity = dS.GetQuantity();
     fTotalDuration = dS.GetTotalTimeInSeconds();
     fCut = dS.GetCut();

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -470,6 +470,29 @@ ROOT::RDF::RNode TRestDataSet::MakeCut(const TRestCut* cut) {
     return df;
 }
 
+///////////////////////////////////////////////
+/// \brief This function will add a new column to the RDataFrame using
+/// the same scheme as the usual RDF::Define method, but it will on top of
+/// that evaluate the values of any relevant quantities used.
+///
+/// For example, the following code line would create a new column named
+/// `test` replacing the relevant quantity `Nsim` and the previously
+/// existing column `probability`.
+/// \code
+/// d.Define("test", "Nsim * probability");
+/// \endcode
+///
+ROOT::RDF::RNode TRestDataSet::Define(const std::string& columnName, const std::string& formula) {
+    std::string evalFormula = formula;
+    for (auto const& [name, properties] : fQuantity)
+        evalFormula =
+            REST_StringHelper::Replace(evalFormula, name, DoubleToString(properties.value, "%12.10e"));
+
+    fDataSet = fDataSet.Define(columnName, evalFormula);
+
+    return fDataSet;
+}
+
 /////////////////////////////////////////////
 /// \brief Prints on screen the information about the metadata members of TRestDataSet
 ///

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -899,4 +899,6 @@ void TRestDataSet::Import(std::vector<std::string> fileNames) {
     for (const auto& fN : fileNames) fTree->Add((TString)fN);
 
     fMergedDataset = true;
+
+    fQuantity.clear();
 }

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -2327,6 +2327,8 @@ std::vector<string> TRestMetadata::GetDataMemberValues(string memberName, Int_t 
 
     result = Replace(result, "{", "");
     result = Replace(result, "}", "");
+    result = Replace(result, "(", "");
+    result = Replace(result, ")", "");
 
     std::vector<std::string> results = REST_StringHelper::Split(result, ",");
 


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Medium: 165](https://badgen.net/badge/PR%20Size/Medium%3A%20165/orange) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_minor_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_minor_fix) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_minor_fix)](https://github.com/rest-for-physics/framework/commits/jgalan_minor_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

`TRestMetadata::GetDataMemberValues` minor fix on TVector2,3 output component

Before this PR (for the case of TVector2,3), the following output was generated when invoking `GetMetadataMember`.

```
root [7] run0->GetMetadataMember("axionGen::fEnergyRange[0]")
(std::string) "(0.05"
root [8] run0->GetMetadataMember("axionGen::fEnergyRange[1]")
(std::string) "10)"
```

After this PR, parenthesis are removed from the output.

```
root [7] run0->GetMetadataMember("axionGen::fEnergyRange[0]")
(std::string) "0.05"
root [8] run0->GetMetadataMember("axionGen::fEnergyRange[1]")
(std::string) "10"
```


Added also:

- `REST_Generate_DataSets` macro that will allow to export several datasets from a given list of dataset names.
- Added new filter condition `equalsTo` that allows to evaluate numerically if a datamember is equal to the filter. If it is not equal, then the run will be rejected and thus not included in the dataset.
- Added method `TRestDataSet::Define` that allows to create a new column using the values of relevant quantities.
- Added method `TRestDataSet::Import( std::vector <std::string> fNames )` allowing to combine datasets into one single instance. If saved to disk the metadata member `fMergedDataSet` will be `true` in order to identify that it is a non-pure original dataset.

For the moment metadata filter conditions do not support units. See issue: https://github.com/rest-for-physics/framework/issues/429