### PR TITLE
Add x_sep to integrate NuSTAR like telescopes

### DIFF
--- a/source/framework/tools/inc/TRestPhysics.h
+++ b/source/framework/tools/inc/TRestPhysics.h
@@ -76,10 +76,10 @@ TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, TV
                                     TVector3 const& a);
 
 TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
-                                        const Double_t R3, const Double_t lMirr);
+                                        const Double_t R3, const Double_t lMirr, const Double_t x_sep);
 
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
-                                         const Double_t R3, const Double_t lMirr, const Double_t focal);
+                                         const Double_t R3, const Double_t lMirr, const Double_t focal, const Double_t x_sep);
 
 TVector3 GetConeNormal(const TVector3& pos, const Double_t alpha, const Double_t R = 0);
 

--- a/source/framework/tools/inc/TRestPhysics.h
+++ b/source/framework/tools/inc/TRestPhysics.h
@@ -79,7 +79,8 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
                                         const Double_t R3, const Double_t lMirr, const Double_t x_sep);
 
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
-                                         const Double_t R3, const Double_t lMirr, const Double_t focal, const Double_t x_sep);
+                                         const Double_t R3, const Double_t lMirr, const Double_t focal,
+                                         const Double_t x_sep);
 
 TVector3 GetConeNormal(const TVector3& pos, const Double_t alpha, const Double_t R = 0);
 

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -92,7 +92,8 @@ TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, co
 /// In case no intersection is found this method returns the unmodified input position
 ///
 TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
-                                        const Double_t R3, const Double_t lMirr) {
+                                        const Double_t R3, const Double_t lMirr, const Double_t x_sep) {
+    pos.Z() += 0.5 * x_sep;
     Double_t e = 2 * R3 * TMath::Tan(alpha);
     Double_t a = dir.X() * dir.X() + dir.Y() * dir.Y();
     Double_t b = 2 * (pos.X() * dir.X() + pos.Y() * dir.Y()) + e * dir.Z();
@@ -120,7 +121,8 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
 /// In case no intersection is found this method returns the unmodified input position
 ///
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
-                                         const Double_t R3, const Double_t lMirr, const Double_t focal) {
+                                         const Double_t R3, const Double_t lMirr, const Double_t focal, const Double_t x_sep) {
+    pos.Z() -= 0.5 * x_sep;
     Double_t beta = 3 * alpha;
     Double_t e = 2 * R3 * TMath::Tan(beta);
     /// Just replaced here *TMath::Cot by /TMath::Tan to fix compilation issues

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -121,7 +121,8 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
 /// In case no intersection is found this method returns the unmodified input position
 ///
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
-                                         const Double_t R3, const Double_t lMirr, const Double_t focal, const Double_t x_sep) {
+                                         const Double_t R3, const Double_t lMirr, const Double_t focal,
+                                         const Double_t x_sep) {
     pos.Z() -= 0.5 * x_sep;
     Double_t beta = 3 * alpha;
     Double_t e = 2 * R3 * TMath::Tan(beta);

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -104,7 +104,8 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
         Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
         if (pos.Z() + root1 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and pos.Z() + root1 * dir.Z() < 0) {
             return pos + root1 * dir;
-        } else if (pos.Z() + root2 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and pos.Z() + root2 * dir.Z() < 0) {
+        } else if (pos.Z() + root2 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and
+                   pos.Z() + root2 * dir.Z() < 0) {
             return pos + root2 * dir;
         }
         return pos;

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -102,9 +102,9 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
     if (a != 0) {
         Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
         Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
-        if (pos.Z() + root1 * dir.Z() > -lMirr and pos.Z() + root1 * dir.Z() < 0) {
+        if (pos.Z() + root1 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and pos.Z() + root1 * dir.Z() < 0) {
             return pos + root1 * dir;
-        } else if (pos.Z() + root2 * dir.Z() > -lMirr and pos.Z() + root2 * dir.Z() < 0) {
+        } else if (pos.Z() + root2 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and pos.Z() + root2 * dir.Z() < 0) {
             return pos + root2 * dir;
         }
         return pos;
@@ -134,9 +134,9 @@ TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& di
     Double_t c = pos.X() * pos.X() + pos.Y() * pos.Y() - R3 * R3 + e * pos.Z() - g * pos.Z() * pos.Z();
     Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
     Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
-    if (pos.Z() + root1 * dir.Z() > 0 and pos.Z() + root1 * dir.Z() < lMirr) {
+    if (pos.Z() + root1 * dir.Z() > 0 and pos.Z() + root1 * dir.Z() < (lMirr * TMath::Cos(beta))) {
         return pos + root1 * dir;
-    } else if (pos.Z() + root2 * dir.Z() > 0 and pos.Z() + root2 * dir.Z() < lMirr) {
+    } else if (pos.Z() + root2 * dir.Z() > 0 and pos.Z() + root2 * dir.Z() < (lMirr * TMath::Cos(beta))) {
         return pos + root2 * dir;
     }
 

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -103,9 +103,11 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
         Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
         Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
         if (pos.Z() + root1 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and pos.Z() + root1 * dir.Z() < 0) {
+            pos.Z() -= 0.5 * x_sep;
             return pos + root1 * dir;
         } else if (pos.Z() + root2 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and
                    pos.Z() + root2 * dir.Z() < 0) {
+            pos.Z() -= 0.5 * x_sep;
             return pos + root2 * dir;
         }
         return pos;
@@ -136,8 +138,10 @@ TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& di
     Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
     Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
     if (pos.Z() + root1 * dir.Z() > 0 and pos.Z() + root1 * dir.Z() < (lMirr * TMath::Cos(beta))) {
+        pos.Z() += 0.5 * x_sep;
         return pos + root1 * dir;
     } else if (pos.Z() + root2 * dir.Z() > 0 and pos.Z() + root2 * dir.Z() < (lMirr * TMath::Cos(beta))) {
+        pos.Z() += 0.5 * x_sep;
         return pos + root2 * dir;
     }
 


### PR DESCRIPTION
![jovoy](https://badgen.net/badge/PR%20submitted%20by%3A/jovoy/blue) ![Ok: 17](https://badgen.net/badge/PR%20Size/Ok%3A%2017/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jovoy_x_sep)](https://github.com/rest-for-physics/framework/commits/jovoy_x_sep)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

X_sep is the distance between the two mirror shells. In the framework it has to be added to the parabolic and hyperbolic mirror functions.