### PR TITLE
TRestHits: error in gaussian fit is now defined by the user

### DIFF
--- a/source/framework/core/inc/TRestHits.h
+++ b/source/framework/core/inc/TRestHits.h
@@ -125,9 +125,9 @@ class TRestHits {
     Double_t GetSkewXY() const;
     Double_t GetSkewZ() const;
 
-    Double_t GetGaussSigmaX();
-    Double_t GetGaussSigmaY();
-    Double_t GetGaussSigmaZ();
+    Double_t GetGaussSigmaX(Double_t error = 150.0);
+    Double_t GetGaussSigmaY(Double_t error = 150.0);
+    Double_t GetGaussSigmaZ(Double_t error = 150.0);
 
     Double_t GetEnergyX() const;
     Double_t GetEnergyY() const;

--- a/source/framework/core/inc/TRestHits.h
+++ b/source/framework/core/inc/TRestHits.h
@@ -125,9 +125,9 @@ class TRestHits {
     Double_t GetSkewXY() const;
     Double_t GetSkewZ() const;
 
-    Double_t GetGaussSigmaX(Double_t error = 150.0);
-    Double_t GetGaussSigmaY(Double_t error = 150.0);
-    Double_t GetGaussSigmaZ(Double_t error = 150.0);
+    Double_t GetGaussSigmaX(Double_t error = 150.0, nHitsMin = 100000);
+    Double_t GetGaussSigmaY(Double_t error = 150.0, nHitsMin = 100000);
+    Double_t GetGaussSigmaZ(Double_t error = 150.0, nHitsMin = 100000);
 
     Double_t GetEnergyX() const;
     Double_t GetEnergyY() const;

--- a/source/framework/core/inc/TRestHits.h
+++ b/source/framework/core/inc/TRestHits.h
@@ -125,9 +125,9 @@ class TRestHits {
     Double_t GetSkewXY() const;
     Double_t GetSkewZ() const;
 
-    Double_t GetGaussSigmaX(Double_t error = 150.0, nHitsMin = 100000);
-    Double_t GetGaussSigmaY(Double_t error = 150.0, nHitsMin = 100000);
-    Double_t GetGaussSigmaZ(Double_t error = 150.0, nHitsMin = 100000);
+    Double_t GetGaussSigmaX(Double_t error = 150.0, Int_t nHitsMin = 100000);
+    Double_t GetGaussSigmaY(Double_t error = 150.0, Int_t nHitsMin = 100000);
+    Double_t GetGaussSigmaZ(Double_t error = 150.0, Int_t nHitsMin = 100000);
 
     Double_t GetEnergyX() const;
     Double_t GetEnergyY() const;

--- a/source/framework/core/src/TRestHits.cxx
+++ b/source/framework/core/src/TRestHits.cxx
@@ -767,15 +767,16 @@ void TRestHits::GetBoundaries(std::vector<double>& dist, double& max, double& mi
 /// Then it fits a gaussian to the hits and extracts the sigma. The hits are just added
 /// for fitting purposes and do not go into any further processing.
 ///
-Double_t TRestHits::GetGaussSigmaX(Double_t error) {
+Double_t TRestHits::GetGaussSigmaX(Double_t error, Int_t nHitsMin) {
     Double_t gausSigmaX = 0;
     Int_t nHits = GetNumberOfHits();
     if (nHits <= 0) {
         gausSigmaX = 0;
     } else {
         Int_t nAdd = 0;
-        bool doHitCorrection = true;
+        // bool doHitCorrection = true;
         // bool doHitCorrection = nHits <= 18; //in case we want to apply it only to the smaller events
+        bool doHitCorrection = nHits <= nHitsMin;
         if (doHitCorrection) {
             nAdd = 2;
         }
@@ -840,14 +841,14 @@ Double_t TRestHits::GetGaussSigmaX(Double_t error) {
 /// It adds a hit to the right and a hit to the left, with energy = 0 +/- user defined error in ADC.
 /// Then it fits a gaussian to the hits and extracts the sigma. The hits are just added
 /// for fitting purposes and do not go into any further processing.
-Double_t TRestHits::GetGaussSigmaY(Double_t error) {
+Double_t TRestHits::GetGaussSigmaY(Double_t error, Int_t nHitsMin) {
     Double_t gausSigmaY = 0;
     Int_t nHits = GetNumberOfHits();
     if (nHits <= 0) {
         gausSigmaY = 0;
     } else {
         Int_t nAdd = 0;
-        bool doHitCorrection = true;
+        bool doHitCorrection = nHits <= nHitsMin;
         if (doHitCorrection) {
             nAdd = 2;
         }
@@ -911,14 +912,14 @@ Double_t TRestHits::GetGaussSigmaY(Double_t error) {
 /// It adds a hit to the right and a hit to the left, with energy = 0 +/- user defined error in ADC.
 /// Then it fits a gaussian to the hits and extracts the sigma. The hits are just added
 /// for fitting purposes and do not go into any further processing.
-Double_t TRestHits::GetGaussSigmaZ(Double_t error) {
+Double_t TRestHits::GetGaussSigmaZ(Double_t error, Int_t nHitsMin) {
     Double_t gausSigmaZ = 0;
     Int_t nHits = GetNumberOfHits();
     if (nHits <= 0) {
         gausSigmaZ = 0;
     } else {
         Int_t nAdd = 0;
-        bool doHitCorrection = true;
+        bool doHitCorrection = nHits <= nHitsMin;
         if (doHitCorrection) {
             nAdd = 2;
         }

--- a/source/framework/core/src/TRestHits.cxx
+++ b/source/framework/core/src/TRestHits.cxx
@@ -763,11 +763,11 @@ void TRestHits::GetBoundaries(std::vector<double>& dist, double& max, double& mi
 }
 ///////////////////////////////////////////////
 /// \brief It computes the gaussian sigma in the X-coordinate.
-/// It adds a hit to the right and a hit to the left, with energy = 0 +/- 70 ADC.
+/// It adds a hit to the right and a hit to the left, with energy = 0 +/- user defined error in ADC.
 /// Then it fits a gaussian to the hits and extracts the sigma. The hits are just added
 /// for fitting purposes and do not go into any further processing.
 ///
-Double_t TRestHits::GetGaussSigmaX() {
+Double_t TRestHits::GetGaussSigmaX(Double_t error) {
     Double_t gausSigmaX = 0;
     Int_t nHits = GetNumberOfHits();
     if (nHits <= 0) {
@@ -804,8 +804,8 @@ Double_t TRestHits::GetGaussSigmaX() {
             y[h] = 0.0;
             ex[0] = 0.0;
             ex[h] = 0.0;
-            ey[0] = 70.0;
-            ey[h] = 70.0;
+            ey[0] = error;
+            ey[h] = error;
         }
         TGraphErrors* grX = new TGraphErrors(nElems, &x[0], &y[0], &ex[0], &ey[0]);
         // TCanvas *c = new TCanvas("c","X position fit",200,10,500,500);
@@ -837,10 +837,10 @@ Double_t TRestHits::GetGaussSigmaX() {
     return abs(gausSigmaX);
 }
 /// \brief It computes the gaussian sigma in the Y-coordinate.
-/// It adds a hit to the right and a hit to the left, with energy = 0 +/- 70 ADC.
+/// It adds a hit to the right and a hit to the left, with energy = 0 +/- user defined error in ADC.
 /// Then it fits a gaussian to the hits and extracts the sigma. The hits are just added
 /// for fitting purposes and do not go into any further processing.
-Double_t TRestHits::GetGaussSigmaY() {
+Double_t TRestHits::GetGaussSigmaY(Double_t error) {
     Double_t gausSigmaY = 0;
     Int_t nHits = GetNumberOfHits();
     if (nHits <= 0) {
@@ -876,8 +876,8 @@ Double_t TRestHits::GetGaussSigmaY() {
             y[h] = 0.0;
             ex[0] = 0.0;
             ex[h] = 0.0;
-            ey[0] = 70.0;
-            ey[h] = 70.0;
+            ey[0] = error;
+            ey[h] = error;
         }
         TGraphErrors* grY = new TGraphErrors(nElems, &x[0], &y[0], &ex[0], &ey[0]);
         // TCanvas *c = new TCanvas("c","Y position fit",200,10,500,500);
@@ -908,10 +908,10 @@ Double_t TRestHits::GetGaussSigmaY() {
     return abs(gausSigmaY);
 }
 /// \brief It computes the gaussian sigma in the Z-coordinate.
-/// It adds a hit to the right and a hit to the left, with energy = 0 +/- 70 ADC.
+/// It adds a hit to the right and a hit to the left, with energy = 0 +/- user defined error in ADC.
 /// Then it fits a gaussian to the hits and extracts the sigma. The hits are just added
 /// for fitting purposes and do not go into any further processing.
-Double_t TRestHits::GetGaussSigmaZ() {
+Double_t TRestHits::GetGaussSigmaZ(Double_t error) {
     Double_t gausSigmaZ = 0;
     Int_t nHits = GetNumberOfHits();
     if (nHits <= 0) {
@@ -947,8 +947,8 @@ Double_t TRestHits::GetGaussSigmaZ() {
             y[h] = 0.0;
             ex[0] = 0.0;
             ex[h] = 0.0;
-            ey[0] = 70.0;
-            ey[h] = 70.0;
+            ey[0] = error;
+            ey[h] = error;
         }
         TGraphErrors* grZ = new TGraphErrors(nElems, &x[0], &y[0], &ex[0], &ey[0]);
         // TCanvas *c = new TCanvas("c","Z position fit",200,10,500,500);


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Ok: 19](https://badgen.net/badge/PR%20Size/Ok%3A%2019/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/cris_hitsGaussError/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/cris_hitsGaussError) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=cris_hitsGaussError)](https://github.com/rest-for-physics/framework/commits/cris_hitsGaussError)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR is required by PR https://github.com/rest-for-physics/detectorlib/pull/82
The hard coded numbers are now arguments of the functions.