### PR TITLE
Removal of custom typedef any since it is misleading with std::any

### DIFF
--- a/source/framework/analysis/inc/TRestBenchMarkProcess.h
+++ b/source/framework/analysis/inc/TRestBenchMarkProcess.h
@@ -53,8 +53,8 @@ class TRestBenchMarkProcess : public TRestEventProcess {
 
    protected:
    public:
-    any GetInputEvent() const override { return fEvent; }
-    any GetOutputEvent() const override { return fEvent; }
+    RESTValue GetInputEvent() const override { return fEvent; }
+    RESTValue GetOutputEvent() const override { return fEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/source/framework/analysis/inc/TRestDataQualityProcess.h
+++ b/source/framework/analysis/inc/TRestDataQualityProcess.h
@@ -61,8 +61,8 @@ class TRestDataQualityProcess : public TRestEventProcess {
 
    protected:
    public:
-    any GetInputEvent() const override { return fEvent; }
-    any GetOutputEvent() const override { return fEvent; }
+    RESTValue GetInputEvent() const override { return fEvent; }
+    RESTValue GetOutputEvent() const override { return fEvent; }
 
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
 

--- a/source/framework/analysis/inc/TRestEventRateAnalysisProcess.h
+++ b/source/framework/analysis/inc/TRestEventRateAnalysisProcess.h
@@ -46,8 +46,8 @@ class TRestEventRateAnalysisProcess : public TRestEventProcess {
     // add here the members of your event process
 
    public:
-    any GetInputEvent() const override { return fEvent; }
-    any GetOutputEvent() const override { return fEvent; }
+    RESTValue GetInputEvent() const override { return fEvent; }
+    RESTValue GetOutputEvent() const override { return fEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/source/framework/analysis/inc/TRestEventSelectionProcess.h
+++ b/source/framework/analysis/inc/TRestEventSelectionProcess.h
@@ -44,8 +44,8 @@ class TRestEventSelectionProcess : public TRestEventProcess {
 
    protected:
    public:
-    any GetInputEvent() const override { return fEvent; }
-    any GetOutputEvent() const override { return fEvent; }
+    RESTValue GetInputEvent() const override { return fEvent; }
+    RESTValue GetOutputEvent() const override { return fEvent; }
 
     void InitProcess() override;
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;

--- a/source/framework/analysis/inc/TRestMySQLToAnalysisProcess.h
+++ b/source/framework/analysis/inc/TRestMySQLToAnalysisProcess.h
@@ -92,8 +92,8 @@ class TRestMySQLToAnalysisProcess : public TRestEventProcess {
     void LoadDefaultConfig();
 
    public:
-    any GetInputEvent() const override { return fEvent; }
-    any GetOutputEvent() const override { return fEvent; }
+    RESTValue GetInputEvent() const override { return fEvent; }
+    RESTValue GetOutputEvent() const override { return fEvent; }
 
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
 

--- a/source/framework/analysis/inc/TRestRealTimeAddInputFileProcess.h
+++ b/source/framework/analysis/inc/TRestRealTimeAddInputFileProcess.h
@@ -45,8 +45,8 @@ class TRestRealTimeAddInputFileProcess : public TRestEventProcess {
     // if you don't want to save them as "metadata".
 
    public:
-    any GetInputEvent() const override { return fEvent; }
-    any GetOutputEvent() const override { return fEvent; }
+    RESTValue GetInputEvent() const override { return fEvent; }
+    RESTValue GetOutputEvent() const override { return fEvent; }
 
     void InitProcess() override;
 

--- a/source/framework/analysis/inc/TRestRealTimeDrawingProcess.h
+++ b/source/framework/analysis/inc/TRestRealTimeDrawingProcess.h
@@ -56,8 +56,8 @@ class TRestRealTimeDrawingProcess : public TRestEventProcess {
 
    protected:
    public:
-    any GetInputEvent() const override { return fEvent; }
-    any GetOutputEvent() const override { return fEvent; }
+    RESTValue GetInputEvent() const override { return fEvent; }
+    RESTValue GetOutputEvent() const override { return fEvent; }
 
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
 

--- a/source/framework/analysis/inc/TRestSummaryProcess.h
+++ b/source/framework/analysis/inc/TRestSummaryProcess.h
@@ -73,8 +73,8 @@ class TRestSummaryProcess : public TRestEventProcess {
 
    protected:
    public:
-    any GetInputEvent() const override { return fEvent; }
-    any GetOutputEvent() const override { return fEvent; }
+    RESTValue GetInputEvent() const override { return fEvent; }
+    RESTValue GetOutputEvent() const override { return fEvent; }
 
     TRestEvent* ProcessEvent(TRestEvent* inputEvent) override;
 

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -2305,7 +2305,7 @@ std::string TRestMetadata::GetConfigBuffer() { return configBuffer; }
 /// All kinds of data member can be found, including non-streamed
 /// data member and base-class data member
 string TRestMetadata::GetDataMemberValue(string memberName) {
-    return any(this, this->ClassName()).GetDataMemberValueString(memberName);
+    return RESTValue(this, this->ClassName()).GetDataMemberValueString(memberName);
 }
 
 ///////////////////////////////////////////////

--- a/source/framework/core/src/TRestTask.cxx
+++ b/source/framework/core/src/TRestTask.cxx
@@ -245,10 +245,10 @@ void TRestTask::PrintArgumentHelp() {
     } else if (fMode == 2) {
         RESTError << "Macro class \"" << this->ClassName() << "\" gets invalided input!" << RESTendl;
         RESTError << "You should give the following arguments ( * : necessary input):" << RESTendl;
-        unsigned int n = any(this).GetNumberOfDataMembers();
+        unsigned int n = RESTValue(this).GetNumberOfDataMembers();
         for (unsigned int i = 1; i < n; i++) {
             if (i < fNRequiredArgument + 1) RESTError << "*";
-            RESTError << any(this).GetDataMember(i).name << RESTendl;
+            RESTError << RESTValue(this).GetDataMember(i).name << RESTendl;
         }
     }
 }

--- a/source/framework/tools/inc/TRestReflector.h
+++ b/source/framework/tools/inc/TRestReflector.h
@@ -418,7 +418,6 @@ TRestReflector WrapType(std::string typeName);
 void CloneAny(TRestReflector from, TRestReflector to);
 };  // namespace REST_Reflection
 
-typedef REST_Reflection::TRestReflector any;
 typedef REST_Reflection::TRestReflector RESTValue;
 
 class RESTVirtualConverter {


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 19](https://badgen.net/badge/PR%20Size/Ok%3A%2019/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=any_to_RESTValue)](https://github.com/rest-for-physics/framework/commits/any_to_RESTValue)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Removal of custom `typedef REST_Reflection::TRestReflector any` since it is misleading with `std::any`.

The custom typedef `any` has been replaced by existing `typedef REST_Reflection::TRestReflector RESTValue`

Related PR:
https://github.com/rest-for-physics/detectorlib/pull/100
https://github.com/rest-for-physics/rawlib/pull/121
https://github.com/rest-for-physics/geant4lib/pull/111
https://github.com/rest-for-physics/tracklib/pull/37
https://github.com/rest-for-physics/legacylib/pull/10
https://github.com/rest-for-physics/connectorslib/pull/39
