### PR TITLE
Adding documentation to CheckRunFileList macro

### DIFF
--- a/macros/REST_CheckRunFileList.C
+++ b/macros/REST_CheckRunFileList.C
@@ -11,11 +11,14 @@ using namespace std;
 
 //*******************************************************************************************************
 //***
-//*** Your HELP is needed to verify, validate and document this macro
-//*** This macro might need update/revision.
+//*** This macro receives as input a filename pattern. The files matching the glob pattern will be open
+//*** and if the run metadata does not exist, or the file was not properly closed, the file will be added
+//*** to a list, helping to identify the corrupted files.
+//***
+//*** Usage: restManager CheckRunFileList "/path/to/data/Run*tag*V2.4.0.root"
 //***
 //*******************************************************************************************************
-Int_t REST_CheckRunFileList(TString namePattern, Int_t N = 100000) {
+Int_t REST_CheckRunFileList(TString namePattern) {
     TGeoManager::SetVerboseLevel(0);
 
     vector<TString> filesNotWellClosed;


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 6](https://badgen.net/badge/PR%20Size/Ok%3A%206/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_macro_doc)](https://github.com/rest-for-physics/framework/commits/jgalan_macro_doc)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Just adding documentation to `CheckRunFileList` macro.

This macro can be used to identify files that were not properly closed, e.g.: after launching the processing to condor cluster.

```
restManager CheckRunFileList "/path/file*Pattern.root"
```

The documentation will be printed when using `REST_PrintMacros.C`.