### PR TITLE
Adding TRestEvent ptr while opening input file

### DIFF
--- a/macros/REST_OpenInputFile.C
+++ b/macros/REST_OpenInputFile.C
@@ -7,19 +7,20 @@ std::map<std::string, TRestMetadata*> metadata;
 
 void REST_OpenInputFile(const std::string& fileName) {
     if (TRestTools::isRunFile(fileName)) {
-        printf("\n%s\n", "REST processed file identified. It contains a valid TRestRun.");
+        printf("\n%s\n\n", "REST processed file identified. It contains a valid TRestRun.");
         run = new TRestRun(fileName);
         printf("\nAttaching TRestRun %s as run...\n", fileName.c_str());
         ana_tree = run->GetAnalysisTree();
-        printf("\nAttaching TRestAnalysisTree as ana_tree...\n");
+        printf("Attaching TRestAnalysisTree as ana_tree...\n");
         ev_tree = run->GetEventTree();
-        printf("\nAttaching event tree as ev_tree...\n");
+        printf("Attaching event tree as ev_tree...\n");
         ev = run->GetInputEvent();
         run->GetEntry(0);
-        printf("\nAttaching input event %s as ev...\n", ev->ClassName());
+        printf("Attaching input event %s as ev...\n", ev->ClassName());
         for (auto& [name, meta] : metadata) delete meta;
         metadata.clear();
         for (int n = 0; n < run->GetNumberOfMetadata(); n++) {
+            if (n == 0) printf("Attaching Metadata classes:\n");
             std::string metaName = run->GetMetadataNames()[n];
             if (metaName.find("Historic") != string::npos) continue;
             TRestMetadata* md = run->GetMetadata(metaName);
@@ -31,9 +32,9 @@ void REST_OpenInputFile(const std::string& fileName) {
             metaName = Replace(metaName, " ", "");
             metaName = Replace(metaName, ".", "_");
             metadata[metaName] = md;
-            printf("\nAttaching Metadata class %s as metadata[\"%s\"]...\n", md->ClassName(),
-                   metaName.c_str());
+            printf("- %s as metadata[\"%s\"]...\n", md->ClassName(), metaName.c_str());
         }
+        printf("\n");
 
     } else if (TRestTools::isDataSet(fileName)) {
         printf("\n%s\n", "REST dataset file identified. It contains a valid TRestDataSet.");

--- a/macros/REST_OpenInputFile.C
+++ b/macros/REST_OpenInputFile.C
@@ -1,40 +1,44 @@
-TRestRun* run0 = nullptr;
-TRestAnalysisTree* ana_tree0 = nullptr;
-TTree* ev_tree0 = nullptr;
-TRestDataSet* dSet0 = nullptr;
-std::map<std::string, TRestMetadata*> metadata0;
+TRestRun* run = nullptr;
+TRestAnalysisTree* ana_tree = nullptr;
+TTree* ev_tree = nullptr;
+TRestEvent* ev = nullptr;
+TRestDataSet* dSet = nullptr;
+std::map<std::string, TRestMetadata*> metadata;
 
 void REST_OpenInputFile(const std::string& fileName) {
     if (TRestTools::isRunFile(fileName)) {
         printf("\n%s\n", "REST processed file identified. It contains a valid TRestRun.");
-        run0 = new TRestRun(fileName);
-        printf("\nAttaching TRestRun %s as run0...\n", fileName.c_str());
-        ana_tree0 = run0->GetAnalysisTree();
-        printf("\nAttaching TRestAnalysisTree as ana_tree0...\n");
-        ev_tree0 = run0->GetEventTree();
-        printf("\nAttaching event tree as ev_tree0...\n");
+        run = new TRestRun(fileName);
+        printf("\nAttaching TRestRun %s as run...\n", fileName.c_str());
+        ana_tree = run->GetAnalysisTree();
+        printf("\nAttaching TRestAnalysisTree as ana_tree...\n");
+        ev_tree = run->GetEventTree();
+        printf("\nAttaching event tree as ev_tree...\n");
+        ev = run->GetInputEvent();
+        run->GetEntry(0);
+        printf("\nAttaching input event %s as ev...\n",ev->ClassName());
         std::map<std::string, int> metanames;
-        for (auto& [name, meta] : metadata0) delete meta;
-        metadata0.clear();
-        for (int n = 0; n < run0->GetNumberOfMetadata(); n++) {
-            std::string metaName = run0->GetMetadataNames()[n];
+        for (auto& [name, meta] : metadata) delete meta;
+        metadata.clear();
+        for (int n = 0; n < run->GetNumberOfMetadata(); n++) {
+            std::string metaName = run->GetMetadataNames()[n];
             if (metaName.find("Historic") != string::npos) continue;
-            TRestMetadata* md = run0->GetMetadata(metaName);
-            metadata0[metaName] = md;
-            printf("\nAttaching Metadata class %s as metadata0[\"%s\"]...\n", md->ClassName(),
+            TRestMetadata* md = run->GetMetadata(metaName);
+            metadata[metaName] = md;
+            printf("\nAttaching Metadata class %s as metadata[\"%s\"]...\n", md->ClassName(),
                    metaName.c_str());
         }
 
     } else if (TRestTools::isDataSet(fileName)) {
         printf("\n%s\n", "REST dataset file identified. It contains a valid TRestDataSet.");
-        printf("\nImporting dataset %s as `dSet0`\n", fileName.c_str());
+        printf("\nImporting dataset %s as `dSet`\n", fileName.c_str());
         printf("\n%s\n", "The dataset is ready. You may now access the dataset using:");
-        printf("\n%s\n", " - dSet0->PrintMetadata()");
-        printf("%s\n", " - dSet0->GetDataFrame().GetColumnNames()");
-        printf("%s\n\n", " - dSet0->GetTree()->GetEntries()");
-        if (dSet0) delete dSet0;
-        dSet0 = new TRestDataSet();
-        dSet0->Import(fileName);
+        printf("\n%s\n", " - dSet->PrintMetadata()");
+        printf("%s\n", " - dSet->GetDataFrame().GetColumnNames()");
+        printf("%s\n\n", " - dSet->GetTree()->GetEntries()");
+        if (dSet) delete dSet;
+        dSet = new TRestDataSet();
+        dSet->Import(fileName);
     } else {
         printf("\n%s is not a valid TRestRun or TRestDataSet\n", fileName.c_str());
     }

--- a/macros/REST_OpenInputFile.C
+++ b/macros/REST_OpenInputFile.C
@@ -29,8 +29,8 @@ void REST_OpenInputFile(const std::string& fileName) {
             }
             std::string mName = Replace(metaName, " ", "");
             mName = Replace(mName, ".", "_");
-            std::string mdcmd = Form("%s* %s = (%s*)run->GetMetadata(\"%s\");", md->ClassName(), mName.c_str(),
-                                    md->ClassName(), metaName.c_str());
+            std::string mdcmd = Form("%s* %s = (%s*)run->GetMetadata(\"%s\");", md->ClassName(),
+                                     mName.c_str(), md->ClassName(), metaName.c_str());
             gROOT->ProcessLine(mdcmd.c_str());
             printf("- %s as %s\n", md->ClassName(), mName.c_str());
         }

--- a/macros/REST_OpenInputFile.C
+++ b/macros/REST_OpenInputFile.C
@@ -15,15 +15,21 @@ void REST_OpenInputFile(const std::string& fileName) {
         ev_tree = run->GetEventTree();
         printf("\nAttaching event tree as ev_tree...\n");
         ev = run->GetInputEvent();
-        run->GetEntry(0);
         printf("\nAttaching input event %s as ev...\n",ev->ClassName());
-        std::map<std::string, int> metanames;
+        run->GetEntry(0);
         for (auto& [name, meta] : metadata) delete meta;
         metadata.clear();
         for (int n = 0; n < run->GetNumberOfMetadata(); n++) {
             std::string metaName = run->GetMetadataNames()[n];
             if (metaName.find("Historic") != string::npos) continue;
             TRestMetadata* md = run->GetMetadata(metaName);
+              if(md == nullptr){
+                printf("\nERROR Cannot get metadata pointer for class %s and name%s\n", md->ClassName(),
+                   metaName.c_str() );
+                continue;
+              }
+            metaName = Replace(metaName, " ", "");
+            metaName = Replace(metaName, ".", "_");
             metadata[metaName] = md;
             printf("\nAttaching Metadata class %s as metadata[\"%s\"]...\n", md->ClassName(),
                    metaName.c_str());

--- a/macros/REST_OpenInputFile.C
+++ b/macros/REST_OpenInputFile.C
@@ -23,11 +23,11 @@ void REST_OpenInputFile(const std::string& fileName) {
             std::string metaName = run->GetMetadataNames()[n];
             if (metaName.find("Historic") != string::npos) continue;
             TRestMetadata* md = run->GetMetadata(metaName);
-              if(md == nullptr){
+            if (md == nullptr) {
                 printf("\nERROR Cannot get metadata pointer for class %s and name%s\n", md->ClassName(),
-                   metaName.c_str() );
+                       metaName.c_str());
                 continue;
-              }
+            }
             metaName = Replace(metaName, " ", "");
             metaName = Replace(metaName, ".", "_");
             metadata[metaName] = md;

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -167,6 +167,8 @@ class TRestRun : public TRestMetadata {
     inline TTree* GetEventTree() const { return fEventTree; }
     inline Int_t GetInputFileNumber() const { return fFileProcess == nullptr ? fInputFileNames.size() : 1; }
 
+    std::vector<std::string> GetEventTypesList();
+
     TRestMetadata* GetMetadata(const TString& name, TFile* file = nullptr);
     TRestMetadata* GetMetadataClass(const TString& type, TFile* file = nullptr);
     std::vector<std::string> GetMetadataNames();

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -888,7 +888,24 @@ Int_t TRestRun::GetNextEvent(TRestEvent* targetEvent, TRestAnalysisTree* targetT
 }
 
 ///////////////////////////////////////////////
+/// \brief It returns a list of available event types inside the file
+///
+std::vector<std::string> TRestRun::GetEventTypesList() {
+    std::vector<std::string> list;
+    TObjArray* branches = GetEventTree()->GetListOfBranches();
+    for (int i = 0; i <= branches->GetLast(); i++) {
+        auto branch = (TBranch*)branches->At(i);
+        if (((std::string)branch->GetName()).find("EventBranch") != string::npos) {
+            std::string eventType = Replace((string)branch->GetName(), "Branch", "");
+            list.emplace_back(eventType);
+        }
+    }
+    return list;
+}
+
+///////////////////////////////////////////////
 /// \brief Calls GetEntry() for both AnalysisTree and EventTree
+///
 void TRestRun::GetEntry(Long64_t entry) {
     if (entry >= GetEntries()) {
         RESTWarning << "TRestRun::GetEntry. Entry requested out of limits" << RESTendl;

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -1137,7 +1137,10 @@ int TRestTools::DownloadRemoteFile(string remoteFile, string localFile) {
             return 0;
         }
     } else {
-        RESTError << "unknown protocol!" << RESTendl;
+        if (!TRestTools::fileExists(remoteFile)) {
+            RESTWarning << "Trying to download: " << remoteFile << RESTendl;
+            RESTWarning << "Unknown protocol!" << RESTendl;
+        }
     }
 
     return -1;


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 62](https://badgen.net/badge/PR%20Size/Ok%3A%2062/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=issue452)](https://github.com/rest-for-physics/framework/commits/issue452)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Addressing issue #452 
- Adding `TRestEvent` pointer while opening `TRestRun` input file
- Removal of the appending `0` for the global variable names
- Now metadata and input event are added using `gROOT->ProcessLine`