### PR TITLE
Simplifying opening of TRestRun and TRestDataSet files

### DIFF
--- a/cmake/thisREST.cmake
+++ b/cmake/thisREST.cmake
@@ -136,7 +136,7 @@ export LIBRARY_PATH=\\\$REST_PATH/lib:\\\$LIBRARY_PATH
 export PYTHONPATH=${PYTHON_BINDINGS_INSTALL_DIR}:\\\$PYTHONPATH
 
 alias restRoot=\\\"restRoot -l\\\"
-alias restRootMacros=\\\"restRoot -l --m 1\\\"
+alias restRootMacros=\\\"restRoot -l --m\\\"
 
 if [ \\\$(rest-config --flags | grep \\\"REST_WELCOME=ON\\\") ]; then
     rest-config --welcome

--- a/macros/REST_OpenInputFile.C
+++ b/macros/REST_OpenInputFile.C
@@ -1,41 +1,41 @@
-TRestRun *run0 = nullptr;
-TRestAnalysisTree *ana_tree0 = nullptr;
-TTree *ev_tree0 = nullptr;
-TRestDataSet *dSet0 = nullptr;
-std::map<std::string, TRestMetadata *> metadata0;
+TRestRun* run0 = nullptr;
+TRestAnalysisTree* ana_tree0 = nullptr;
+TTree* ev_tree0 = nullptr;
+TRestDataSet* dSet0 = nullptr;
+std::map<std::string, TRestMetadata*> metadata0;
 
-void REST_OpenInputFile(const std::string &fileName){
+void REST_OpenInputFile(const std::string& fileName) {
+    if (TRestTools::isRunFile(fileName)) {
+        printf("\n%s\n", "REST processed file identified. It contains a valid TRestRun.");
+        run0 = new TRestRun(fileName);
+        printf("\nAttaching TRestRun %s as run0...\n", fileName.c_str());
+        ana_tree0 = run0->GetAnalysisTree();
+        printf("\nAttaching TRestAnalysisTree as ana_tree0...\n");
+        ev_tree0 = run0->GetEventTree();
+        printf("\nAttaching event tree as ev_tree0...\n");
+        std::map<std::string, int> metanames;
+        for (auto& [name, meta] : metadata0) delete meta;
+        metadata0.clear();
+        for (int n = 0; n < run0->GetNumberOfMetadata(); n++) {
+            std::string metaName = run0->GetMetadataNames()[n];
+            if (metaName.find("Historic") != string::npos) continue;
+            TRestMetadata* md = run0->GetMetadata(metaName);
+            metadata0[metaName] = md;
+            printf("\nAttaching Metadata class %s as metadata0[\"%s\"]...\n", md->ClassName(),
+                   metaName.c_str());
+        }
 
-  if (TRestTools::isRunFile(fileName)){
-    printf("\n%s\n", "REST processed file identified. It contains a valid TRestRun.");
-    run0 = new TRestRun(fileName);
-    printf("\nAttaching TRestRun %s as run0...\n", fileName.c_str());
-    ana_tree0 = run0->GetAnalysisTree();
-    printf("\nAttaching TRestAnalysisTree as ana_tree0...\n");
-    ev_tree0 = run0->GetEventTree();
-    printf("\nAttaching event tree as ev_tree0...\n");
-    std::map<std::string, int> metanames;
-    for(auto &[name, meta] : metadata0)delete meta;
-    metadata0.clear();
-      for (int n = 0; n < run0->GetNumberOfMetadata(); n++) {
-        std::string metaName = run0->GetMetadataNames()[n];
-          if (metaName.find("Historic") != string::npos)continue;
-          TRestMetadata* md = run0->GetMetadata(metaName);
-          metadata0[metaName] = md;
-          printf("\nAttaching Metadata class %s as metadata0[\"%s\"]...\n", md->ClassName() , metaName.c_str());
-      }
-    
-  } else if (TRestTools::isDataSet(fileName )){
-    printf("\n%s\n", "REST dataset file identified. It contains a valid TRestDataSet.");
-    printf("\nImporting dataset %s as `dSet0`\n",fileName.c_str());
-    printf("\n%s\n", "The dataset is ready. You may now access the dataset using:");
-    printf("\n%s\n", " - dSet0->PrintMetadata()");
-    printf("%s\n", " - dSet0->GetDataFrame().GetColumnNames()");
-    printf("%s\n\n", " - dSet0->GetTree()->GetEntries()");
-    if(dSet0)delete dSet0;
-    dSet0 = new TRestDataSet();
-    dSet0->Import(fileName);
-  } else {
-    printf("\n%s is not a valid TRestRun or TRestDataSet\n",fileName.c_str());
-  }
+    } else if (TRestTools::isDataSet(fileName)) {
+        printf("\n%s\n", "REST dataset file identified. It contains a valid TRestDataSet.");
+        printf("\nImporting dataset %s as `dSet0`\n", fileName.c_str());
+        printf("\n%s\n", "The dataset is ready. You may now access the dataset using:");
+        printf("\n%s\n", " - dSet0->PrintMetadata()");
+        printf("%s\n", " - dSet0->GetDataFrame().GetColumnNames()");
+        printf("%s\n\n", " - dSet0->GetTree()->GetEntries()");
+        if (dSet0) delete dSet0;
+        dSet0 = new TRestDataSet();
+        dSet0->Import(fileName);
+    } else {
+        printf("\n%s is not a valid TRestRun or TRestDataSet\n", fileName.c_str());
+    }
 }

--- a/macros/REST_OpenInputFile.C
+++ b/macros/REST_OpenInputFile.C
@@ -3,6 +3,7 @@ TRestRun *run0 = nullptr;
 TRestAnalysisTree *ana_tree0 = nullptr;
 TTree *ev_tree0 = nullptr;
 TRestDataSet *dSet0 = nullptr;
+std::map<std::string, TRestMetadata *> metadata0;
 
 void REST_OpenInputFile(const std::string &fileName){
 
@@ -14,7 +15,16 @@ void REST_OpenInputFile(const std::string &fileName){
     printf("\nAttaching TRestAnalysisTree as ana_tree0...\n");
     ev_tree0 = run0->GetEventTree();
     printf("\nAttaching event tree as ev_tree0...\n");
-    
+    std::map<std::string, int> metanames;
+    for(auto &[name, meta] : metadata0)delete meta;
+    metadata0.clear();
+      for (int n = 0; n < run0->GetNumberOfMetadata(); n++) {
+        std::string metaName = run0->GetMetadataNames()[n];
+          if (metaName.find("Historic") != string::npos)continue;
+          TRestMetadata* md = run0->GetMetadata(metaName);
+          metadata0[metaName] = md;
+          printf("\nAttaching Metadata class %s as metadata0[\"%s\"]...\n", md->ClassName() , metaName.c_str());
+      }
     
   } else if (TRestTools::isDataSet(fileName )){
     printf("\n%s\n", "REST dataset file identified. It contains a valid TRestDataSet.");
@@ -23,6 +33,7 @@ void REST_OpenInputFile(const std::string &fileName){
     printf("\n%s\n", " - dSet0->PrintMetadata()");
     printf("%s\n", " - dSet0->GetDataFrame().GetColumnNames()");
     printf("%s\n\n", " - dSet0->GetTree()->GetEntries()");
+    if(dSet0)delete dSet0;
     dSet0 = new TRestDataSet();
     dSet0->Import(fileName);
   } else {

--- a/macros/REST_OpenInputFile.C
+++ b/macros/REST_OpenInputFile.C
@@ -1,0 +1,32 @@
+
+TRestRun *run0 = nullptr;
+TRestAnalysisTree *ana_tree0 = nullptr;
+TTree *ev_tree0 = nullptr;
+TRestDataSet *dSet0 = nullptr;
+
+void REST_OpenInputFile(const std::string &fileName){
+
+  if (TRestTools::isRunFile(fileName)){
+    printf("\n%s\n", "REST processed file identified. It contains a valid TRestRun.");
+    run0 = new TRestRun(fileName);
+    printf("\nAttaching TRestRun %s as run0...\n", fileName.c_str());
+    ana_tree0 = run0->GetAnalysisTree();
+    printf("\nAttaching TRestAnalysisTree as ana_tree0...\n");
+    ev_tree0 = run0->GetEventTree();
+    printf("\nAttaching event tree as ev_tree0...\n");
+    
+    
+  } else if (TRestTools::isDataSet(fileName )){
+    printf("\n%s\n", "REST dataset file identified. It contains a valid TRestDataSet.");
+    printf("\nImporting dataset %s as `dSet0`\n",fileName.c_str());
+    printf("\n%s\n", "The dataset is ready. You may now access the dataset using:");
+    printf("\n%s\n", " - dSet0->PrintMetadata()");
+    printf("%s\n", " - dSet0->GetDataFrame().GetColumnNames()");
+    printf("%s\n\n", " - dSet0->GetTree()->GetEntries()");
+    dSet0 = new TRestDataSet();
+    dSet0->Import(fileName);
+  } else {
+    printf("\n%s is not a valid TRestRun or TRestDataSet\n",fileName.c_str());
+  }
+
+}

--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -95,10 +95,10 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    // load input root file with TRestRun, initialize input event, analysis tree and metadata structures
-    int nFile = 0;
-    int nDataSet = 0;
-    for (int i = 1; i < argc; i++) {
+    std::string runName = "";
+    std::string dSName = "";
+
+     for (int i = 1; i < argc; i++) {
         const string opt = (string)argv[i];
         if (opt.at(0) == ('-')) continue;
         printf("\nAttaching file %s\n", opt.c_str());
@@ -107,30 +107,22 @@ int main(int argc, char* argv[]) {
             printf("\nFile %s not compatible ... !!\n", opt.c_str());
             continue;
         }
-
-        if (TRestTools::isRunFile(opt)) {
-            printf("\n%s\n", "REST processed file identified. It contains a valid TRestRun.");
-            printf("\nAttaching TRestRun %s as run%i...\n", opt.c_str(), nFile);
-            string runcmd = Form("TRestRun* run%i = new TRestRun (\"%s\");", nFile, opt.c_str());
-            if (debug) printf("%s\n", runcmd.c_str());
-            gROOT->ProcessLine(runcmd.c_str());
-            argv[i] = (char*)"";
-            nFile++;
-        } else if (TRestTools::isDataSet(opt)) {
-            printf("\n%s\n", "REST dataset file identified. It contains a valid TRestDataSet.");
-            printf("\nImporting dataset as `dSet%i`\n", nDataSet);
-            printf("\n%s\n", "The dataset is ready. You may now access the dataset using:");
-            printf("\n%s\n", " - dSet0->PrintMetadata()");
-            printf("%s\n", " - dSet0->GetDataFrame().GetColumnNames()");
-            printf("%s\n\n", " - dSet0->GetTree()->GetEntries()");
-            string runcmd = "TRestDataSet *dSet" + to_string(nDataSet) + " = new TRestDataSet();";
-            gROOT->ProcessLine(runcmd.c_str());
-            runcmd = Form("dSet%i->Import(\"%s\");", nDataSet, opt.c_str());
-            gROOT->ProcessLine(runcmd.c_str());
-            argv[i] = (char*)"";
-            nDataSet++;
+        if (TRestTools::isRunFile(opt) && runName.empty()){
+          runName = opt;
+          string cmd = ".L "+ REST_PATH + "/macros/REST_OpenInputFile.C";
+          if (!loadMacros && dSName.empty())gROOT->ProcessLine(cmd.c_str());
+          cmd = "REST_OpenInputFile(\""+runName +"\")";
+          gROOT->ProcessLine(cmd.c_str());
+          argv[i] = (char*)"";
+        } else if (TRestTools::isDataSet(opt) && dSName.empty()) {
+          dSName = opt;
+          string cmd = ".L "+ REST_PATH + "/macros/REST_OpenInputFile.C";
+          if (!loadMacros && runName.empty())gROOT->ProcessLine(cmd.c_str());
+          cmd = "REST_OpenInputFile(\""+dSName +"\")";
+          gROOT->ProcessLine(cmd.c_str());
+          argv[i] = (char*)"";
         }
-    }
+     }
 
     // display root's command line
     TRint theApp("App", &argc, argv);

--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -100,15 +100,15 @@ int main(int argc, char* argv[]) {
     int nDataSet = 0;
     for (int i = 1; i < argc; i++) {
         const string opt = (string)argv[i];
-        if (opt.at(0) == ('-') ) continue;
+        if (opt.at(0) == ('-')) continue;
         printf("\nAttaching file %s\n", opt.c_str());
 
-        if (opt.find("http") == string::npos && !TRestTools::fileExists(opt) ){
-          printf("\nFile %s not compatible ... !!\n", opt.c_str());
-          continue;
+        if (opt.find("http") == string::npos && !TRestTools::fileExists(opt)) {
+            printf("\nFile %s not compatible ... !!\n", opt.c_str());
+            continue;
         }
 
-         if ( TRestTools::isRunFile(opt) ) {
+        if (TRestTools::isRunFile(opt)) {
             printf("\n%s\n", "REST processed file identified. It contains a valid TRestRun.");
             printf("\nAttaching TRestRun %s as run%i...\n", opt.c_str(), nFile);
             string runcmd = Form("TRestRun* run%i = new TRestRun (\"%s\");", nFile, opt.c_str());
@@ -118,12 +118,12 @@ int main(int argc, char* argv[]) {
             nFile++;
         } else if (TRestTools::isDataSet(opt)) {
             printf("\n%s\n", "REST dataset file identified. It contains a valid TRestDataSet.");
-            printf("\nImporting dataset as `dSet%i`\n",nDataSet);
+            printf("\nImporting dataset as `dSet%i`\n", nDataSet);
             printf("\n%s\n", "The dataset is ready. You may now access the dataset using:");
             printf("\n%s\n", " - dSet0->PrintMetadata()");
             printf("%s\n", " - dSet0->GetDataFrame().GetColumnNames()");
             printf("%s\n\n", " - dSet0->GetTree()->GetEntries()");
-            string runcmd = "TRestDataSet *dSet"+to_string(nDataSet) +" = new TRestDataSet();";
+            string runcmd = "TRestDataSet *dSet" + to_string(nDataSet) + " = new TRestDataSet();";
             gROOT->ProcessLine(runcmd.c_str());
             runcmd = Form("dSet%i->Import(\"%s\");", nDataSet, opt.c_str());
             gROOT->ProcessLine(runcmd.c_str());

--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -3,9 +3,9 @@
 #include <TRint.h>
 #include <TSystem.h>
 
-#include "TRestTools.h"
-#include "TRestStringOutput.h"
 #include "TRestStringHelper.h"
+#include "TRestStringOutput.h"
+#include "TRestTools.h"
 #include "TRestVersion.h"
 
 using namespace std;

--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -3,9 +3,9 @@
 #include <TRint.h>
 #include <TSystem.h>
 
-#include "TRestMetadata.h"
-#include "TRestRun.h"
 #include "TRestTools.h"
+#include "TRestStringOutput.h"
+#include "TRestStringHelper.h"
 #include "TRestVersion.h"
 
 using namespace std;

--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -25,7 +25,7 @@ int main(int argc, char* argv[]) {
     // set the env and debug status
     setenv("REST_VERSION", REST_RELEASE, 1);
 
-    Int_t loadMacros = 0;
+    Bool_t loadMacros = false;
     for (int i = 1; i < argc; i++) {
         char* c = &argv[i][0];
         if (*c == '-') {
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
                     gVerbose = StringToVerboseLevel(argv[i + 1]);
                     break;
                 case 'm':
-                    loadMacros = StringToInteger(argv[i + 1]);
+                    loadMacros = true;
                     break;
                 case 'h':
                     // We use cout here since we will just exit afterwards
@@ -101,7 +101,6 @@ int main(int argc, char* argv[]) {
      for (int i = 1; i < argc; i++) {
         const string opt = (string)argv[i];
         if (opt.at(0) == ('-')) continue;
-        printf("\nAttaching file %s\n", opt.c_str());
 
         if (opt.find("http") == string::npos && !TRestTools::fileExists(opt)) {
             printf("\nFile %s not compatible ... !!\n", opt.c_str());

--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -203,6 +203,7 @@ int main(int argc, char* argv[]) {
             string runcmd = Form("TFile* f = TFile::Open(\"%s\");", opt.c_str());
             printf("\n%s\n", runcmd.c_str());
 
+            printf("\n%s\n", "Opening ROOT file as `f`:");
             gROOT->ProcessLine(runcmd.c_str());
             argv[i] = (char*)"";
         } else


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 68](https://badgen.net/badge/PR%20Size/Ok%3A%2068/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=restroot_update)](https://github.com/rest-for-physics/framework/commits/restroot_update)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Simplifiying `restRoot` behaviour for opening `TRestRun` and `TRestDataSet`
- Reimplementing TRestAnalysisTree, TRestEvent and metadata objects in a dedicated macro `REST_LoadInputFiles.C`
- Droping support for multiple files, now only one `TRestRun` and/or `TRestDataSet` can be opened (the first one)
- If the file is not a `TRestRun` or a `TRestDataSet` it just use default `root` behaviour using `TRint`
- Now the flag to load macros is just  `--m` instead of `--m 1` since the latest is misleading and error prone.