### PR TITLE
TRestDataSetGainMap improvements

### DIFF
--- a/source/framework/analysis/inc/TRestDataSetGainMap.h
+++ b/source/framework/analysis/inc/TRestDataSetGainMap.h
@@ -171,7 +171,8 @@ class TRestDataSetGainMap : public TRestMetadata {
         void DrawGainMap(const int peakNumber = 0);
 
         void Refit(const double x, const double y, const double energy, const TVector2& range);
-        void Refit(const int x, const int y, const int peakNumber, const TVector2& range);
+        void Refit(const size_t x, const size_t y, const size_t peakNumber, const TVector2& range);
+        void UpdateCalibrationFits(const size_t x, const size_t y);
 
         void SetPlaneId(const Int_t& planeId) { fPlaneId = planeId; }
         void SetModuleId(const Int_t& moduleId) { fModuleId = moduleId; }

--- a/source/framework/analysis/inc/TRestDataSetGainMap.h
+++ b/source/framework/analysis/inc/TRestDataSetGainMap.h
@@ -157,20 +157,20 @@ class TRestDataSetGainMap : public TRestMetadata {
         std::string GetDataSetFileName() const { return fDataSetFileName; }
         TVector2 GetReadoutRangeVar() const { return fReadoutRange; }
 
-        void DrawSpectrum(bool drawFits = true, int color = -1, TCanvas* c = nullptr);
-        void DrawSpectrum(const double x, const double y, bool drawFits = true, int color = -1,
+        void DrawSpectrum(const bool drawFits = true, const int color = -1, TCanvas* c = nullptr);
+        void DrawSpectrum(const TVector2& position, bool drawFits = true, int color = -1,
                           TCanvas* c = nullptr);
-        void DrawSpectrum(const size_t index_x, const size_t index_y, bool drawFits = true, int color = -1,
+        void DrawSpectrum(const int index_x, const int index_y, bool drawFits = true, int color = -1,
                           TCanvas* c = nullptr);
         void DrawFullSpectrum();
 
         void DrawLinearFit();
-        void DrawLinearFit(const double x, const double y, TCanvas* c = nullptr);
-        void DrawLinearFit(const size_t index_x, const size_t index_y, TCanvas* c = nullptr);
+        void DrawLinearFit(const TVector2& position, TCanvas* c = nullptr);
+        void DrawLinearFit(const int index_x, const int index_y, TCanvas* c = nullptr);
 
         void DrawGainMap(const int peakNumber = 0);
 
-        void Refit(const double x, const double y, const double energy, const TVector2& range);
+        void Refit(const TVector2& position, const double energy, const TVector2& range);
         void Refit(const size_t x, const size_t y, const size_t peakNumber, const TVector2& range);
         void UpdateCalibrationFits(const size_t x, const size_t y);
 

--- a/source/framework/analysis/src/TRestDataSetGainMap.cxx
+++ b/source/framework/analysis/src/TRestDataSetGainMap.cxx
@@ -897,10 +897,11 @@ void TRestDataSetGainMap::Module::UpdateCalibrationFits(const size_t x, const si
 
     int c = 0;
     for (size_t i = 0; i < fEnergyPeaks.size(); i++) {
-        TF1* g = h->GetFunction(((std::string) "g" + std::to_string(peakNumber)).c_str());
+        std::string fitName = (std::string) "g" + std::to_string(i);
+        TF1* g = h->GetFunction(fitName.c_str());
         if (!g)
-            RESTWarning << "No fit found for energy peak " << newPeakPos << " in segment " << x << "," << y
-                        << p->RESTendl;
+            RESTWarning << "No fit ( " << fitName << " ) found for energy peak " << fEnergyPeaks[i]
+                        << " in segment " << x << "," << y << p->RESTendl;
         gr->SetPoint(c++, g->GetParameter(1), fEnergyPeaks[i]);
     }
 
@@ -1032,7 +1033,7 @@ void TRestDataSetGainMap::Module::DrawSpectrum(const size_t index_x, const size_
     if (drawFits)
         for (size_t c = 0; c < fEnergyPeaks.size(); c++) {
             auto fit = fSegSpectra[index_x][index_y]->GetFunction(("g" + std::to_string(c)).c_str());
-            if (!fit) RESTError << "Fit for energy peak" << fEnergyPeaks[c] << " not found." << p->RESTendl;
+            if (!fit) RESTWarning << "Fit for energy peak" << fEnergyPeaks[c] << " not found." << p->RESTendl;
             if (!fit) continue;
             fit->SetLineColor(c + 2 != colorT++ ? c + 2 : c + 3); /* does not work with kRed, kBlue, etc.
                   as they are not defined with the same number as the first 10 basic colors. See

--- a/source/framework/analysis/src/TRestDataSetGainMap.cxx
+++ b/source/framework/analysis/src/TRestDataSetGainMap.cxx
@@ -109,13 +109,13 @@
 /// for (auto pID : gm.GetPlaneIDs())
 ///     for (auto mID : gm.GetModuleIDs(pID))
 ///         gm.GetModule(pID,mID)->DrawSpectrum();
-/// // Draw only the desired spectrum (the one at position (x,y)=(0,0) in this case)
-/// gm.GetModule(0,0)->DrawSpectrum(0.0, 0.0);
+/// // Draw only the desired spectrum (segment 0,0 in this case)
+/// gm.GetModule(0,0)->DrawSpectrum(0, 0);
 /// // Refit the desired peak (peak with energy 22.5 in this case) with a new range
 /// TVector2 range(100000, 200000); // Define here the new range for the fit as you wish
-/// gm.GetModule(0,0)->Refit(0.0, 0.0, 22.5, range)
+/// gm.GetModule(0,0)->Refit(TVector2(0,0), 22.5, range);
 /// // Check the result
-/// gm.GetModule(0,0)->DrawSpectrum(0.0, 0.0);
+/// gm.GetModule(0,0)->DrawSpectrum(TVector2(0.0,0.0)); // using x,y physical coord is possible
 /// // Export the new calibration
 /// gm.Export(); // gm.Export("anyOtherFileName.root")
 /// \endcode

--- a/source/framework/analysis/src/TRestDataSetGainMap.cxx
+++ b/source/framework/analysis/src/TRestDataSetGainMap.cxx
@@ -657,7 +657,9 @@ void TRestDataSetGainMap::Module::GenerateGainMap() {
     std::vector<std::vector<TH1F*>> h(fNumberOfSegmentsX, std::vector<TH1F*>(fNumberOfSegmentsY, nullptr));
     for (size_t i = 0; i < h.size(); i++) {
         for (size_t j = 0; j < h.at(0).size(); j++) {
-            h[i][j] = new TH1F("", "", fNBins, fCalibRange.X(),
+            std::string name = "hSpc_" + std::to_string(fPlaneId) + "_" + std::to_string(fModuleId) + "_" +
+                               std::to_string(i) + "_" + std::to_string(j);
+            h[i][j] = new TH1F(name.c_str(), "", fNBins, fCalibRange.X(),
                                fCalibRange.Y());  // h[column][row] equivalent to h[x][y]
         }
     }


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Medium: 129](https://badgen.net/badge/PR%20Size/Medium%3A%20129/orange) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=alvaroezq_updateFitGM)](https://github.com/rest-for-physics/framework/commits/alvaroezq_updateFitGM) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Some improvements to the TRestDataSetGainMap:

- [Naming the segmented spectra TH1F](https://github.com/rest-for-physics/framework/commit/3396b55a6d391d4834343c4d15116be65367ac8b). Better practice to name them appropiately.
- [Simplifying some overloads](https://github.com/rest-for-physics/framework/commit/69eefa9e73903aa30c7f6a5e3223305370602766). This avoids explicit casting on parameters of DrawSpectrum, DrawLinearFit and Refit functions when calling them. This simplyfies the procedure of checking and refitting the peaks.
- [Adding function UpdateCalibrationFits()](https://github.com/rest-for-physics/framework/commit/0effbab29c9d8ff180b7cffa208da7919cfb62cf). This is useful to write auxiliar code (macros) that help on the refitting of the peaks.
- Updating and [improving documentation](https://github.com/rest-for-physics/framework/commit/0ae648ea183a02f1aadb998af0c109825da32fee)