### PR TITLE
Add x_sep to integrate NuSTAR like optics

### DIFF
--- a/source/framework/tools/inc/TRestPhysics.h
+++ b/source/framework/tools/inc/TRestPhysics.h
@@ -76,10 +76,10 @@ TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, TV
                                     TVector3 const& a);
 
 TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
-                                        const Double_t R3, const Double_t lMirr);
+                                        const Double_t R3, const Double_t lMirr, const Double_t x_sep);
 
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
-                                         const Double_t R3, const Double_t lMirr, const Double_t focal);
+                                         const Double_t R3, const Double_t lMirr, const Double_t focal, const Double_t x_sep);
 
 TVector3 GetConeNormal(const TVector3& pos, const Double_t alpha, const Double_t R = 0);
 

--- a/source/framework/tools/inc/TRestPhysics.h
+++ b/source/framework/tools/inc/TRestPhysics.h
@@ -79,7 +79,8 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
                                         const Double_t R3, const Double_t lMirr, const Double_t x_sep);
 
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
-                                         const Double_t R3, const Double_t lMirr, const Double_t focal, const Double_t x_sep);
+                                         const Double_t R3, const Double_t lMirr, const Double_t focal,
+                                         const Double_t x_sep);
 
 TVector3 GetConeNormal(const TVector3& pos, const Double_t alpha, const Double_t R = 0);
 

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -92,7 +92,8 @@ TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, co
 /// In case no intersection is found this method returns the unmodified input position
 ///
 TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
-                                        const Double_t R3, const Double_t lMirr) {
+                                        const Double_t R3, const Double_t lMirr, const Double_t x_sep) {
+    pos.Z() += 0.5 * x_sep;
     Double_t e = 2 * R3 * TMath::Tan(alpha);
     Double_t a = dir.X() * dir.X() + dir.Y() * dir.Y();
     Double_t b = 2 * (pos.X() * dir.X() + pos.Y() * dir.Y()) + e * dir.Z();
@@ -102,8 +103,10 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
         Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
         Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
         if (pos.Z() + root1 * dir.Z() > -lMirr and pos.Z() + root1 * dir.Z() < 0) {
+            pos.Z() -= 0.5 * x_sep;
             return pos + root1 * dir;
         } else if (pos.Z() + root2 * dir.Z() > -lMirr and pos.Z() + root2 * dir.Z() < 0) {
+            pos.Z() -= 0.5 * x_sep;
             return pos + root2 * dir;
         }
         return pos;
@@ -120,7 +123,8 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
 /// In case no intersection is found this method returns the unmodified input position
 ///
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
-                                         const Double_t R3, const Double_t lMirr, const Double_t focal) {
+                                         const Double_t R3, const Double_t lMirr, const Double_t focal, const Double_t x_sep) {
+    pos.Z() -= 0.5 * x_sep;
     Double_t beta = 3 * alpha;
     Double_t e = 2 * R3 * TMath::Tan(beta);
     /// Just replaced here *TMath::Cot by /TMath::Tan to fix compilation issues
@@ -132,8 +136,10 @@ TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& di
     Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
     Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
     if (pos.Z() + root1 * dir.Z() > 0 and pos.Z() + root1 * dir.Z() < lMirr) {
+        pos.Z() += 0.5 * x_sep;
         return pos + root1 * dir;
     } else if (pos.Z() + root2 * dir.Z() > 0 and pos.Z() + root2 * dir.Z() < lMirr) {
+        pos.Z() += 0.5 * x_sep;
         return pos + root2 * dir;
     }
 

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -102,10 +102,10 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
     if (a != 0) {
         Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
         Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
-        if (pos.Z() + root1 * dir.Z() > -lMirr and pos.Z() + root1 * dir.Z() < 0) {
+        if (pos.Z() + root1 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and pos.Z() + root1 * dir.Z() < 0) {
             pos.Z() -= 0.5 * x_sep;
             return pos + root1 * dir;
-        } else if (pos.Z() + root2 * dir.Z() > -lMirr and pos.Z() + root2 * dir.Z() < 0) {
+        } else if (pos.Z() + root2 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and pos.Z() + root2 * dir.Z() < 0) {
             pos.Z() -= 0.5 * x_sep;
             return pos + root2 * dir;
         }
@@ -135,10 +135,10 @@ TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& di
     Double_t c = pos.X() * pos.X() + pos.Y() * pos.Y() - R3 * R3 + e * pos.Z() - g * pos.Z() * pos.Z();
     Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
     Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
-    if (pos.Z() + root1 * dir.Z() > 0 and pos.Z() + root1 * dir.Z() < lMirr) {
+    if (pos.Z() + root1 * dir.Z() > 0 and pos.Z() + root1 * dir.Z() < (lMirr * TMath::Cos(alpha))) {
         pos.Z() += 0.5 * x_sep;
         return pos + root1 * dir;
-    } else if (pos.Z() + root2 * dir.Z() > 0 and pos.Z() + root2 * dir.Z() < lMirr) {
+    } else if (pos.Z() + root2 * dir.Z() > 0 and pos.Z() + root2 * dir.Z() < (lMirr * TMath::Cos(alpha))) {
         pos.Z() += 0.5 * x_sep;
         return pos + root2 * dir;
     }

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -105,7 +105,8 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
         if (pos.Z() + root1 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and pos.Z() + root1 * dir.Z() < 0) {
             pos.Z() -= 0.5 * x_sep;
             return pos + root1 * dir;
-        } else if (pos.Z() + root2 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and pos.Z() + root2 * dir.Z() < 0) {
+        } else if (pos.Z() + root2 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and
+                   pos.Z() + root2 * dir.Z() < 0) {
             pos.Z() -= 0.5 * x_sep;
             return pos + root2 * dir;
         }
@@ -123,7 +124,8 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
 /// In case no intersection is found this method returns the unmodified input position
 ///
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
-                                         const Double_t R3, const Double_t lMirr, const Double_t focal, const Double_t x_sep) {
+                                         const Double_t R3, const Double_t lMirr, const Double_t focal,
+                                         const Double_t x_sep) {
     pos.Z() -= 0.5 * x_sep;
     Double_t beta = 3 * alpha;
     Double_t e = 2 * R3 * TMath::Tan(beta);

--- a/source/framework/tools/src/TRestPhysics.cxx
+++ b/source/framework/tools/src/TRestPhysics.cxx
@@ -93,7 +93,6 @@ TVector3 GetPlaneVectorIntersection(const TVector3& pos, const TVector3& dir, co
 ///
 TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
                                         const Double_t R3, const Double_t lMirr, const Double_t x_sep) {
-    pos.Z() += 0.5 * x_sep;
     Double_t e = 2 * R3 * TMath::Tan(alpha);
     Double_t a = dir.X() * dir.X() + dir.Y() * dir.Y();
     Double_t b = 2 * (pos.X() * dir.X() + pos.Y() * dir.Y()) + e * dir.Z();
@@ -103,11 +102,9 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
         Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
         Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
         if (pos.Z() + root1 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and pos.Z() + root1 * dir.Z() < 0) {
-            pos.Z() -= 0.5 * x_sep;
             return pos + root1 * dir;
         } else if (pos.Z() + root2 * dir.Z() > -(lMirr * TMath::Cos(alpha)) and
                    pos.Z() + root2 * dir.Z() < 0) {
-            pos.Z() -= 0.5 * x_sep;
             return pos + root2 * dir;
         }
         return pos;
@@ -126,7 +123,6 @@ TVector3 GetParabolicVectorIntersection(const TVector3& pos, const TVector3& dir
 TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& dir, const Double_t alpha,
                                          const Double_t R3, const Double_t lMirr, const Double_t focal,
                                          const Double_t x_sep) {
-    pos.Z() -= 0.5 * x_sep;
     Double_t beta = 3 * alpha;
     Double_t e = 2 * R3 * TMath::Tan(beta);
     /// Just replaced here *TMath::Cot by /TMath::Tan to fix compilation issues
@@ -138,10 +134,8 @@ TVector3 GetHyperbolicVectorIntersection(const TVector3& pos, const TVector3& di
     Double_t root1 = (-half_b - TMath::Sqrt(half_b * half_b - a * c)) / a;
     Double_t root2 = (-half_b + TMath::Sqrt(half_b * half_b - a * c)) / a;
     if (pos.Z() + root1 * dir.Z() > 0 and pos.Z() + root1 * dir.Z() < (lMirr * TMath::Cos(alpha))) {
-        pos.Z() += 0.5 * x_sep;
         return pos + root1 * dir;
     } else if (pos.Z() + root2 * dir.Z() > 0 and pos.Z() + root2 * dir.Z() < (lMirr * TMath::Cos(alpha))) {
-        pos.Z() += 0.5 * x_sep;
         return pos + root2 * dir;
     }
 


### PR DESCRIPTION
![jovoy](https://badgen.net/badge/PR%20submitted%20by%3A/jovoy/blue) ![Ok: 11](https://badgen.net/badge/PR%20Size/Ok%3A%2011/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jovoy-x_sep)](https://github.com/rest-for-physics/framework/commits/jovoy-x_sep)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

X_sep is the distance between the two mirror shells. In the framework it has to be added to the parabolic and hyperbolic mirror functions.
Update: x_sep now has to be added into the interaction between vector and cone.