### PR TITLE
Fix Typo

### DIFF
--- a/source/framework/analysis/src/TRestDataSetCalibration.cxx
+++ b/source/framework/analysis/src/TRestDataSetCalibration.cxx
@@ -192,7 +192,7 @@ void TRestDataSetCalibration::Calibrate() {
 
     if (fCalibFile.empty()) {
         auto histo = dataSet.GetDataFrame().Histo1D(
-            {"spectrum", "spectrum", fNBins, fCalibRange.X(), fCalibRange.X()}, fCalObservable);
+            {"spectrum", "spectrum", fNBins, fCalibRange.X(), fCalibRange.Y()}, fCalObservable);
         spectrum = std::unique_ptr<TH1F>(static_cast<TH1F*>(histo->DrawClone()));
 
         // Get position of the maximum


### PR DESCRIPTION
![JPorron](https://badgen.net/badge/PR%20submitted%20by%3A/JPorron/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jporron-dataset-calibration)](https://github.com/rest-for-physics/framework/commits/jporron-dataset-calibration) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

A typo was preventing the interval selection to be chosen for the histogram to be calibrated.