### PR TITLE
Adjust metadata writing sequence to avoid StreamerInfo missing

### DIFF
--- a/source/framework/core/src/TRestManager.cxx
+++ b/source/framework/core/src/TRestManager.cxx
@@ -37,16 +37,28 @@ ClassImp(TRestManager);
 
 TRestManager::TRestManager() { Initialize(); }
 
-TRestManager::~TRestManager() {}
+TRestManager::~TRestManager() {
+    // delete all the added metadata objects(besides self)
+    if (fMetaObjects.size() > 1) {
+        for (unsigned int i = fMetaObjects.size() - 1; i >= 1; i--) {
+            delete fMetaObjects[i];
+        }
+    }
+}
 
 ///////////////////////////////////////////////
 /// \brief Set the class name as section name during initialization.
 ///
 void TRestManager::Initialize() {
     SetSectionName(this->ClassName());
-
+    // delete all the added metadata objects(besides self)
+    if (fMetaObjects.size() > 1) {
+        for (unsigned int i = fMetaObjects.size() - 1; i >= 1; i--) {
+            delete fMetaObjects[i];
+        }
+    }
+    // add self to the metadata objects list
     fMetaObjects.clear();
-
     fMetaObjects.push_back(this);
 }
 

--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -955,7 +955,7 @@ void TRestProcessRunner::ConfigOutputFile() {
     delete fOutputDataFile;
 
     // merge process's data file to the main file
-    // we must call this method before writing process metadata, 
+    // we must call this method before writing process metadata,
     // otherwise there would be problems of streamer missing
     // https://github.com/rest-for-physics/framework/issues/348
     fRunInfo->SetNFilesSplit(fNFilesSplit);
@@ -966,14 +966,14 @@ void TRestProcessRunner::ConfigOutputFile() {
 }
 
 void TRestProcessRunner::WriteProcessesMetadata() {
-    //if (fRunInfo->GetInputFile() == nullptr) {
-    //    if (!fRunInfo->GetOutputFile()) {
-    //        // We are not ready yet to write
-    //        return;
-    //    }
-    //    fRunInfo->cd();
-    //} else
-    //    
+    // if (fRunInfo->GetInputFile() == nullptr) {
+    //     if (!fRunInfo->GetOutputFile()) {
+    //         // We are not ready yet to write
+    //         return;
+    //     }
+    //     fRunInfo->cd();
+    // } else
+    //
     fOutputDataFile->cd();
 
     this->Write(nullptr, TObject::kWriteDelete);
@@ -1013,8 +1013,8 @@ void TRestProcessRunner::MergeOutputFile() {
     } else {
         RESTError << "Output file: " << fOutputDataFileName << " is lost?" << RESTendl;
     }
-    //if (fRunInfo->GetInputFile() == nullptr) 
-    //WriteProcessesMetadata();
+    // if (fRunInfo->GetInputFile() == nullptr)
+    // WriteProcessesMetadata();
 }
 
 // tools

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -991,7 +991,7 @@ TFile* TRestRun::MergeToOutputFile(vector<string> filenames, string outputfilena
         m->OutputFile(filename.c_str(), "RECREATE");
     } else {
         filename = outputfilename;
-        RESTInfo << "Creating file : " << filename << RESTendl;
+        RESTInfo << "Updating file : " << filename << RESTendl;
         m->OutputFile(filename.c_str(), "UPDATE");
     }
 


### PR DESCRIPTION
![nkx111](https://badgen.net/badge/PR%20submitted%20by%3A/nkx111/blue) ![Large: 3353](https://badgen.net/badge/PR%20Size/Large%3A%203353/red) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/nkx111-streamerinfo/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/nkx111-streamerinfo) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=nkx111-streamerinfo)](https://github.com/rest-for-physics/framework/commits/nkx111-streamerinfo)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This is to fix issue #358. Changed the sequence of metadata writing after process has finished. Previously: process metadata -- merge with process files -- TRestRun metadata. Now: merge with process files -- TRestRun metadata -- process metadata. Sometimes the merging operation will cause the later metadata writing operation overwriting the StreamerInfo of the previously written metadata classes. So we need to do the merging at the beginning.

This also fix a bug that the output file is not closed (because TRestRun is not deleted) by TRestManager. This might also be part of the cause of #358