### PR TITLE
fix: `REST_HOME` is now dynamically set to the user's home

### DIFF
--- a/cmake/thisREST.cmake
+++ b/cmake/thisREST.cmake
@@ -129,7 +129,7 @@ fi
 export REST_SOURCE=${CMAKE_CURRENT_SOURCE_DIR}
 export REST_PATH=\\\${thisdir}
 # REST_HOME is where temporary files are stored
-export REST_HOME=$ENV{HOME}
+export REST_HOME=\\\${HOME}
 export ROOT_INCLUDE_PATH=\\\$REST_PATH/include${Garfield_INCLUDE_ENV}:\\\$ROOT_INCLUDE_PATH
 export REST_INPUTDATA=\\\$REST_PATH/data
 export REST_GARFIELD_INCLUDE=${Garfield_INCLUDE_DIRS}


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=lobis-fix-rest-home)](https://github.com/rest-for-physics/framework/commits/lobis-fix-rest-home) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Before this change, `REST_HOME` was set to the user's home at the time of installation, which makes sense if the user is who build and install REST. However this breaks when REST is used on shared systems as the local user would have `REST_HOME` point to the home of the user who installed REST.