### PR TITLE
Adding possibility to add a list of files to TRestDataSet 

### DIFF
--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -213,6 +213,6 @@ class TRestDataSet : public TRestMetadata {
     TRestDataSet(const char* cfgFileName, const std::string& name = "");
     ~TRestDataSet();
 
-    ClassDefOverride(TRestDataSet, 7);
+    ClassDefOverride(TRestDataSet, 8);
 };
 #endif

--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -105,6 +105,9 @@ class TRestDataSet : public TRestMetadata {
     /// A list of new columns together with its corresponding expressions added to the dataset
     std::vector<std::pair<std::string, std::string>> fColumnNameExpressions;  //<
 
+    /// List of files to generate the dataSet
+    std::vector<std::string> fFileList;  //!
+
     /// A flag to enable Multithreading during dataframe generation
     Bool_t fMT = false;  //<
 
@@ -181,6 +184,7 @@ class TRestDataSet : public TRestMetadata {
     inline auto GetCut() const { return fCut; }
     inline auto IsMergedDataSet() const { return fMergedDataset; }
 
+    inline void SetFileList(const std::vector<std::string>& fileList) { fFileList = fileList; }
     inline void SetObservablesList(const std::vector<std::string>& obsList) { fObservablesList = obsList; }
     inline void SetFilePattern(const std::string& pattern) { fFilePattern = pattern; }
     inline void SetQuantity(const std::map<std::string, RelevantQuantity>& quantity) { fQuantity = quantity; }

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -389,16 +389,16 @@ std::vector<std::string> TRestDataSet::FileSelection() {
         return fFileSelection;
     }
 
-    std::vector<std::string> fileNames = TRestTools::GetFilesMatchingPattern(fFilePattern);
+    if(fFileList.empty())fFileList = TRestTools::GetFilesMatchingPattern(fFilePattern);
 
     RESTInfo << "TRestDataSet::FileSelection. Starting file selection." << RESTendl;
-    RESTInfo << "Total files : " << fileNames.size() << RESTendl;
+    RESTInfo << "Total files : " << fFileList.size() << RESTendl;
     RESTInfo << "This process may take long computation time in case there are many files." << RESTendl;
 
     fTotalDuration = 0;
     std::cout << "Processing file selection.";
     int cnt = 1;
-    for (const auto& file : fileNames) {
+    for (const auto& file : fFileList) {
         if (cnt % 100 == 0) {
             std::cout << std::endl;
             std::cout << "Files processed: " << cnt << " ." << std::flush;


### PR DESCRIPTION
Added the posibility to add a file list instead of a file pattern in TRestDataSet.

Note that if the file list is empty it will just use the file pattern provided, however the file pattern will be ignored if the file list is not empty.