### PR TITLE
REST_StringHelper::isAExpression. Fixing a bug

### DIFF
--- a/source/framework/tools/src/TRestStringHelper.cxx
+++ b/source/framework/tools/src/TRestStringHelper.cxx
@@ -40,8 +40,8 @@ Int_t REST_StringHelper::isAExpression(const string& in) {
     }
 
     if (!symbol) {
-        size_t pos = in.find_first_of("+-*/e^%");
-        if (pos > 0 && pos < in.size() - 1) {
+        size_t pos = in.substr(1, in.length() - 2).find_first_of("+-*/e^%");
+        if (pos != string::npos) {
             symbol = true;
         }
     }


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan_expression_fix/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan_expression_fix) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_expression_fix)](https://github.com/rest-for-physics/framework/commits/jgalan_expression_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

REST_StringHelper::isAExpression had a bug.

The method was not properly identifying a expression that starts with minus sign