### PR TITLE
Fix typo

### DIFF
--- a/source/framework/analysis/src/TRestDataSetCalibration.cxx
+++ b/source/framework/analysis/src/TRestDataSetCalibration.cxx
@@ -192,7 +192,7 @@ void TRestDataSetCalibration::Calibrate() {
 
     if (fCalibFile.empty()) {
         auto histo = dataSet.GetDataFrame().Histo1D(
-            {"spectrum", "spectrum", fNBins, fCalibRange.X(), fCalibRange.X()}, fCalObservable);
+            {"spectrum", "spectrum", fNBins, fCalibRange.X(), fCalibRange.Y()}, fCalObservable);
         spectrum = std::unique_ptr<TH1F>(static_cast<TH1F*>(histo->DrawClone()));
 
         // Get position of the maximum


### PR DESCRIPTION
![JPorron](https://badgen.net/badge/PR%20submitted%20by%3A/JPorron/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jporron-dataset-calibration2)](https://github.com/rest-for-physics/framework/commits/jporron-dataset-calibration2) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Please, REMOVE this text! This is just a template to serve as a reminder.

Please, give as much detail as possible at your PR and create the simplest possible PR to facilitate reviewing.

If your PR fixes a given issue, please specify the number followed by #

Fixes #

Give a detailed list of changes proposed in this pull-request. For example:
- Feature added ...
- Upgraded class TRestXYZ to ...
- Added pipeline validation ...
- Documented ...
- Example added at ...
- Script ...


Once your PR is approved remember to **increase the framework release** version following [these instructions](https://rest-for-physics.github.io/rest-advanced/new-release.html#submitting-a-new-rest-official-release). Remember to have a look to our general [contribution guide](https://github.com/rest-for-physics/framework/blob/master/CONTRIBUTING.md).

Reminder: Please, new features and upgrades should be sufficiently documented and a corresponding validation test at the pipeline should be implemented.

Reminder: Adding this to your PR description will notify members at the core_dev team: @rest-for-physics/core_dev

Reminder: When writing your PR description remember to leave any necessary instructions to test the new implementation.

Reminder: to set-up the PR in the draft state when there is still work in progress, and make it ready once all pipelines have suceeded.