### PR TITLE
Updating hit positions scaling in Eve scene

### DIFF
--- a/source/framework/core/inc/TRestBrowser.h
+++ b/source/framework/core/inc/TRestBrowser.h
@@ -68,8 +68,8 @@ class TRestBrowser {
 
     TRestEventViewer* fEventViewer = nullptr;  //!
 
-    void SetViewer(TRestEventViewer* eV);
-    void SetViewer(const TString& viewerName);
+    void SetViewer(TRestEventViewer* eV, const Double_t& geomScale = 0.1);
+    void SetViewer(const TString& viewerName, const Double_t& geomScale = 0.1);
     void SetLeftPanelButtons();
     void SetBottomPanelButtons();
     Bool_t LoadEventId(Int_t eventID, Int_t subEventID = -1);
@@ -105,7 +105,7 @@ class TRestBrowser {
 
     // Constructors
     TRestBrowser();
-    TRestBrowser(const TString& viewerName);
+    TRestBrowser(const TString& viewerName, const Double_t& geomScale = 0.1);
 
     // Destructor
     ~TRestBrowser();

--- a/source/framework/core/inc/TRestBrowser.h
+++ b/source/framework/core/inc/TRestBrowser.h
@@ -68,8 +68,8 @@ class TRestBrowser {
 
     TRestEventViewer* fEventViewer = nullptr;  //!
 
-    void SetViewer(TRestEventViewer* eV, const Double_t& geomScale = 0.1);
-    void SetViewer(const TString& viewerName, const Double_t& geomScale = 0.1);
+    void SetViewer(TRestEventViewer* eV, Double_t geomScale = 0.1);
+    void SetViewer(const TString& viewerName, Double_t geomScale = 0.1);
     void SetLeftPanelButtons();
     void SetBottomPanelButtons();
     Bool_t LoadEventId(Int_t eventID, Int_t subEventID = -1);
@@ -105,7 +105,7 @@ class TRestBrowser {
 
     // Constructors
     TRestBrowser();
-    TRestBrowser(const TString& viewerName, const Double_t& geomScale = 0.1);
+    TRestBrowser(const TString& viewerName, Double_t geomScale = 0.1);
 
     // Destructor
     ~TRestBrowser();

--- a/source/framework/core/inc/TRestEveEventViewer.h
+++ b/source/framework/core/inc/TRestEveEventViewer.h
@@ -38,10 +38,9 @@
 
 #include "TRestEventViewer.h"
 
-#define GEOM_SCALE 1
-
 class TRestEveEventViewer : public TRestEventViewer {
    protected:
+    Double_t fGeomScale = 0.1;
     TEveManager* gEve;
 
     TEveWindowSlot* slot;
@@ -86,8 +85,11 @@ class TRestEveEventViewer : public TRestEventViewer {
     void SetGeometry(TGeoManager* geo);
     void Update();
 
-    void SetMinRadious(Double_t rmin) { fMinRadius = rmin; }
-    void SetMaxRadious(Double_t rmax) { fMaxRadius = rmax; }
+    void SetMinRadius(Double_t rmin) { fMinRadius = rmin; }
+    void SetMaxRadius(Double_t rmax) { fMaxRadius = rmax; }
+
+    void SetGeomScale(const Double_t& scale) { fGeomScale = scale; }
+    Double_t GetGeomScale() { return fGeomScale; }
 
     // Constructor
     TRestEveEventViewer();

--- a/source/framework/core/inc/TRestEveEventViewer.h
+++ b/source/framework/core/inc/TRestEveEventViewer.h
@@ -40,7 +40,6 @@
 
 class TRestEveEventViewer : public TRestEventViewer {
    protected:
-    Double_t fGeomScale = 0.1;
     TEveManager* gEve;
 
     TEveWindowSlot* slot;
@@ -87,9 +86,6 @@ class TRestEveEventViewer : public TRestEventViewer {
 
     void SetMinRadius(Double_t rmin) { fMinRadius = rmin; }
     void SetMaxRadius(Double_t rmax) { fMaxRadius = rmax; }
-
-    void SetGeomScale(const Double_t& scale) { fGeomScale = scale; }
-    Double_t GetGeomScale() { return fGeomScale; }
 
     // Constructor
     TRestEveEventViewer();

--- a/source/framework/core/inc/TRestEventViewer.h
+++ b/source/framework/core/inc/TRestEventViewer.h
@@ -35,6 +35,8 @@ class TRestEventViewer {
     TGeoManager* fGeometry = nullptr;  //!
     TRestEvent* fEvent = nullptr;      //!
 
+    Double_t fGeomScale = 0.1;
+
     TPad* fPad = nullptr;
     TCanvas* fCanvas = nullptr;
 
@@ -54,6 +56,9 @@ class TRestEventViewer {
     // Getters
     TGeoManager* GetGeometry() { return fGeometry; }
     TRestEvent* GetEvent() { return fEvent; }
+
+    void SetGeomScale(const Double_t& scale) { fGeomScale = scale; }
+    Double_t GetGeomScale() { return fGeomScale; }
 
     // Constructor
     TRestEventViewer();

--- a/source/framework/core/inc/TRestEventViewer.h
+++ b/source/framework/core/inc/TRestEventViewer.h
@@ -57,7 +57,7 @@ class TRestEventViewer {
     TGeoManager* GetGeometry() { return fGeometry; }
     TRestEvent* GetEvent() { return fEvent; }
 
-    void SetGeomScale(const Double_t& scale) { fGeomScale = scale; }
+    void SetGeomScale(Double_t scale) { fGeomScale = scale; }
     Double_t GetGeomScale() { return fGeomScale; }
 
     // Constructor

--- a/source/framework/core/inc/TRestEventViewer.h
+++ b/source/framework/core/inc/TRestEventViewer.h
@@ -58,7 +58,7 @@ class TRestEventViewer {
     TRestEvent* GetEvent() { return fEvent; }
 
     void SetGeomScale(Double_t scale) { fGeomScale = scale; }
-    Double_t GetGeomScale() { return fGeomScale; }
+    Double_t GetGeomScale() const { return fGeomScale; }
 
     // Constructor
     TRestEventViewer();

--- a/source/framework/core/src/TRestBrowser.cxx
+++ b/source/framework/core/src/TRestBrowser.cxx
@@ -41,7 +41,7 @@ TRestBrowser::TRestBrowser() {
     }
 }
 
-TRestBrowser::TRestBrowser(const TString& viewerName, const Double_t& geomScale) {
+TRestBrowser::TRestBrowser(const TString& viewerName, Double_t geomScale) {
     Initialize("I");
     SetViewer(viewerName, geomScale);
 }
@@ -89,7 +89,7 @@ void TRestBrowser::Initialize(const TString& opt) {
     // frmMain->MapWindow();
 }
 
-void TRestBrowser::SetViewer(TRestEventViewer* eV, const Double_t& geomScale) {
+void TRestBrowser::SetViewer(TRestEventViewer* eV, Double_t geomScale) {
     if (fEventViewer != nullptr) {
         cout << "Event viewer has already been set!" << endl;
         return;
@@ -103,7 +103,7 @@ void TRestBrowser::SetViewer(TRestEventViewer* eV, const Double_t& geomScale) {
     }
 }
 
-void TRestBrowser::SetViewer(const TString& viewerName, const Double_t& geomScale) {
+void TRestBrowser::SetViewer(const TString& viewerName, Double_t geomScale) {
     if (Count((string)viewerName, "Viewer") > 0) {
         TRestEventViewer* viewer = REST_Reflection::Assembly((string)viewerName);
         viewer->SetGeomScale(geomScale);

--- a/source/framework/core/src/TRestBrowser.cxx
+++ b/source/framework/core/src/TRestBrowser.cxx
@@ -41,9 +41,9 @@ TRestBrowser::TRestBrowser() {
     }
 }
 
-TRestBrowser::TRestBrowser(const TString& viewerName) {
+TRestBrowser::TRestBrowser(const TString& viewerName, const Double_t& geomScale) {
     Initialize("I");
-    SetViewer(viewerName);
+    SetViewer(viewerName, geomScale);
 }
 
 TRestBrowser::~TRestBrowser() {
@@ -89,7 +89,8 @@ void TRestBrowser::Initialize(const TString& opt) {
     // frmMain->MapWindow();
 }
 
-void TRestBrowser::SetViewer(TRestEventViewer* eV) {
+void TRestBrowser::SetViewer(TRestEventViewer* eV, const Double_t& geomScale) {
+    eV->SetGeomScale(geomScale);
     if (fEventViewer != nullptr) {
         cout << "Event viewer has already been set!" << endl;
         return;
@@ -102,13 +103,14 @@ void TRestBrowser::SetViewer(TRestEventViewer* eV) {
     }
 }
 
-void TRestBrowser::SetViewer(const TString& viewerName) {
+void TRestBrowser::SetViewer(const TString& viewerName, const Double_t& geomScale) {
     if (Count((string)viewerName, "Viewer") > 0) {
         TRestEventViewer* viewer = REST_Reflection::Assembly((string)viewerName);
+        viewer->SetGeomScale(geomScale);
         if (viewer != nullptr) {
             SetViewer(viewer);
         } else {
-            RESTError << viewerName << " not recoginzed! Did you install the corresponding library?"
+            RESTError << viewerName << " not recognized! Did you install the corresponding library?"
                       << RESTendl;
             RESTError << "Also check EVE feature is turned on in REST for 3d event viewing." << RESTendl;
             RESTWarning << "Using default event viewer" << RESTendl;

--- a/source/framework/core/src/TRestBrowser.cxx
+++ b/source/framework/core/src/TRestBrowser.cxx
@@ -90,13 +90,13 @@ void TRestBrowser::Initialize(const TString& opt) {
 }
 
 void TRestBrowser::SetViewer(TRestEventViewer* eV, const Double_t& geomScale) {
-    eV->SetGeomScale(geomScale);
     if (fEventViewer != nullptr) {
         cout << "Event viewer has already been set!" << endl;
         return;
     }
     if (eV != nullptr) {
         fEventViewer = eV;
+        fEventViewer->SetGeomScale(geomScale);
         // b->StartEmbedding(1, -1);
         eV->Embed(fBrowser);
         // b->StopEmbedding();
@@ -108,7 +108,7 @@ void TRestBrowser::SetViewer(const TString& viewerName, const Double_t& geomScal
         TRestEventViewer* viewer = REST_Reflection::Assembly((string)viewerName);
         viewer->SetGeomScale(geomScale);
         if (viewer != nullptr) {
-            SetViewer(viewer);
+            SetViewer(viewer, geomScale);
         } else {
             RESTError << viewerName << " not recognized! Did you install the corresponding library?"
                       << RESTendl;

--- a/source/framework/core/src/TRestEveEventViewer.cxx
+++ b/source/framework/core/src/TRestEveEventViewer.cxx
@@ -13,6 +13,7 @@
 ///_______________________________________________________________________________
 
 #include "TRestEveEventViewer.h"
+#include "TRestStringOutput.h"
 
 using namespace std;
 
@@ -22,6 +23,8 @@ TRestEveEventViewer::TRestEveEventViewer() {
     Initialize();
     fEnergyDeposits = new TEvePointSet();
     fEnergyDeposits->SetElementName("Energy deposits");
+
+    RESTWarning << "XXX" << RESTendl;
 }
 
 TRestEveEventViewer::~TRestEveEventViewer() {
@@ -182,7 +185,7 @@ void TRestEveEventViewer::Update() {
 
 void TRestEveEventViewer::AddSphericalHit(double x, double y, double z, double radius, double en) {
     fEnergyDeposits->SetOwnIds(kTRUE);
-    fEnergyDeposits->SetNextPoint(x * GEOM_SCALE, y * GEOM_SCALE, z * GEOM_SCALE);
+    fEnergyDeposits->SetNextPoint(x * fGeomScale, y * fGeomScale, z * fGeomScale);
     fEnergyDeposits->SetMarkerColor(kYellow);
     fEnergyDeposits->SetMarkerSize(Size_t(radius));
     fEnergyDeposits->SetMarkerStyle(4);

--- a/source/framework/core/src/TRestEveEventViewer.cxx
+++ b/source/framework/core/src/TRestEveEventViewer.cxx
@@ -23,8 +23,6 @@ TRestEveEventViewer::TRestEveEventViewer() {
     Initialize();
     fEnergyDeposits = new TEvePointSet();
     fEnergyDeposits->SetElementName("Energy deposits");
-
-    RESTWarning << "XXX" << RESTendl;
 }
 
 TRestEveEventViewer::~TRestEveEventViewer() {

--- a/source/framework/core/src/TRestEveEventViewer.cxx
+++ b/source/framework/core/src/TRestEveEventViewer.cxx
@@ -23,6 +23,18 @@ TRestEveEventViewer::TRestEveEventViewer() {
     Initialize();
     fEnergyDeposits = new TEvePointSet();
     fEnergyDeposits->SetElementName("Energy deposits");
+
+    RESTWarning << "There are some issues with geometry representation in Eve 3D scenes!" << RESTendl;
+    RESTWarning
+        << "We use a geometry scaling factor to place the hits in the scene and correct a placement problem"
+        << RESTendl;
+    RESTWarning << "Presently the default value of fGeomScale is " << fGeomScale << RESTendl;
+    RESTWarning << "Please, report to the dev-team if you experience problems visualizing the geometry."
+                << RESTendl;
+    RESTWarning << "For example: when hit positions seem to do not match geometry positions" << RESTendl;
+
+    RESTWarning << " " << RESTendl;
+    RESTWarning << "You may try to fix this using TRestEventViewer::SetGeomScale(1.0);" << RESTendl;
 }
 
 TRestEveEventViewer::~TRestEveEventViewer() {

--- a/source/framework/core/src/TRestEveEventViewer.cxx
+++ b/source/framework/core/src/TRestEveEventViewer.cxx
@@ -13,6 +13,7 @@
 ///_______________________________________________________________________________
 
 #include "TRestEveEventViewer.h"
+
 #include "TRestStringOutput.h"
 
 using namespace std;

--- a/source/framework/core/src/TRestEveEventViewer.cxx
+++ b/source/framework/core/src/TRestEveEventViewer.cxx
@@ -30,7 +30,7 @@ TRestEveEventViewer::TRestEveEventViewer() {
         << "We use a geometry scaling factor to place the hits in the scene and correct a placement problem"
         << RESTendl;
     RESTWarning << "Presently the default value of fGeomScale is " << fGeomScale << RESTendl;
-    RESTWarning << "Please, report to the dev-team if you experience problems visualizing the geometry."
+    RESTWarning << "Please, report to the dev team if you experience problems visualizing the geometry."
                 << RESTendl;
     RESTWarning << "For example: when hit positions seem to do not match geometry positions" << RESTendl;
 


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 33](https://badgen.net/badge/PR%20Size/Ok%3A%2033/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_geom_scale)](https://github.com/rest-for-physics/framework/commits/jgalan_geom_scale)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Now the GEOM_SCALE define has been replaced by a data member at `TRestEventViewer::fGeomScale`. In this way we can update the value of scaling dynamically. The default value is now back to `fGeomScale=0.1`. Recently it was updated in #440. However this has generated problems.

Using the present PR and https://github.com/rest-for-physics/geant4lib/pull/108, and the example `01.NLDBD` I see the event properly placed now with 

```
REST_Geant4_ViewEvent( "file.root");
```

<img width="382" alt="Screenshot 2023-06-21 at 11 19 31" src="https://github.com/rest-for-physics/framework/assets/12447509/354044cb-9782-4a57-a5f9-dfc0176cebe8">


while it is placed outside if I redefine `geomScale` to 1.0.

```
REST_Geant4_ViewEvent( "file.root", 1.0);
```


<img width="382" alt="Screenshot 2023-06-21 at 11 18 54" src="https://github.com/rest-for-physics/framework/assets/12447509/c2c61581-91e5-4f33-8dee-486c6095b4fe">

This is only affecting visualisation

It would be interesting to find out when this is happening, so I added a warning message to encourage users feedback.

<img width="811" alt="Screenshot 2023-06-21 at 11 32 46" src="https://github.com/rest-for-physics/framework/assets/12447509/e86f98a7-b436-450f-b4cd-91f4bd6cb33a">


