### PR TITLE
Addressing warning on TResHits_Iterator in latest compiler (12.2.0)

### DIFF
--- a/source/framework/core/inc/TRestHits.h
+++ b/source/framework/core/inc/TRestHits.h
@@ -197,7 +197,13 @@ class TRestHits {
 
     virtual void PrintHits(Int_t nHits = -1) const;
 
-    class TRestHits_Iterator : public std::iterator<std::random_access_iterator_tag, TRestHits_Iterator> {
+     class TRestHits_Iterator {
+       public:
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = TRestHits_Iterator;
+        using difference_type = int;
+        using pointer = void;
+        using reference = void;
        private:
         int maxIndex = 0;
         int index = 0;

--- a/source/framework/core/inc/TRestHits.h
+++ b/source/framework/core/inc/TRestHits.h
@@ -197,13 +197,14 @@ class TRestHits {
 
     virtual void PrintHits(Int_t nHits = -1) const;
 
-     class TRestHits_Iterator {
+    class TRestHits_Iterator {
        public:
         using iterator_category = std::random_access_iterator_tag;
         using value_type = TRestHits_Iterator;
         using difference_type = int;
         using pointer = void;
         using reference = void;
+
        private:
         int maxIndex = 0;
         int index = 0;


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 8](https://badgen.net/badge/PR%20Size/Ok%3A%208/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=iterator_warning)](https://github.com/rest-for-physics/framework/commits/iterator_warning)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Warning found on sultan with latest Debian version (12.2) and gcc compiler 12.2.0
The warning is because inheritance of `std::iterator` is deprecated, this PR address this warning is by using declarations inside `TRestHits_Iterator`