### PR TITLE
TRestDataSetOdds fix and some more

### DIFF
--- a/source/framework/analysis/inc/TRestDataSetOdds.h
+++ b/source/framework/analysis/inc/TRestDataSetOdds.h
@@ -62,9 +62,18 @@ class TRestDataSetOdds : public TRestMetadata {
 
     void ComputeLogOdds();
 
+    std::vector<std::tuple<std::string, TVector2, int>> GetOddsObservables();
+    std::string GetOddsFile() { return fOddsFile; }
+    std::string GetDataSetName() { return fDataSetName; }
+    std::string GetOutputFileName() { return fOutputFileName; }
+    TRestCut* GetCut() { return fCut; }
+
     inline void SetDataSetName(const std::string& dSName) { fDataSetName = dSName; }
     inline void SetOutputFileName(const std::string& outName) { fOutputFileName = outName; }
     inline void SetOddsFile(const std::string& oddsFile) { fOddsFile = oddsFile; }
+    inline void SetCut(TRestCut* cut) { fCut = cut; }
+    void SetOddsObservables(const std::vector<std::tuple<std::string, TVector2, int>>& obs);
+    void AddOddsObservable(const std::string& name, const TVector2& range, int nbins);
 
     TRestDataSetOdds();
     TRestDataSetOdds(const char* configFilename, std::string name = "");

--- a/source/framework/analysis/src/TRestDataSetOdds.cxx
+++ b/source/framework/analysis/src/TRestDataSetOdds.cxx
@@ -281,11 +281,40 @@ void TRestDataSetOdds::ComputeLogOdds() {
     }
 }
 
+std::vector<std::tuple<std::string, TVector2, int>> TRestDataSetOdds::GetOddsObservables() {
+    std::vector<std::tuple<std::string, TVector2, int>> obs;
+    for (size_t i = 0; i < fObsName.size(); i++) {
+        if (i >= fObsName.size() || i >= fObsRange.size() || i >= fObsNbins.size()) {
+            RESTError << "Sizes for observables names, ranges and bins do not match!" << RESTendl;
+            break;
+        }
+        obs.push_back(std::make_tuple(fObsName[i], fObsRange[i], fObsNbins[i]));
+    }
+    return obs;
+}
+
+void TRestDataSetOdds::AddOddsObservable(const std::string& name, const TVector2& range, int nbins) {
+    fObsName.push_back(name);
+    fObsRange.push_back(range);
+    fObsNbins.push_back(nbins);
+}
+
+void TRestDataSetOdds::SetOddsObservables(const std::vector<std::tuple<std::string, TVector2, int>>& obs) {
+    fObsName.clear();
+    fObsRange.clear();
+    fObsNbins.clear();
+    for (const auto& [name, range, nbins] : obs) AddOddsObservable(name, range, nbins);
+}
+
 /////////////////////////////////////////////
 /// \brief Prints on screen the information about the metadata members of TRestDataSetOdds
 ///
 void TRestDataSetOdds::PrintMetadata() {
     TRestMetadata::PrintMetadata();
+
+    // if (fCut) fCut->PrintMetadata();
+    if (!fOddsFile.empty()) RESTMetadata << " Odds file: " << fOddsFile << RESTendl;
+    RESTMetadata << " DataSet file: " << fDataSetName << RESTendl;
 
     RESTMetadata << " Observables to compute: " << RESTendl;
     for (size_t i = 0; i < fObsName.size(); i++) {

--- a/source/framework/analysis/src/TRestDataSetOdds.cxx
+++ b/source/framework/analysis/src/TRestDataSetOdds.cxx
@@ -244,6 +244,12 @@ void TRestDataSetOdds::ComputeLogOdds() {
             if (odds == 0) return 1000.;
             return log(1. - odds) - log(odds);
         };
+
+        if (df.GetColumnType(obsName) != "Double_t") {
+            RESTWarning << "Column " << obsName << " is not of type 'double'. It will be converted."
+                        << RESTendl;
+            df = df.Redefine(obsName, "static_cast<double>(" + obsName + ")");
+        }
         df = df.Define(oddsName, GetLogOdds, {obsName});
         auto h = df.Histo1D(oddsName);
 


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 54](https://badgen.net/badge/PR%20Size/Ok%3A%2054/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=alvaroezq_oddsFix)](https://github.com/rest-for-physics/framework/commits/alvaroezq_oddsFix) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR is meant to solve a problem when computing log odds for columns of the dataset with int values. This problem happens because the lambda function `GetLogOdds` requires the `double val` parameter,  which causes the TTreeReader to read the corresponding column as it was a double, thus causing error when the branch is not double type. To solve this in a simple way, the RDataFrame  columns (of the selected observables to compute the log odds) that are not double types are Redefine with a static_cast<double> to double. This solves the issue with simple types such as int (which is a common case).

Also some minor additions (see list below).

The changes are:
- Redefine the columns involved in log odds computation to be casted to double.
- Some debug messages are added within the ComputeLogOdds method. Also change a previous std::cout to RESTInfo.
- Add getters and setters