### PR TITLE
TRestDataSetGainMap improvements and bug fixes

### DIFF
--- a/source/framework/analysis/inc/TRestDataSetGainMap.h
+++ b/source/framework/analysis/inc/TRestDataSetGainMap.h
@@ -33,6 +33,7 @@
 #include <TTree.h>
 #include <TVector2.h>
 
+#include "TRestCut.h"
 #include "TRestDataSet.h"
 #include "TRestMetadata.h"
 
@@ -60,6 +61,8 @@ class TRestDataSetGainMap : public TRestMetadata {
     /// Name of the file where the gain map was (or will be) exported
     std::string fOutputFileName = "";  //<
 
+    /// Cut to be applied to the calibration data
+    TRestCut* fCut = nullptr;  //<
 
     void Initialize() override;
     void InitFromConfigFile() override;
@@ -80,6 +83,7 @@ class TRestDataSetGainMap : public TRestMetadata {
     std::string GetObservable() const { return fObservable; }
     std::string GetSpatialObservableX() const { return fSpatialObservableX; }
     std::string GetSpatialObservableY() const { return fSpatialObservableY; }
+    TRestCut* GetCut() const { return fCut; }
 
     Module* GetModule(const int planeID, const int moduleID);
     double GetSlopeParameter(const int planeID, const int moduleID, const double x, const double y);
@@ -95,6 +99,7 @@ class TRestDataSetGainMap : public TRestMetadata {
     void SetSpatialObservableY(const std::string& spatialObservableY) {
         fSpatialObservableY = spatialObservableY;
     }
+    void SetCut(TRestCut* cut) { fCut = cut; }
 
     void Import(const std::string& fileName);
     void Export(const std::string& fileName = "");

--- a/source/framework/analysis/inc/TRestDataSetGainMap.h
+++ b/source/framework/analysis/inc/TRestDataSetGainMap.h
@@ -125,6 +125,9 @@ class TRestDataSetGainMap : public TRestMetadata {
        private:
         /// Pointer to the parent class
         const TRestDataSetGainMap* p = nullptr;  //<!
+
+        std::pair<double, double> FitPeaks(TH1F* hSeg, TGraph* gr);
+
        public:
         /// Plane ID (unique identifier). Although it is not linked to any TRestDetectorReadout it is
         /// recommended to use the same.

--- a/source/framework/analysis/inc/TRestDataSetGainMap.h
+++ b/source/framework/analysis/inc/TRestDataSetGainMap.h
@@ -242,7 +242,7 @@ class TRestDataSetGainMap : public TRestMetadata {
         void DrawLinearFit(const TVector2& position, TCanvas* c = nullptr);
         void DrawLinearFit(const int index_x, const int index_y, TCanvas* c = nullptr);
 
-        void DrawGainMap(const int peakNumber = 0);
+        void DrawGainMap(const int peakNumber = 0, const bool fullModuleAsRef = true);
 
         void Refit(const TVector2& position, const double energy, const TVector2& range);
         void Refit(const size_t x, const size_t y, const size_t peakNumber, const TVector2& range);

--- a/source/framework/analysis/inc/TRestDataSetGainMap.h
+++ b/source/framework/analysis/inc/TRestDataSetGainMap.h
@@ -85,6 +85,7 @@ class TRestDataSetGainMap : public TRestMetadata {
     std::string GetSpatialObservableY() const { return fSpatialObservableY; }
     TRestCut* GetCut() const { return fCut; }
 
+    Module* GetModule(const size_t index = 0);
     Module* GetModule(const int planeID, const int moduleID);
     double GetSlopeParameter(const int planeID, const int moduleID, const double x, const double y);
     double GetInterceptParameter(const int planeID, const int moduleID, const double x, const double y);
@@ -93,7 +94,7 @@ class TRestDataSetGainMap : public TRestMetadata {
 
     void SetCalibrationFileName(const std::string& fileName) { fCalibFileName = fileName; }
     void SetOutputFileName(const std::string& fileName) { fOutputFileName = fileName; }
-    void SetModuleCalibration(const Module& moduleCal);
+    void SetModule(const Module& moduleCal);
     void SetObservable(const std::string& observable) { fObservable = observable; }
     void SetSpatialObservableX(const std::string& spatialObservableX) {
         fSpatialObservableX = spatialObservableX;
@@ -189,11 +190,11 @@ class TRestDataSetGainMap : public TRestMetadata {
         /// Array containing the observable spectrum for each segment.
         std::vector<std::vector<TH1F*>> fSegSpectra = {};  //<
 
-        /// Spectrum of the observable for the whole module.
-        TH1F* fFullSpectrum = nullptr;  //<
-
         /// Array containing the calibration linear fit for each segment.
         std::vector<std::vector<TGraph*>> fSegLinearFit = {};  //<
+
+        /// Spectrum of the observable for the whole module.
+        TH1F* fFullSpectrum = nullptr;  //<
 
         /// Calibration linear fit for the whole module.
         TGraph* fFullLinearFit = nullptr;  //<
@@ -206,6 +207,7 @@ class TRestDataSetGainMap : public TRestMetadata {
 
         void LoadConfigFromTiXmlElement(const TiXmlElement* module);
 
+        TRestDataSetGainMap* GetParent() const { return const_cast<TRestDataSetGainMap*>(p); }
         std::pair<int, int> GetIndexMatrix(const double x, const double y) const;
         double GetSlope(const double x, const double y) const;
         double GetIntercept(const double x, const double y) const;
@@ -224,7 +226,7 @@ class TRestDataSetGainMap : public TRestMetadata {
         std::set<double> GetSplitX() const { return fSplitX; }
         std::set<double> GetSplitY() const { return fSplitY; }
         std::string GetDataSetFileName() const { return fDataSetFileName; }
-        TVector2 GetReadoutRangeVar() const { return fReadoutRange; }
+        TVector2 GetReadoutRange() const { return fReadoutRange; }
 
         void DrawSpectrum(const bool drawFits = true, const int color = -1, TCanvas* c = nullptr);
         void DrawSpectrum(const TVector2& position, bool drawFits = true, int color = -1,

--- a/source/framework/analysis/inc/TRestDataSetGainMap.h
+++ b/source/framework/analysis/inc/TRestDataSetGainMap.h
@@ -217,7 +217,7 @@ class TRestDataSetGainMap : public TRestMetadata {
                           TCanvas* c = nullptr);
         void DrawFullSpectrum();
 
-        void DrawLinearFit();
+        void DrawLinearFit(TCanvas* c = nullptr);
         void DrawLinearFit(const TVector2& position, TCanvas* c = nullptr);
         void DrawLinearFit(const int index_x, const int index_y, TCanvas* c = nullptr);
 

--- a/source/framework/analysis/inc/TRestDataSetGainMap.h
+++ b/source/framework/analysis/inc/TRestDataSetGainMap.h
@@ -88,6 +88,8 @@ class TRestDataSetGainMap : public TRestMetadata {
     Module* GetModule(const int planeID, const int moduleID);
     double GetSlopeParameter(const int planeID, const int moduleID, const double x, const double y);
     double GetInterceptParameter(const int planeID, const int moduleID, const double x, const double y);
+    double GetSlopeParameterFullSpc(const int planeID, const int moduleID);
+    double GetInterceptParameterFullSpc(const int planeID, const int moduleID);
 
     void SetCalibrationFileName(const std::string& fileName) { fCalibFileName = fileName; }
     void SetOutputFileName(const std::string& fileName) { fOutputFileName = fileName; }
@@ -168,6 +170,12 @@ class TRestDataSetGainMap : public TRestMetadata {
         /// Array containing the slope of the linear fit for each segment.
         std::vector<std::vector<double>> fSlope = {};  //<
 
+        /// Slope of the calibration linear fit of whole module
+        double fFullSlope = 0;  //<
+
+        /// Intercept of the calibration linear fit of whole module
+        double fFullIntercept = 0;  //<
+
         /// Array containing the intercept of the linear fit for each segment.
         std::vector<std::vector<double>> fIntercept = {};  //<
 
@@ -181,8 +189,14 @@ class TRestDataSetGainMap : public TRestMetadata {
         /// Array containing the observable spectrum for each segment.
         std::vector<std::vector<TH1F*>> fSegSpectra = {};  //<
 
+        /// Spectrum of the observable for the whole module.
+        TH1F* fFullSpectrum = nullptr;  //<
+
         /// Array containing the calibration linear fit for each segment.
         std::vector<std::vector<TGraph*>> fSegLinearFit = {};  //<
+
+        /// Calibration linear fit for the whole module.
+        TGraph* fFullLinearFit = nullptr;  //<
 
        public:
         void AddPeak(const double& energyPeak, const TVector2& rangePeak = TVector2(0, 0)) {
@@ -195,6 +209,8 @@ class TRestDataSetGainMap : public TRestMetadata {
         std::pair<int, int> GetIndexMatrix(const double x, const double y) const;
         double GetSlope(const double x, const double y) const;
         double GetIntercept(const double x, const double y) const;
+        double GetSlopeFullSpc() const { return fFullSlope; };
+        double GetInterceptFullSpc() const { return fFullIntercept; };
 
         Int_t GetPlaneId() const { return fPlaneId; }
         Int_t GetModuleId() const { return fModuleId; }
@@ -215,7 +231,7 @@ class TRestDataSetGainMap : public TRestMetadata {
                           TCanvas* c = nullptr);
         void DrawSpectrum(const int index_x, const int index_y, bool drawFits = true, int color = -1,
                           TCanvas* c = nullptr);
-        void DrawFullSpectrum();
+        void DrawFullSpectrum(const bool drawFits = true, const int color = -1, TCanvas* c = nullptr);
 
         void DrawLinearFit(TCanvas* c = nullptr);
         void DrawLinearFit(const TVector2& position, TCanvas* c = nullptr);
@@ -225,7 +241,10 @@ class TRestDataSetGainMap : public TRestMetadata {
 
         void Refit(const TVector2& position, const double energy, const TVector2& range);
         void Refit(const size_t x, const size_t y, const size_t peakNumber, const TVector2& range);
+        void RefitFullSpc(const double energy, const TVector2& range);
+        void RefitFullSpc(const size_t peakNumber, const TVector2& range);
         void UpdateCalibrationFits(const size_t x, const size_t y);
+        void UpdateCalibrationFitsFullSpc();
 
         void SetPlaneId(const Int_t& planeId) { fPlaneId = planeId; }
         void SetModuleId(const Int_t& moduleId) { fModuleId = moduleId; }

--- a/source/framework/analysis/inc/TRestDataSetGainMap.h
+++ b/source/framework/analysis/inc/TRestDataSetGainMap.h
@@ -127,6 +127,7 @@ class TRestDataSetGainMap : public TRestMetadata {
         const TRestDataSetGainMap* p = nullptr;  //<!
 
         std::pair<double, double> FitPeaks(TH1F* hSeg, TGraph* gr);
+        std::pair<double, double> UpdateCalibrationFits(TH1F* hSeg, TGraph* gr);
 
        public:
         /// Plane ID (unique identifier). Although it is not linked to any TRestDetectorReadout it is

--- a/source/framework/analysis/src/TRestDataSetGainMap.cxx
+++ b/source/framework/analysis/src/TRestDataSetGainMap.cxx
@@ -725,8 +725,6 @@ void TRestDataSetGainMap::Module::GenerateGainMap() {
 
     dataSet.SetDataFrame(dataSet.MakeCut(p->GetCut()));
 
-    SetSplits();
-
     if (fSplitX.empty()) SetSplitX();
     if (fSplitY.empty()) SetSplitY();
 

--- a/source/framework/analysis/src/TRestDataSetGainMap.cxx
+++ b/source/framework/analysis/src/TRestDataSetGainMap.cxx
@@ -1412,7 +1412,15 @@ void TRestDataSetGainMap::Module::DrawLinearFit(TCanvas* c) {
     }
 }
 
-void TRestDataSetGainMap::Module::DrawGainMap(const int peakNumber) {
+/////////////////////////////////////////////
+/// \brief Function to draw the relative gain map for a given energy peak of the module.
+///
+/// \param peakNumber The index of the peak to be drawn (remember they are in descending order).
+/// \param fullModuleAsRef If true, it will use the peak position at the full module spectrum
+/// as reference for the gain map. If false, it will use the centered segment of the module
+/// as reference.
+///
+void TRestDataSetGainMap::Module::DrawGainMap(const int peakNumber, bool fullModuleAsRef) {
     if (peakNumber < 0 || peakNumber >= (int)fEnergyPeaks.size()) {
         RESTError << "Peak number out of range (peakNumber should be between 0 and "
                   << fEnergyPeaks.size() - 1 << " )" << p->RESTendl;
@@ -1437,7 +1445,12 @@ void TRestDataSetGainMap::Module::DrawGainMap(const int peakNumber) {
     TH2F* hGainMap = new TH2F(("h" + t).c_str(), title.c_str(), fNumberOfSegmentsX, fReadoutRange.X(),
                               fReadoutRange.Y(), fNumberOfSegmentsY, fReadoutRange.X(), fReadoutRange.Y());
 
-    const double peakPosRef = fFullLinearFit->GetPointX(peakNumber);
+    double peakPosRef = fFullLinearFit->GetPointX(peakNumber);
+    if (!fullModuleAsRef) {
+        int index_x = fNumberOfSegmentsX > 0 ? (fNumberOfSegmentsX - 1) / 2 : 0;
+        int index_y = fNumberOfSegmentsY > 0 ? (fNumberOfSegmentsY - 1) / 2 : 0;
+        peakPosRef = fSegLinearFit[index_x][index_y]->GetPointX(peakNumber);
+    }
 
     auto itX = fSplitX.begin();
     for (size_t i = 0; i < fSegLinearFit.size(); i++) {

--- a/source/framework/analysis/src/TRestDataSetGainMap.cxx
+++ b/source/framework/analysis/src/TRestDataSetGainMap.cxx
@@ -298,7 +298,7 @@ void TRestDataSetGainMap::CalibrateDataSet(const std::string& dataSetFileName, s
         if (eC.find("*") != std::string::npos || eC.find("?") != std::string::npos) {
             for (auto& c : columns)
                 if (MatchString(c, eC)) excludeCol.insert(c);
-        } else
+        } else if (std::find(columns.begin(), columns.end(), eC) != columns.end())
             excludeCol.insert(eC);
     }
     // Remove the calibObsName, calibObsNameFullSpc and pmIDname from the list of columns to be excluded
@@ -306,7 +306,7 @@ void TRestDataSetGainMap::CalibrateDataSet(const std::string& dataSetFileName, s
     excludeCol.erase(calibObsNameFullSpc);
     excludeCol.erase(pmIDname);
 
-    RESTDebug << "Excluding columns: " << RESTendl;
+    RESTDebug << "Excluding columns: ";
     for (auto& c : excludeCol) RESTDebug << c << ", ";
     RESTDebug << RESTendl;
 
@@ -513,8 +513,16 @@ void TRestDataSetGainMap::Export(const std::string& fileName) {
 void TRestDataSetGainMap::PrintMetadata() {
     TRestMetadata::PrintMetadata();
     RESTMetadata << " Calibration dataset: " << fCalibFileName << RESTendl;
-    if (fCut) fCut->Print();
+    if (fCut) {
+        RESTMetadata << " Cuts applied: ";
+        /* print only cutStrings and paramCut because
+        TRestDataSet::MakeCut() uses fCut->GetCutStrings() and fCut->GetParamCut() */
+        for (const auto& cut : fCut->GetCutStrings()) RESTMetadata << cut << ", " << RESTendl;
+        for (const auto& cut : fCut->GetParamCut())
+            RESTMetadata << cut.first << " " << cut.second << ", " << RESTendl;
+    }
     RESTMetadata << " Output file: " << fOutputFileName << RESTendl;
+    RESTMetadata << RESTendl;
     RESTMetadata << " Number of planes:  " << GetNumberOfPlanes() << RESTendl;
     RESTMetadata << " Number of modules: " << GetNumberOfModules() << RESTendl;
     RESTMetadata << " Calibration observable: " << fObservable << RESTendl;

--- a/source/framework/analysis/src/TRestDataSetGainMap.cxx
+++ b/source/framework/analysis/src/TRestDataSetGainMap.cxx
@@ -218,6 +218,7 @@ void TRestDataSetGainMap::CalibrateDataSet(const std::string& dataSetFileName, s
     }
 
     TRestDataSet dataSet;
+    dataSet.EnableMultiThreading(true);
     dataSet.Import(dataSetFileName);
     auto dataFrame = dataSet.GetDataFrame();
 
@@ -628,6 +629,7 @@ void TRestDataSetGainMap::Module::GenerateGainMap() {
     }
     if (!TRestTools::isDataSet(dsFileName)) RESTWarning << dsFileName << " is not a dataset." << p->RESTendl;
     TRestDataSet dataSet;
+    dataSet.EnableMultiThreading(true);
     dataSet.Import(dsFileName);
     fDataSetFileName = dsFileName;
 

--- a/source/framework/analysis/src/TRestDataSetGainMap.cxx
+++ b/source/framework/analysis/src/TRestDataSetGainMap.cxx
@@ -186,6 +186,8 @@ void TRestDataSetGainMap::InitFromConfigFile() {
         moduleDefinition = GetNextElement(moduleDefinition);
     }
 
+    fCut = (TRestCut*)InstantiateChildMetadata("TRestCut");
+
     if (GetVerboseLevel() >= TRestStringOutput::REST_Verbose_Level::REST_Debug) PrintMetadata();
 }
 
@@ -347,6 +349,7 @@ TRestDataSetGainMap& TRestDataSetGainMap::operator=(TRestDataSetGainMap& src) {
     fObservable = src.GetObservable();
     fSpatialObservableX = src.GetSpatialObservableX();
     fSpatialObservableY = src.GetSpatialObservableY();
+    fCut = src.GetCut();
     fModulesCal.clear();
     for (auto pID : src.GetPlaneIDs())
         for (auto mID : src.GetModuleIDs(pID)) fModulesCal.push_back(*src.GetModule(pID, mID));
@@ -432,6 +435,7 @@ void TRestDataSetGainMap::Export(const std::string& fileName) {
 void TRestDataSetGainMap::PrintMetadata() {
     TRestMetadata::PrintMetadata();
     RESTMetadata << " Calibration dataset: " << fCalibFileName << RESTendl;
+    if (fCut) fCut->Print();
     RESTMetadata << " Output file: " << fOutputFileName << RESTendl;
     RESTMetadata << " Number of planes:  " << GetNumberOfPlanes() << RESTendl;
     RESTMetadata << " Number of modules: " << GetNumberOfModules() << RESTendl;
@@ -632,6 +636,8 @@ void TRestDataSetGainMap::Module::GenerateGainMap() {
     dataSet.EnableMultiThreading(true);
     dataSet.Import(dsFileName);
     fDataSetFileName = dsFileName;
+
+    dataSet.SetDataFrame(dataSet.MakeCut(p->GetCut()));
 
     SetSplits();
 


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Large: 526](https://badgen.net/badge/PR%20Size/Large%3A%20526/red) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=alvaroEzq_gmFix)](https://github.com/rest-for-physics/framework/commits/alvaroEzq_gmFix) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Bugs fixing:
- TRestDataSetGainMap::Module::DrawSpectrum and DrawLinearFit didnt associate properly the subpad canvas to the corresponding spectrum/linearfit. 
- TRestDataSetGainMap::Module::DrawGainMap had fNumberOfSegmentsX and fNumberOfSegmentsY swapped.

Improvements:
- Description for class attributes and cleaning header comments
- Add cuts to apply to the input calibration TRestDataSet. Printing of the cut was implemented here because the TRestCut::PrintMetadata() does not show the cuts (maybe this should be addressed there instead...)
- Possibility to exclude columns in TRestDatasetGainMap::CalibrateDataSet to exported TRestDataSet
- Add whole module spectrum and calibration. For this, two private methods were added to avoid duplicated code.