### PR TITLE
Increasing default verbose level of `restManager` to `Info`

### DIFF
--- a/source/bin/restManager.cxx
+++ b/source/bin/restManager.cxx
@@ -53,7 +53,8 @@ void PrintHelp() {
 
     RESTcout.setheader("Usage1 : ./restManager ");
     RESTcout << "--c CONFIG_FILE [--i/f INPUT] [--o OUTPUT] [--j THREADS] [--e EVENTS_TO_PROCESS] [--v "
-                "VERBOSELEVEL] [--d RUNID] [--p PDF_PLOTS.pdf]" << RESTendl;
+                "VERBOSELEVEL] [--d RUNID] [--p PDF_PLOTS.pdf]"
+             << RESTendl;
     RESTcout.setheader("Usage2 : ./restManager ");
     RESTcout << "TASK_NAME ARG1 ARG2 ARG3" << RESTendl;
 
@@ -63,20 +64,24 @@ void PrintHelp() {
     RESTcout.setheader("CONFIG_FILE: ");
     RESTcout << "-" << RESTendl;
     RESTcout << "The rml configuration file. It should contain a TRestManager section. This "
-                "argument MUST be provided. The others can be also specified in the rml file." << RESTendl;
+                "argument MUST be provided. The others can be also specified in the rml file."
+             << RESTendl;
     RESTcout.setheader("INPUT      : ");
     RESTcout << "-" << RESTendl;
     RESTcout << "Input file name. If not given it will be acquired from the rml file. If you want "
                 "to use multiple input file, you can either specify the string of matching pattern with "
-                "quotation marks surrounding it, or put the file names in a .list file." << RESTendl;
+                "quotation marks surrounding it, or put the file names in a .list file."
+             << RESTendl;
     RESTcout.setheader("OUTPUT     : ");
     RESTcout << "-" << RESTendl;
     RESTcout << "Output file name. It can be given as a name string (abc.root), or as an expression "
-                "with naming fields to be replaced (Run[RunNumber]_[Tag].root)." << RESTendl;
+                "with naming fields to be replaced (Run[RunNumber]_[Tag].root)."
+             << RESTendl;
     RESTcout.setheader("THREADS    : ");
     RESTcout << "-" << RESTendl;
     RESTcout << "Enable specific number of threads to run the jobs. In most time 3~6 threads are "
-                "enough to make full use of computer power. Maximum is 15." << RESTendl;
+                "enough to make full use of computer power. Maximum is 15."
+             << RESTendl;
     RESTcout.setheader("");
     RESTcout << "=" << RESTendl;
 }

--- a/source/bin/restManager.cxx
+++ b/source/bin/restManager.cxx
@@ -53,8 +53,7 @@ void PrintHelp() {
 
     RESTcout.setheader("Usage1 : ./restManager ");
     RESTcout << "--c CONFIG_FILE [--i/f INPUT] [--o OUTPUT] [--j THREADS] [--e EVENTS_TO_PROCESS] [--v "
-                "VERBOSELEVEL] [--d RUNID] [--p PDF_PLOTS.pdf]"
-             << RESTendl;
+                "VERBOSELEVEL] [--d RUNID] [--p PDF_PLOTS.pdf]" << RESTendl;
     RESTcout.setheader("Usage2 : ./restManager ");
     RESTcout << "TASK_NAME ARG1 ARG2 ARG3" << RESTendl;
 
@@ -64,24 +63,20 @@ void PrintHelp() {
     RESTcout.setheader("CONFIG_FILE: ");
     RESTcout << "-" << RESTendl;
     RESTcout << "The rml configuration file. It should contain a TRestManager section. This "
-                "argument MUST be provided. The others can be also specified in the rml file."
-             << RESTendl;
+                "argument MUST be provided. The others can be also specified in the rml file." << RESTendl;
     RESTcout.setheader("INPUT      : ");
     RESTcout << "-" << RESTendl;
     RESTcout << "Input file name. If not given it will be acquired from the rml file. If you want "
                 "to use multiple input file, you can either specify the string of matching pattern with "
-                "quotation marks surrounding it, or put the file names in a .list file."
-             << RESTendl;
+                "quotation marks surrounding it, or put the file names in a .list file." << RESTendl;
     RESTcout.setheader("OUTPUT     : ");
     RESTcout << "-" << RESTendl;
     RESTcout << "Output file name. It can be given as a name string (abc.root), or as an expression "
-                "with naming fields to be replaced (Run[RunNumber]_[Tag].root)."
-             << RESTendl;
+                "with naming fields to be replaced (Run[RunNumber]_[Tag].root)." << RESTendl;
     RESTcout.setheader("THREADS    : ");
     RESTcout << "-" << RESTendl;
     RESTcout << "Enable specific number of threads to run the jobs. In most time 3~6 threads are "
-                "enough to make full use of computer power. Maximum is 15."
-             << RESTendl;
+                "enough to make full use of computer power. Maximum is 15." << RESTendl;
     RESTcout.setheader("");
     RESTcout << "=" << RESTendl;
 }
@@ -158,6 +153,7 @@ int main(int argc, char* argv[]) {
     // Load libraries
     TRestTools::LoadRESTLibrary(true);
     gInterpreter->ProcessLine("#define REST_MANAGER");
+    gVerbose = StringToVerboseLevel("2");
 
     // read arguments
     if (args.size() >= 2) {

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -352,7 +352,7 @@ void TRestDataSet::GenerateDataSet() {
     fDataSet = MakeCut(fCut);
 
     // Adding new user columns added to the dataset
-    for (const auto & [ cName, cExpression ] : fColumnNameExpressions) {
+    for (const auto& [cName, cExpression] : fColumnNameExpressions) {
         RESTInfo << "Adding column to dataset: " << cName << RESTendl;
         finalList.emplace_back(cName);
         fDataSet = DefineColumn(cName, cExpression);
@@ -383,7 +383,8 @@ std::vector<std::string> TRestDataSet::FileSelection() {
 
     if (!time_stamp_end || !time_stamp_start) {
         RESTError << "TRestDataSet::FileSelect. Start or end dates not properly formed. Please, check "
-                     "REST_StringHelper::StringToTimeStamp documentation for valid formats" << RESTendl;
+                     "REST_StringHelper::StringToTimeStamp documentation for valid formats"
+                  << RESTendl;
         return fFileSelection;
     }
 
@@ -438,7 +439,7 @@ std::vector<std::string> TRestDataSet::FileSelection() {
         if (!accept) continue;
 
         Double_t acc = 0;
-        for (auto & [ name, properties ] : fQuantity) {
+        for (auto& [name, properties] : fQuantity) {
             std::string value = run.ReplaceMetadataMembers(properties.metadata);
             const Double_t val = REST_StringHelper::StringToDouble(value);
 
@@ -495,7 +496,7 @@ ROOT::RDF::RNode TRestDataSet::MakeCut(const TRestCut* cut) {
 
     auto paramCut = cut->GetParamCut();
     auto obsList = df.GetColumnNames();
-    for (const auto & [ param, condition ] : paramCut) {
+    for (const auto& [param, condition] : paramCut) {
         if (std::find(obsList.begin(), obsList.end(), param) != obsList.end()) {
             std::string pCut = param + condition;
             RESTDebug << "Applying cut " << pCut << RESTendl;
@@ -542,7 +543,7 @@ ROOT::RDF::RNode TRestDataSet::DefineColumn(const std::string& columnName, const
     auto df = fDataSet;
 
     std::string evalFormula = formula;
-    for (auto const & [ name, properties ] : fQuantity)
+    for (auto const& [name, properties] : fQuantity)
         evalFormula = REST_StringHelper::Replace(evalFormula, name, properties.value);
 
     df = df.Define(columnName, evalFormula);
@@ -608,7 +609,7 @@ void TRestDataSet::PrintMetadata() {
         RESTMetadata << " Relevant quantities: " << RESTendl;
         RESTMetadata << " -------------------- " << RESTendl;
 
-        for (auto const & [ name, properties ] : fQuantity) {
+        for (auto const& [name, properties] : fQuantity) {
             RESTMetadata << " - Name : " << name << ". Value : " << properties.value
                          << ". Strategy: " << properties.strategy << RESTendl;
             RESTMetadata << " - Metadata: " << properties.metadata << RESTendl;
@@ -620,7 +621,7 @@ void TRestDataSet::PrintMetadata() {
     if (!fColumnNameExpressions.empty()) {
         RESTMetadata << " New columns added to generated dataframe: " << RESTendl;
         RESTMetadata << " ---------------------------------------- " << RESTendl;
-        for (const auto & [ cName, cExpression ] : fColumnNameExpressions)
+        for (const auto& [cName, cExpression] : fColumnNameExpressions)
             RESTMetadata << " - Name : " << cName << " Expression: " << cExpression << RESTendl;
     }
 
@@ -784,7 +785,8 @@ void TRestDataSet::Export(const std::string& filename) {
             if (type != "Double_t" && type != "Int_t") {
                 RESTError << "Branch name : " << bName << " is type : " << type << RESTendl;
                 RESTError << "Only Int_t and Double_t types are allowed for "
-                             "exporting to ASCII table" << RESTendl;
+                             "exporting to ASCII table"
+                          << RESTendl;
                 RESTError << "File will not be generated" << RESTendl;
                 return;
             }
@@ -819,7 +821,7 @@ void TRestDataSet::Export(const std::string& filename) {
         }
         fprintf(f, "###\n");
         fprintf(f, "### Relevant quantities: \n");
-        for (auto & [ name, properties ] : fQuantity) {
+        for (auto& [name, properties] : fQuantity) {
             fprintf(f, "### - %s : %s - %s\n", name.c_str(), properties.value.c_str(),
                     properties.description.c_str());
         }

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -345,20 +345,25 @@ void TRestDataSet::GenerateDataSet() {
 
     ROOT::EnableImplicitMT();
 
+    RESTInfo << "Initializing dataset" << RESTendl;
     fDataSet = ROOT::RDataFrame("AnalysisTree", fFileSelection);
 
+    RESTInfo << "Making cuts" << RESTendl;
     fDataSet = MakeCut(fCut);
 
     // Adding new user columns added to the dataset
-    for (const auto& [cName, cExpression] : fColumnNameExpressions) {
+    for (const auto & [ cName, cExpression ] : fColumnNameExpressions) {
+        RESTInfo << "Adding column to dataset: " << cName << RESTendl;
         finalList.emplace_back(cName);
         fDataSet = DefineColumn(cName, cExpression);
     }
 
+    RESTInfo << "Generating snapshot." << RESTendl;
     std::string user = getenv("USER");
     std::string fOutName = "/tmp/rest_output_" + user + ".root";
     fDataSet.Snapshot("AnalysisTree", fOutName, finalList);
 
+    RESTInfo << "Re-importing analysis tree." << RESTendl;
     fDataSet = ROOT::RDataFrame("AnalysisTree", fOutName);
 
     TFile* f = TFile::Open(fOutName.c_str());
@@ -378,8 +383,7 @@ std::vector<std::string> TRestDataSet::FileSelection() {
 
     if (!time_stamp_end || !time_stamp_start) {
         RESTError << "TRestDataSet::FileSelect. Start or end dates not properly formed. Please, check "
-                     "REST_StringHelper::StringToTimeStamp documentation for valid formats"
-                  << RESTendl;
+                     "REST_StringHelper::StringToTimeStamp documentation for valid formats" << RESTendl;
         return fFileSelection;
     }
 
@@ -392,8 +396,17 @@ std::vector<std::string> TRestDataSet::FileSelection() {
     }
 
     fTotalDuration = 0;
+    std::cout << "Total files : " << fileNames.size() << std::endl;
+    std::cout << "Processing file selection .";
+    int cnt = 1;
     for (const auto& file : fileNames) {
+        if (cnt % 100 == 0) {
+            std::cout << std::endl;
+            std::cout << "Files processed: " << cnt << " ." << std::flush;
+        }
+        cnt++;
         TRestRun run(file);
+        std::cout << "." << std::flush;
         double runStart = run.GetStartTimestamp();
         double runEnd = run.GetEndTimestamp();
 
@@ -425,7 +438,7 @@ std::vector<std::string> TRestDataSet::FileSelection() {
         if (!accept) continue;
 
         Double_t acc = 0;
-        for (auto& [name, properties] : fQuantity) {
+        for (auto & [ name, properties ] : fQuantity) {
             std::string value = run.ReplaceMetadataMembers(properties.metadata);
             const Double_t val = REST_StringHelper::StringToDouble(value);
 
@@ -464,7 +477,7 @@ std::vector<std::string> TRestDataSet::FileSelection() {
         fTotalDuration += run.GetEndTimestamp() - run.GetStartTimestamp();
         fFileSelection.push_back(file);
     }
-    RESTInfo << RESTendl;
+    std::cout << std::endl;
 
     return fFileSelection;
 }
@@ -482,7 +495,7 @@ ROOT::RDF::RNode TRestDataSet::MakeCut(const TRestCut* cut) {
 
     auto paramCut = cut->GetParamCut();
     auto obsList = df.GetColumnNames();
-    for (const auto& [param, condition] : paramCut) {
+    for (const auto & [ param, condition ] : paramCut) {
         if (std::find(obsList.begin(), obsList.end(), param) != obsList.end()) {
             std::string pCut = param + condition;
             RESTDebug << "Applying cut " << pCut << RESTendl;
@@ -529,7 +542,7 @@ ROOT::RDF::RNode TRestDataSet::DefineColumn(const std::string& columnName, const
     auto df = fDataSet;
 
     std::string evalFormula = formula;
-    for (auto const& [name, properties] : fQuantity)
+    for (auto const & [ name, properties ] : fQuantity)
         evalFormula = REST_StringHelper::Replace(evalFormula, name, properties.value);
 
     df = df.Define(columnName, evalFormula);
@@ -595,7 +608,7 @@ void TRestDataSet::PrintMetadata() {
         RESTMetadata << " Relevant quantities: " << RESTendl;
         RESTMetadata << " -------------------- " << RESTendl;
 
-        for (auto const& [name, properties] : fQuantity) {
+        for (auto const & [ name, properties ] : fQuantity) {
             RESTMetadata << " - Name : " << name << ". Value : " << properties.value
                          << ". Strategy: " << properties.strategy << RESTendl;
             RESTMetadata << " - Metadata: " << properties.metadata << RESTendl;
@@ -607,7 +620,7 @@ void TRestDataSet::PrintMetadata() {
     if (!fColumnNameExpressions.empty()) {
         RESTMetadata << " New columns added to generated dataframe: " << RESTendl;
         RESTMetadata << " ---------------------------------------- " << RESTendl;
-        for (const auto& [cName, cExpression] : fColumnNameExpressions)
+        for (const auto & [ cName, cExpression ] : fColumnNameExpressions)
             RESTMetadata << " - Name : " << cName << " Expression: " << cExpression << RESTendl;
     }
 
@@ -760,6 +773,7 @@ void TRestDataSet::InitFromConfigFile() {
 /// of the TRestDataSet instance that contains the conditions used to generate the dataset.
 ///
 void TRestDataSet::Export(const std::string& filename) {
+    RESTInfo << "Exporting dataset" << RESTendl;
     if (TRestTools::GetFileNameExtension(filename) == "txt" ||
         TRestTools::GetFileNameExtension(filename) == "csv") {
         std::vector<std::string> dataTypes;
@@ -770,8 +784,7 @@ void TRestDataSet::Export(const std::string& filename) {
             if (type != "Double_t" && type != "Int_t") {
                 RESTError << "Branch name : " << bName << " is type : " << type << RESTendl;
                 RESTError << "Only Int_t and Double_t types are allowed for "
-                             "exporting to ASCII table"
-                          << RESTendl;
+                             "exporting to ASCII table" << RESTendl;
                 RESTError << "File will not be generated" << RESTendl;
                 return;
             }
@@ -806,7 +819,7 @@ void TRestDataSet::Export(const std::string& filename) {
         }
         fprintf(f, "###\n");
         fprintf(f, "### Relevant quantities: \n");
-        for (auto& [name, properties] : fQuantity) {
+        for (auto & [ name, properties ] : fQuantity) {
             fprintf(f, "### - %s : %s - %s\n", name.c_str(), properties.value.c_str(),
                     properties.description.c_str());
         }


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 17](https://badgen.net/badge/PR%20Size/Ok%3A%2017/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan-dataset)](https://github.com/rest-for-physics/framework/commits/jgalan-dataset)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adding more output inside `TRestDataSet::GenerateDataSet` to know the state of dataset compilation.

Adding progress bar at the file selection stage
