### PR TITLE
REST_OpenInputFile.C. Fixing instance name containing minus sign

### DIFF
--- a/macros/REST_OpenInputFile.C
+++ b/macros/REST_OpenInputFile.C
@@ -29,6 +29,7 @@ void REST_OpenInputFile(const std::string& fileName) {
             }
             std::string mName = Replace(metaName, " ", "");
             mName = Replace(mName, ".", "_");
+            mName = Replace(mName, "-", "_");
             std::string mdcmd = Form("%s* %s = (%s*)run->GetMetadata(\"%s\");", md->ClassName(),
                                      mName.c_str(), md->ClassName(), metaName.c_str());
             gROOT->ProcessLine(mdcmd.c_str());


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=restRoot_fix)](https://github.com/rest-for-physics/framework/commits/restRoot_fix)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Fixes an issue opening with `restRoot` when the name contains minus signs.

<img width="1440" alt="Screenshot 2023-07-21 at 11 48 18" src="https://github.com/rest-for-physics/framework/assets/12447509/d0562b63-c214-44e5-9a26-1f74a68376ee">
