### PR TITLE
Minor TRestDataSet and TRestRun fixes

### DIFF
--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -149,6 +149,7 @@ class TRestDataSet : public TRestMetadata {
     inline auto GetEndTime() const { return fEndTime; }
     inline auto GetFilePattern() const { return fFilePattern; }
     inline auto GetObservablesList() const { return fObservablesList; }
+    inline auto GetFileSelection() const { return fFileSelection; }
     inline auto GetProcessObservablesList() const { return fProcessObservablesList; }
     inline auto GetFilterMetadata() const { return fFilterMetadata; }
     inline auto GetFilterContains() const { return fFilterContains; }

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -174,7 +174,7 @@ class TRestRun : public TRestMetadata {
     inline int GetNumberOfMetadata() const { return fMetadata.size(); }
 
     inline std::string GetMetadataMember(const std::string& instr) { return ReplaceMetadataMember(instr); }
-    std::string ReplaceMetadataMembers(const std::string& instr, Int_t precision = 2);
+    std::string ReplaceMetadataMembers(const std::string& instr, Int_t precision = 8);
 
     Bool_t EvaluateMetadataMember(const std::string& instr);
 

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -814,6 +814,7 @@ TRestDataSet& TRestDataSet::operator=(TRestDataSet& dS) {
     fEndTime = dS.GetEndTime();
     fFilePattern = dS.GetFilePattern();
     fObservablesList = dS.GetObservablesList();
+    fFileSelection = dS.GetFileSelection();
     fProcessObservablesList = dS.GetProcessObservablesList();
     fFilterMetadata = dS.GetFilterMetadata();
     fFilterContains = dS.GetFilterContains();

--- a/source/framework/tools/src/TRestStringHelper.cxx
+++ b/source/framework/tools/src/TRestStringHelper.cxx
@@ -81,13 +81,12 @@ string REST_StringHelper::CropWithPrecision(string in, Int_t precision) {
     if (REST_StringHelper::isANumber(in) && in.find(".") != string::npos) {
         string rootStr;
         size_t newPrecision = precision;
-        if (in.find("e") != string::npos)
-        {
+        if (in.find("e") != string::npos) {
             rootStr = in.substr(in.find("e"), -1);
-            newPrecision = std::min( (int) newPrecision, (int) in.find("e") - (int) in.find(".") - 1 );
+            newPrecision = std::min((int)newPrecision, (int)in.find("e") - (int)in.find(".") - 1);
         }
-		std::string rr = in.substr(0, in.find(".") + newPrecision + 1) + rootStr;
-		return rr;
+        std::string rr = in.substr(0, in.find(".") + newPrecision + 1) + rootStr;
+        return rr;
     }
     return in;
 }

--- a/source/framework/tools/src/TRestStringHelper.cxx
+++ b/source/framework/tools/src/TRestStringHelper.cxx
@@ -80,8 +80,14 @@ string REST_StringHelper::CropWithPrecision(string in, Int_t precision) {
     if (precision == 0) return in;
     if (REST_StringHelper::isANumber(in) && in.find(".") != string::npos) {
         string rootStr;
-        if (in.find("e") != string::npos) rootStr = in.substr(in.find("e"), -1);
-        return in.substr(0, in.find(".") + precision + 1) + rootStr;
+        size_t newPrecision = precision;
+        if (in.find("e") != string::npos)
+        {
+            rootStr = in.substr(in.find("e"), -1);
+            newPrecision = std::min( (int) newPrecision, (int) in.find("e") - (int) in.find(".") - 1 );
+        }
+		std::string rr = in.substr(0, in.find(".") + newPrecision + 1) + rootStr;
+		return rr;
     }
     return in;
 }


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 10](https://badgen.net/badge/PR%20Size/Ok%3A%2010/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_dataset_update/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_dataset_update) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_dataset_update)](https://github.com/rest-for-physics/framework/commits/jgalan_dataset_update)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- `TRestRun::ReplaceMetadataMembers`. Now default precision is infinite.
- `TRestDataSet::GetFileSelection` added to TRestDataSet copy method
- `REST_StringHelper::CropWithPrecision` fixing a bug causing problems when the given precision is bigger than the string implicit precision.