### PR TITLE
Masks debugging

### DIFF
--- a/source/framework/masks/src/TRestCombinedMask.cxx
+++ b/source/framework/masks/src/TRestCombinedMask.cxx
@@ -61,7 +61,6 @@
 ///
 /// \code
 ///     TRestCombinedMask mask("masks.rml", "combined");
-///     mask.GenerateCombined();
 ///     TCanvas *c = mask.DrawMonteCarlo(30000);
 ///     c->Draw();
 ///     c->Print("combined.png");

--- a/source/framework/masks/src/TRestCombinedMask.cxx
+++ b/source/framework/masks/src/TRestCombinedMask.cxx
@@ -173,6 +173,7 @@ void TRestCombinedMask::InitFromConfigFile() {
         cont++;
         msk = (TRestPatternMask*)this->InstantiateChildMetadata(cont, "Mask");
     }
+    Initialize();
 }
 
 /////////////////////////////////////////////

--- a/source/framework/masks/src/TRestCombinedMask.cxx
+++ b/source/framework/masks/src/TRestCombinedMask.cxx
@@ -148,8 +148,16 @@ void TRestCombinedMask::Initialize() {
 ///
 Int_t TRestCombinedMask::GetRegion(Double_t& x, Double_t& y) {
     Int_t region = 0;
+    Double_t xIn = x;
+    Double_t yIn = y;
     for (const auto mask : fMasks) {
         Int_t id = mask->GetRegion(x, y);
+
+        // The (x,y) coordinates are transformed for each mask.
+        // We need to recover the original point to be evaluated for each mask.
+        x = xIn;
+        y = yIn;
+
         RESTDebug << "TRestCombinedMask::GetRegion. Mask type: " << mask->GetType() << " region : " << id
                   << RESTendl;
         if (id == 0) return 0;

--- a/source/framework/masks/src/TRestSpiderMask.cxx
+++ b/source/framework/masks/src/TRestSpiderMask.cxx
@@ -216,6 +216,9 @@ Int_t TRestSpiderMask::GetRegion(Double_t& x, Double_t& y) {
 void TRestSpiderMask::GenerateSpider() {
     if (fArmsSeparationAngle <= 0) return;
 
+    fPositiveRanges.clear();
+    fNegativeRanges.clear();
+
     std::pair<Double_t, Double_t> additional_negative = {-1, -1};
 
     // The angle parameter could introduce an offset but we let finally this task to TRestPatternMask


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 12](https://badgen.net/badge/PR%20Size/Ok%3A%2012/green) [![](https://gitlab.cern.ch/rest-for-physics/framework/badges/jgalan-masks-update/pipeline.svg)](https://gitlab.cern.ch/rest-for-physics/framework/-/commits/jgalan-masks-update) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan-masks-update)](https://github.com/rest-for-physics/framework/commits/jgalan-masks-update)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- [x] Updated documentation of TRestCombinedMask
- [x] Fixing a bug due to not clearing std::vector on Initialisation.
- [x] Solving issue that could potentially appear in case of masks rotation. 