### PR TITLE
Minor updates 

### DIFF
--- a/cmake/thisREST.cmake
+++ b/cmake/thisREST.cmake
@@ -143,6 +143,7 @@ export PYTHONPATH=${PYTHON_BINDINGS_INSTALL_DIR}:\\\$PYTHONPATH
 
 alias restRoot=\\\"restRoot -l\\\"
 alias restRootMacros=\\\"restRoot -l --m\\\"
+alias restListMacros=\\\"restManager ListMacros\\\"
 
 if [ \\\$(rest-config --flags | grep \\\"REST_WELCOME=ON\\\") ]; then
     rest-config --welcome

--- a/macros/REST_CheckValidRuns.C
+++ b/macros/REST_CheckValidRuns.C
@@ -1,24 +1,47 @@
 #include <iostream>
+#include <filesystem>
+
 #include <vector>
 
 #include "TGeoManager.h"
 #include "TRestTask.h"
 #include "TSystem.h"
 using namespace std;
+namespace fs = std::filesystem;
 
-#ifndef RESTTask_CheckRunFileList
-#define RESTTask_CheckRunFileList
+#ifndef RESTTask_CheckValidRuns
+#define RESTTask_CheckValidRuns
 
 //*******************************************************************************************************
 //***
-//*** Your HELP is needed to verify, validate and document this macro
-//*** This macro might need update/revision.
+//*** Description: This macro will identify run files that were not properly closed.
+//***
+//*** --------------
+//*** The first and mandatory argument must provide a full data and pattern to filter the files that
+//*** will be checked. E.g. to add all the Hits files from run number 123 the first argument would be
+//*** pattern = "/path/to/data/Run00123*Hits*root".
+//***
+//*** IMPORTANT: The pattern must be given using double quotes ""
+//***
+//*** --------------
+//*** Usage: restManager CheckValidRuns "/full/path/file_*pattern*.root" [purge]
+//*** --------------
+//***
+//*** An optional parameter `purge` can be made true. In that case, this macro will not just provide
+//*** a list of the files not properly closed but it will also remove them!
+//***
+//*** The following command will remove the non-valid runs
+//*** --------------
+//*** Usage: restManager CheckValidRuns "/full/path/file_*pattern*.root" 1
+//*** --------------
+//***
+//*** CAUTION: Be aware that any non-REST file in the list will be removed if you use purge=1
 //***
 //*******************************************************************************************************
-Int_t REST_CheckRunFileList(TString namePattern, Int_t N = 100000) {
+Int_t REST_CheckValidRuns(TString namePattern, Bool_t purge = false) {
     TGeoManager::SetVerboseLevel(0);
 
-    vector<TString> filesNotWellClosed;
+    vector<std::string> filesNotWellClosed;
 
     TRestStringOutput RESTLog;
 
@@ -70,7 +93,16 @@ Int_t REST_CheckRunFileList(TString namePattern, Int_t N = 100000) {
         RESTLog << "---------------------" << RESTendl;
         RESTLog << "Files not well closed" << RESTendl;
         RESTLog << "---------------------" << RESTendl;
-        for (int i = 0; i < filesNotWellClosed.size(); i++) RESTLog << filesNotWellClosed[i] << RESTendl;
+        for (int i = 0; i < filesNotWellClosed.size(); i++) {
+            RESTLog << filesNotWellClosed[i] << RESTendl;
+            if (purge) fs::remove(filesNotWellClosed[i]);
+        }
+
+        if (purge) {
+            RESTLog << "---------------------------" << RESTendl;
+            RESTLog << "The files have been removed" << RESTendl;
+            RESTLog << "---------------------------" << RESTendl;
+        }
     }
 
     RESTLog << "------------------------------" << RESTendl;

--- a/macros/REST_CheckValidRuns.C
+++ b/macros/REST_CheckValidRuns.C
@@ -1,6 +1,5 @@
-#include <iostream>
 #include <filesystem>
-
+#include <iostream>
 #include <vector>
 
 #include "TGeoManager.h"

--- a/macros/REST_GenerateDataSets.C
+++ b/macros/REST_GenerateDataSets.C
@@ -16,7 +16,7 @@
 //*******************************************************************************************************
 
 Int_t REST_GenerateDataSets(const std::string& inputRML, const std::string& datasets,
-                            const std::string& outPath = "") {
+                            std::string outPath = "") {
     std::vector<std::string> sets = REST_StringHelper::Split(datasets, ",");
 
     for (const auto& set : sets) {

--- a/macros/REST_GenerateDataSets.C
+++ b/macros/REST_GenerateDataSets.C
@@ -15,14 +15,16 @@
 //***
 //*******************************************************************************************************
 
-Int_t REST_GenerateDataSets(const std::string& inputRML, const std::string& datasets) {
+Int_t REST_GenerateDataSets(const std::string& inputRML, const std::string& datasets,
+                            const std::string& outPath = "") {
     std::vector<std::string> sets = REST_StringHelper::Split(datasets, ",");
 
     for (const auto& set : sets) {
         std::cout << "Set : " << set << std::endl;
         TRestDataSet d(inputRML.c_str(), set.c_str());
         d.GenerateDataSet();
-        d.Export("Dataset_" + set + ".root");
+        if (!outPath.empty() && outPath.back() != '/') outPath += '/';
+        d.Export(outPath + "Dataset_" + set + ".root");
     }
     return 0;
 }

--- a/source/framework/core/src/TRestSystemOfUnits.cxx
+++ b/source/framework/core/src/TRestSystemOfUnits.cxx
@@ -310,8 +310,16 @@ TRestSystemOfUnits::TRestSystemOfUnits(string unitsStr) {
 
         } else {
             if (pos == unitsStr.size() - 1) {
-                RESTWarning << "last character inside \"" << unitsStr << "\" \"" << unitsStr[pos]
+                RESTWarning << "Last character inside \"" << unitsStr << "\" \"" << unitsStr[pos]
                             << "\" unrecognized in unit definition!" << RESTendl;
+
+                std::string lastChar = unitsStr.substr(pos, 1);
+
+                if (isANumber(lastChar)) {
+                    std::string tmpStr = unitsStr;
+                    tmpStr.insert(pos, "^");
+                    RESTWarning << "Perhaps you meant: " << tmpStr << RESTendl;
+                }
             }
 
             pos++;


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Ok: 52](https://badgen.net/badge/PR%20Size/Ok%3A%2052/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_minor_fixes)](https://github.com/rest-for-physics/framework/commits/jgalan_minor_fixes) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR brings the following updates:

- `REST_GenerateDataSets` will now accept to define optionally an output path.
- Added an alias: `restListMacros` to `thisREST.sh` so that users become aware of the possibility to print out a list of macros and their corresponding documentation.
- Added more informative warning on `TRestSystemOfUnits`.
- Renamed `REST_CheckRunFileList` renamed to `REST_CheckValidRuns`. It has also been documented, and a new optional argument `purge` allows to remove the non-valid runs.

<img width="576" alt="Screenshot 2023-11-22 at 09 33 29" src="https://github.com/rest-for-physics/framework/assets/12447509/23a6eff1-9621-4ef7-b118-c7dc0e7dda1b">