### PR TITLE
RML metadata instances will allow now env variables in the name definition.

### DIFF
--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -1144,9 +1144,10 @@ void TRestMetadata::ReplaceForLoopVars(TiXmlElement* e, map<string, string> forL
                 }
             }
 
-            e->SetAttribute(name, ReplaceMathematicalExpressions(outputBuffer, 0,
-                                                                 "Please, check parameter name: " + parName +
-                                                                     " (ReplaceForLoopVars)").c_str());
+            e->SetAttribute(name, ReplaceMathematicalExpressions(
+                                      outputBuffer, 0,
+                                      "Please, check parameter name: " + parName + " (ReplaceForLoopVars)")
+                                      .c_str());
         }
 
         attr = attr->Next();
@@ -1299,7 +1300,8 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
             TiXmlElement* ele = GetElementFromFile(filename);
             if (ele == nullptr) {
                 RESTError << "TRestMetadata::ExpandIncludeFile. No xml elements contained in the include "
-                             "file \"" << filename << "\"" << RESTendl;
+                             "file \""
+                          << filename << "\"" << RESTendl;
                 exit(1);
             }
             while (ele != nullptr) {
@@ -1381,7 +1383,8 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
 
                 if (remoteele == nullptr) {
                     RESTWarning << "Cannot find the needed xml section in "
-                                   "include file!" << RESTendl;
+                                   "include file!"
+                                << RESTendl;
                     RESTWarning << "type: \"" << type << "\" , name: \"" << name << "\" . Skipping"
                                 << RESTendl;
                     RESTWarning << RESTendl;
@@ -2264,7 +2267,8 @@ TString TRestMetadata::GetLibraryVersion() { return fLibraryVersion; }
 void TRestMetadata::ReSetVersion() {
     if (!this->InheritsFrom("TRestRun"))
         RESTError << "version is a static value, you cannot set version "
-                     "for a class!" << RESTendl;
+                     "for a class!"
+                  << RESTendl;
     else {
         fVersion = REST_RELEASE;
     }
@@ -2276,7 +2280,8 @@ void TRestMetadata::ReSetVersion() {
 void TRestMetadata::UnSetVersion() {
     if (!this->InheritsFrom("TRestRun"))
         RESTError << "version is a static value, you cannot set version "
-                     "for a class!" << RESTendl;
+                     "for a class!"
+                  << RESTendl;
     else {
         fVersion = -1;
         fCommit = -1;
@@ -2541,7 +2546,8 @@ void TRestMetadata::ReadOneParameter(string name, string value) {
                     } else {
                         RESTWarning << this->ClassName() << " find unit definition in parameter: " << name
                                     << ", but the corresponding data member doesn't support it. Data "
-                                       "member type: " << datamember.type << RESTendl;
+                                       "member type: "
+                                    << datamember.type << RESTendl;
                         datamember.ParseString(value);
                     }
                 } else {

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -1144,10 +1144,9 @@ void TRestMetadata::ReplaceForLoopVars(TiXmlElement* e, map<string, string> forL
                 }
             }
 
-            e->SetAttribute(name, ReplaceMathematicalExpressions(
-                                      outputBuffer, 0,
-                                      "Please, check parameter name: " + parName + " (ReplaceForLoopVars)")
-                                      .c_str());
+            e->SetAttribute(name, ReplaceMathematicalExpressions(outputBuffer, 0,
+                                                                 "Please, check parameter name: " + parName +
+                                                                     " (ReplaceForLoopVars)").c_str());
         }
 
         attr = attr->Next();
@@ -1300,8 +1299,7 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
             TiXmlElement* ele = GetElementFromFile(filename);
             if (ele == nullptr) {
                 RESTError << "TRestMetadata::ExpandIncludeFile. No xml elements contained in the include "
-                             "file \""
-                          << filename << "\"" << RESTendl;
+                             "file \"" << filename << "\"" << RESTendl;
                 exit(1);
             }
             while (ele != nullptr) {
@@ -1383,8 +1381,7 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
 
                 if (remoteele == nullptr) {
                     RESTWarning << "Cannot find the needed xml section in "
-                                   "include file!"
-                                << RESTendl;
+                                   "include file!" << RESTendl;
                     RESTWarning << "type: \"" << type << "\" , name: \"" << name << "\" . Skipping"
                                 << RESTendl;
                     RESTWarning << RESTendl;
@@ -1669,7 +1666,7 @@ TVector3 TRestMetadata::Get3DVectorParameterWithUnits(std::string parName, TVect
 /// Exits the whole program if the xml file does not exist, or is in wrong in
 /// syntax. Returns NULL if no element matches NameOrDecalre
 ///
-TiXmlElement* TRestMetadata::GetElementFromFile(std::string configFilename, std::string NameOrDecalre) {
+TiXmlElement* TRestMetadata::GetElementFromFile(std::string configFilename, std::string NameOrDeclare) {
     TiXmlDocument doc;
     TiXmlElement* rootele;
 
@@ -1693,26 +1690,27 @@ TiXmlElement* TRestMetadata::GetElementFromFile(std::string configFilename, std:
                   << RESTendl;
         exit(1);
     }
-    if (NameOrDecalre == "") {
+    if (NameOrDeclare == "") {
         return (TiXmlElement*)rootele->Clone();
     }
     // search with either name or declare in either root element or sub-root
     // element
     while (rootele != nullptr) {
-        if (rootele->Value() != nullptr && (string)rootele->Value() == NameOrDecalre) {
+        if (rootele->Value() != nullptr && (string)rootele->Value() == NameOrDeclare) {
             return (TiXmlElement*)rootele->Clone();
         }
 
-        if (rootele->Attribute("name") != nullptr && (string)rootele->Attribute("name") == NameOrDecalre) {
+        if (rootele->Attribute("name") != nullptr && (string)rootele->Attribute("name") == NameOrDeclare) {
             return (TiXmlElement*)rootele->Clone();
         }
 
-        TiXmlElement* etemp = GetElement(NameOrDecalre, rootele);
+        TiXmlElement* etemp = GetElement(NameOrDeclare, rootele);
         if (etemp != nullptr) {
             return (TiXmlElement*)etemp->Clone();
         }
 
-        etemp = GetElementWithName("", NameOrDecalre, rootele);
+        etemp = GetElementWithName("", NameOrDeclare, rootele);
+
         if (etemp != nullptr) {
             return (TiXmlElement*)etemp->Clone();
         }
@@ -1721,7 +1719,7 @@ TiXmlElement* TRestMetadata::GetElementFromFile(std::string configFilename, std:
     }
 
     return nullptr;
-    /*ferr << "Cannot find xml element with name \""<< NameOrDecalre <<"\" in rml
+    /*ferr << "Cannot find xml element with name \""<< NameOrDeclare <<"\" in rml
     file \"" << configFilename << endl; GetChar(); exit(1);*/
 }
 
@@ -1761,8 +1759,12 @@ TiXmlElement* TRestMetadata::GetElementWithName(std::string eleDeclare, std::str
     {
         TiXmlElement* ele = e->FirstChildElement();
         while (ele != nullptr) {
-            if (ele->Attribute("name") != nullptr && (string)ele->Attribute("name") == eleName) {
-                return ele;
+            if (ele->Attribute("name") != nullptr) {
+                std::string nameValue = (string)ele->Attribute("name");
+                nameValue = ReplaceVariables(nameValue);
+                if (nameValue == eleName) {
+                    return ele;
+                }
             }
             ele = ele->NextSiblingElement();
         }
@@ -1771,8 +1773,12 @@ TiXmlElement* TRestMetadata::GetElementWithName(std::string eleDeclare, std::str
     {
         TiXmlElement* ele = e->FirstChildElement(eleDeclare.c_str());
         while (ele != nullptr) {
-            if (ele->Attribute("name") != nullptr && (string)ele->Attribute("name") == eleName) {
-                return ele;
+            if (ele->Attribute("name") != nullptr) {
+                std::string nameValue = (string)ele->Attribute("name");
+                nameValue = ReplaceVariables(nameValue);
+                if (nameValue == eleName) {
+                    return ele;
+                }
             }
             ele = ele->NextSiblingElement(eleDeclare.c_str());
         }
@@ -2258,8 +2264,7 @@ TString TRestMetadata::GetLibraryVersion() { return fLibraryVersion; }
 void TRestMetadata::ReSetVersion() {
     if (!this->InheritsFrom("TRestRun"))
         RESTError << "version is a static value, you cannot set version "
-                     "for a class!"
-                  << RESTendl;
+                     "for a class!" << RESTendl;
     else {
         fVersion = REST_RELEASE;
     }
@@ -2271,8 +2276,7 @@ void TRestMetadata::ReSetVersion() {
 void TRestMetadata::UnSetVersion() {
     if (!this->InheritsFrom("TRestRun"))
         RESTError << "version is a static value, you cannot set version "
-                     "for a class!"
-                  << RESTendl;
+                     "for a class!" << RESTendl;
     else {
         fVersion = -1;
         fCommit = -1;
@@ -2537,8 +2541,7 @@ void TRestMetadata::ReadOneParameter(string name, string value) {
                     } else {
                         RESTWarning << this->ClassName() << " find unit definition in parameter: " << name
                                     << ", but the corresponding data member doesn't support it. Data "
-                                       "member type: "
-                                    << datamember.type << RESTendl;
+                                       "member type: " << datamember.type << RESTendl;
                         datamember.ParseString(value);
                     }
                 } else {


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 20](https://badgen.net/badge/PR%20Size/Ok%3A%2020/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_md_update)](https://github.com/rest-for-physics/framework/commits/jgalan_md_update) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Using this update now we will be able to create a template section in the following way.

```
<TRestDataSet name="BabyIAXO_XMM_mm_P${STEP}" />
         <parameter name="filePattern" value="${DUST}/run_*rayTracing_Primakoff_XMM_Micromegas_P${STEP}*_V2.4.0.root"/>
...

</TRestDataSet>
```

In that way I can now create datasets for each gas step in BabyIAXO with one single definition.

The new code was tested and working properly when using:

```
restManager GenerateDataSets dataset.rml BabyIAXO_XMM_mm_P991
```