### PR TITLE
Add option to PID prefix on downloads to avoid faults

### DIFF
--- a/source/framework/core/src/TRestEvent.cxx
+++ b/source/framework/core/src/TRestEvent.cxx
@@ -49,6 +49,8 @@
 
 #include "TRestEvent.h"
 
+#include "TRestRun.h"
+
 using namespace std;
 
 ClassImp(TRestEvent);
@@ -170,7 +172,11 @@ void TRestEvent::RestartPad(Int_t nElements) {
 
 void TRestEvent::InitializeWithMetadata(TRestRun* run) { Initialize(); }
 
-void TRestEvent::InitializeReferences(TRestRun* run) { fRun = run; }
+void TRestEvent::InitializeReferences(TRestRun* run) {
+    fRun = run;
+    SetRunOrigin(fRun->GetRunNumber());
+    SetSubRunOrigin(fRun->GetSubRunNumber());
+}
 
 //////////////////////////////////////////////////////////////////////////
 /// Run to print event data info on console

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -1284,7 +1284,7 @@ void TRestMetadata::ExpandIncludeFile(TiXmlElement* e) {
             url = _filename;
         }
 
-        filename = TRestTools::DownloadRemoteFile(url);
+        filename = TRestTools::DownloadRemoteFile(url, true);
     } else {
         filename = SearchFile(_filename);
     }

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -127,7 +127,7 @@ class TRestTools {
 
     static std::string Execute(std::string cmd);
 
-    static std::string DownloadRemoteFile(const std::string& remoteFile);
+    static std::string DownloadRemoteFile(const std::string& remoteFile, bool pidPrefix = false);
     static int DownloadRemoteFile(std::string remoteFile, std::string localFile);
     static int UploadToServer(std::string localFile, std::string remoteFile, std::string methodUrl = "");
 

--- a/source/framework/tools/src/TRestTools.cxx
+++ b/source/framework/tools/src/TRestTools.cxx
@@ -1121,7 +1121,7 @@ std::istream& TRestTools::GetLine(std::istream& is, std::string& t) {
 /// will be used, including scp, wget. Downloads to REST_USER_PATH + "/download/" + filename
 /// by default.
 ///
-std::string TRestTools::DownloadRemoteFile(const string& url) {
+std::string TRestTools::DownloadRemoteFile(const string& url, bool pidPrefix) {
     string pureName = TRestTools::GetPureFileName(url);
     if (pureName.empty()) {
         RESTWarning << "error! (TRestTools::DownloadRemoteFile): url is not a file!" << RESTendl;
@@ -1133,7 +1133,8 @@ std::string TRestTools::DownloadRemoteFile(const string& url) {
     if (url.find("local:") == 0) {
         return Replace(url, "local:", "");
     } else {
-        string fullpath = REST_USER_PATH + "/download/" + pureName;
+        string fullpath =
+            REST_USER_PATH + "/download/" + (pidPrefix ? "PID_" + ToString(getpid()) + "_" : "") + pureName;
         int out;
         int attempts = 10;
         do {
@@ -1153,7 +1154,6 @@ std::string TRestTools::DownloadRemoteFile(const string& url) {
             return "";
         }
     }
-    return "";
 }
 
 ///////////////////////////////////////////////


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 12](https://badgen.net/badge/PR%20Size/Ok%3A%2012/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=lobis-download)](https://github.com/rest-for-physics/framework/commits/lobis-download) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

I noticed some analysis processes were failing when running concurrently and this fixes it.