### PR TITLE
Improve support for remote metadata files

### DIFF
--- a/source/framework/core/inc/TRestMetadata.h
+++ b/source/framework/core/inc/TRestMetadata.h
@@ -72,7 +72,7 @@ class TRestMetadata : public TNamed {
     void ReadEnvInElement(TiXmlElement* e, bool overwrite = true);
     void ReadElement(TiXmlElement* e, bool recursive = false);
     void ReplaceForLoopVars(TiXmlElement* e, std::map<std::string, std::string> forLoopVar);
-    void ExpandForLoopOnce(TiXmlElement* e, std::map<std::string, std::string> forLoopVar);
+    void ExpandForLoopOnce(TiXmlElement* e, const std::map<std::string, std::string>& forLoopVar);
     void ExpandForLoops(TiXmlElement* e, std::map<std::string, std::string> forLoopVar);
     void ExpandIfSections(TiXmlElement* e);
     void ExpandIncludeFile(TiXmlElement* e);

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -1209,7 +1209,7 @@ void TRestMetadata::ExpandForLoops(TiXmlElement* e, map<string, string> forloopv
         vector<string> loopvars = Split(_in, ":");
 
         RESTDebug << "----expanding for loop----" << RESTendl;
-        for (string loopvar : loopvars) {
+        for (const string& loopvar : loopvars) {
             forloopvar[_name] = loopvar;
             fVariables[_name] = loopvar;
             ExpandForLoopOnce(e, forloopvar);
@@ -1265,7 +1265,7 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
         filename = TRestTools::DownloadRemoteFile(url);
     } else {
         filename = SearchFile(_filename);
-    }l
+    }
 
     if (filename.empty()) {
         RESTError << "TRestMetadata::ExpandIncludeFile. Include file \"" << _filename << "\" does not exist!"

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -125,7 +125,7 @@ class TRestTools {
 
     static std::string Execute(std::string cmd);
 
-    static std::string DownloadRemoteFile(std::string remoteFile);
+    static std::string DownloadRemoteFile(const std::string& remoteFile);
     static int DownloadRemoteFile(std::string remoteFile, std::string localFile);
     static int UploadToServer(std::string localFile, std::string remoteFile, std::string methodUrl = "");
 

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -1050,12 +1050,11 @@ std::istream& TRestTools::GetLine(std::istream& is, std::string& t) {
 /// by default.
 ///
 std::string TRestTools::DownloadRemoteFile(const string& url) {
-    cout << "TRestTools::DownloadRemoteFile: " << url << endl;
     string pureName = TRestTools::GetPureFileName(url);
     if (pureName.empty()) {
-        cout << "error! (TRestTools::DownloadRemoteFile): url is not a file!" << endl;
-        cout << "please specify a concrete file name in this url" << endl;
-        cout << "url: " << url << endl;
+        RESTWarning << "error! (TRestTools::DownloadRemoteFile): url is not a file!" << RESTendl;
+        RESTWarning << "please specify a concrete file name in this url" << RESTendl;
+        RESTWarning << "url: " << url << RESTendl;
         return "";
     }
 
@@ -1071,14 +1070,12 @@ std::string TRestTools::DownloadRemoteFile(const string& url) {
                 RESTWarning << "Retrying download in 5 seconds" << RESTendl;
                 std::this_thread::sleep_for(std::chrono::seconds(5));
             } else if (attempts < 10) {
-                RESTSuccess << "Download suceeded after " << 10 - attempts << " attempts" << RESTendl;
+                RESTSuccess << "Download succeeded after " << 10 - attempts << " attempts" << RESTendl;
             }
             attempts--;
         } while (out == 1024 && attempts > 0);
 
-        if (out == 0) {
-            return fullpath;
-        } else if (TRestTools::fileExists(fullpath)) {
+        if (out == 0 || TRestTools::fileExists(fullpath)) {
             return fullpath;
         } else {
             return "";

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -1049,9 +1049,10 @@ std::istream& TRestTools::GetLine(std::istream& is, std::string& t) {
 /// will be used, including scp, wget. Downloads to REST_USER_PATH + "/download/" + filename
 /// by default.
 ///
-std::string TRestTools::DownloadRemoteFile(string url) {
-    string purename = TRestTools::GetPureFileName(url);
-    if (purename == "") {
+std::string TRestTools::DownloadRemoteFile(const string& url) {
+    cout << "TRestTools::DownloadRemoteFile: " << url << endl;
+    string pureName = TRestTools::GetPureFileName(url);
+    if (pureName.empty()) {
         cout << "error! (TRestTools::DownloadRemoteFile): url is not a file!" << endl;
         cout << "please specify a concrete file name in this url" << endl;
         cout << "url: " << url << endl;
@@ -1061,7 +1062,7 @@ std::string TRestTools::DownloadRemoteFile(string url) {
     if (url.find("local:") == 0) {
         return Replace(url, "local:", "");
     } else {
-        string fullpath = REST_USER_PATH + "/download/" + purename;
+        string fullpath = REST_USER_PATH + "/download/" + pureName;
         int out;
         int attempts = 10;
         do {

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -49,6 +49,8 @@
 #include <TSystem.h>
 #include <TUrl.h>
 
+#include <regex>
+
 #ifdef USE_Curl
 #include <curl/curl.h>
 #endif
@@ -711,11 +713,9 @@ bool TRestTools::isDataSet(const std::string& filename) {
 ///////////////////////////////////////////////
 /// \brief Returns true if **filename** is an *http* address.
 ///
-bool TRestTools::isURL(const string& filename) {
-    if (filename.find("http") == 0) {
-        return true;
-    }
-    return false;
+bool TRestTools::isURL(const string& s) {
+    std::regex pattern("^https?://(.+)");
+    return std::regex_match(s, pattern);
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 33](https://badgen.net/badge/PR%20Size/Ok%3A%2033/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=479-support-downloading-files-over-http-at-addmetadata-definition)](https://github.com/rest-for-physics/framework/commits/479-support-downloading-files-over-http-at-addmetadata-definition) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Improve support for remote files: when a metadata file is added in the usual way (`addMetadata` element in the xml) if it parses as an http(s) uri it will be downloaded and saved to the local filesystem.