### PR TITLE
TRestDataSetPlot improvements

### DIFF
--- a/source/framework/core/inc/TRestDataSetPlot.h
+++ b/source/framework/core/inc/TRestDataSetPlot.h
@@ -95,6 +95,7 @@ class TRestDataSetPlot : public TRestMetadata {
         std::vector<std::pair<std::array<std::string, 3>, TVector2>> variablePos;
         std::vector<std::pair<std::array<std::string, 3>, TVector2>> metadataPos;
         std::vector<std::pair<std::array<std::string, 3>, TVector2>> obsPos;
+        std::vector<std::pair<std::array<std::string, 3>, TVector2>> expPos;
 
         TRestCut* panelCut = nullptr;
 
@@ -182,6 +183,6 @@ class TRestDataSetPlot : public TRestMetadata {
     TRestDataSetPlot(const char* configFilename, std::string name = "");
     ~TRestDataSetPlot();
 
-    ClassDefOverride(TRestDataSetPlot, 1);
+    ClassDefOverride(TRestDataSetPlot, 2);
 };
 #endif

--- a/source/framework/core/src/TRestDataSetPlot.cxx
+++ b/source/framework/core/src/TRestDataSetPlot.cxx
@@ -93,7 +93,9 @@
 /// Different keys are provided: `metadata` is meant for the metadata info inside the
 /// TRestDataSet (as a RelevantQuantity), `variable` for a predefined variable e.g. rate,
 /// `observable` for an observable value and `expression` for a mathematical expression
-/// that can contain any of the previous.
+/// that can contain any of the previous. Note that the time-related variables _startTime_,
+/// _endTime_ and _runLength_ (then _meanRate_ too) are obtained from the TRestDataSet and
+/// not the RDataFrame of the TRestDataSet, thus they are not afected by the cuts.
 /// All the keys have the same structure which is detailed below:
 /// * **value**: Name of the metadata, variable or observable value.
 /// * **label**: String of the label that will be written before the observable value.
@@ -109,6 +111,10 @@
 ///          <metadata value="[TRestRun::fRunTag]" label="Run tag" x="0.25" y="0.82" />
 ///          <variable value="[[entries]]" label="Entries" x="0.25" y="0.58" />
 ///          <observable value="alphaTrackAna_angle" label="Mean Angle" units="rad" x="0.25" y="0.01" />
+///          <expression value="cos(alphaTrackAna_angle)^2" label="Cosine of the mean angle" units="" x="0.25"
+///          y="0.12" />
+///          <expression value="[TRestDetector::fDriftField]*[TRestDetector::fPressure]" label="Drift field"
+///          units="V/cm" x="0.25" y="0.24" />
 ///          <addCut name="Fiducial"/>
 ///    </panel>
 /// \endcode

--- a/source/framework/core/src/TRestDataSetPlot.cxx
+++ b/source/framework/core/src/TRestDataSetPlot.cxx
@@ -589,6 +589,41 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
         paramMap["[[runLength]]"] = StringWithPrecision(runLength, panel.precision);
         paramMap["[[entries]]"] = StringWithPrecision(entries, panel.precision);
         paramMap["[[meanRate]]"] = StringWithPrecision(meanRate, panel.precision);
+
+        paramMap["[[cutNames]]"] = "";
+        paramMap["[[cuts]]"] = "";
+        if (fCut) {
+            for (const auto& cut : fCut->GetCuts()) {
+                if (paramMap["[[cutNames]]"].empty())
+                    paramMap["[[cutNames]]"] += cut.GetName();
+                else
+                    paramMap["[[cutNames]]"] += "," + (std::string)cut.GetName();
+                if (paramMap["[[cuts]]"].empty())
+                    paramMap["[[cuts]]"] += cut.GetTitle();
+                else
+                    paramMap["[[cuts]]"] += " && " + (std::string)cut.GetTitle();
+            }
+        }
+
+        paramMap["[[panelCutNames]]"] = "";
+        paramMap["[[panelCuts]]"] = "";
+        if (panel.panelCut) {
+            for (const auto& cut : panel.panelCut->GetCuts()) {
+                if (paramMap["[[panelCutNames]]"].empty())
+                    paramMap["[[panelCutNames]]"] += cut.GetName();
+                else
+                    paramMap["[[panelCutNames]]"] += "," + (std::string)cut.GetName();
+                if (paramMap["[[panelCuts]]"].empty())
+                    paramMap["[[panelCuts]]"] += cut.GetTitle();
+                else
+                    paramMap["[[panelCuts]]"] += " && " + (std::string)cut.GetTitle();
+            }
+        }
+
+        RESTInfo << "Global cuts: " << paramMap["[[cuts]]"] << RESTendl;
+        if (!paramMap["[[panelCuts]]"].empty())
+            RESTInfo << "Additional panel cuts: " << paramMap["[[panelCuts]]"] << RESTendl;
+
         // Replace panel variables and generate a TLatex label
         for (const auto& [key, posLabel] : panel.variablePos) {
             auto&& [variable, label, units] = key;

--- a/source/framework/core/src/TRestDataSetPlot.cxx
+++ b/source/framework/core/src/TRestDataSetPlot.cxx
@@ -256,6 +256,8 @@
 /// 2023-04: First implementation of TRestDataSetPlot, based on TRestAnalysisPlot
 /// JuanAn Garcia
 ///
+/// 2024-05: Extend some functionalities, Álvaro Ezquerro
+///
 /// \class TRestDataSetPlot
 /// \author: JuanAn Garcia   e-mail: juanangp@unizar.es
 ///

--- a/source/framework/core/src/TRestDataSetPlot.cxx
+++ b/source/framework/core/src/TRestDataSetPlot.cxx
@@ -537,6 +537,7 @@ void TRestDataSetPlot::GenerateDataSetFromFilePattern(TRestDataSet& dataSet) {
 ///
 void TRestDataSetPlot::PlotCombinedCanvas() {
     TRestDataSet dataSet;
+    dataSet.EnableMultiThreading(true);
 
     // Import dataSet
     dataSet.Import(fDataSetName);

--- a/source/framework/core/src/TRestDataSetPlot.cxx
+++ b/source/framework/core/src/TRestDataSetPlot.cxx
@@ -776,24 +776,18 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
             // Scale histos
             if (plots.scale != "") {
                 std::string inputScale = plots.scale;
-                while (inputScale.find("binSize") != std::string::npos) {
-                    double binSize = hist.histo->GetXaxis()->GetBinWidth(1);
-                    inputScale.replace(inputScale.find("binSize"), 7, DoubleToString(binSize));
-                }
-                while (inputScale.find("entries") != std::string::npos) {
-                    double entries = hist.histo->GetEntries();
-                    inputScale.replace(inputScale.find("entries"), 7, DoubleToString(entries));
-                }
-                while (inputScale.find("runLength") != std::string::npos) {
-                    double runLength = dataSet.GetTotalTimeInSeconds() / 3600.;  // in hours
-                    inputScale.replace(inputScale.find("runLength"), 9, DoubleToString(runLength));
-                }
-                while (inputScale.find("integral") != std::string::npos) {
-                    double integral = hist.histo->Integral("width");
-                    inputScale.replace(inputScale.find("integral"), 8, DoubleToString(integral));
-                }
+                double binSize = hist.histo->GetXaxis()->GetBinWidth(1);
+                double entries = hist.histo->GetEntries();
+                double runLength = dataSet.GetTotalTimeInSeconds() / 3600.;  // in hours
+                double integral = hist.histo->Integral("width");
+
+                inputScale = Replace(inputScale, "binSize", DoubleToString(binSize));
+                inputScale = Replace(inputScale, "entries", DoubleToString(entries));
+                inputScale = Replace(inputScale, "runLength", DoubleToString(runLength));
+                inputScale = Replace(inputScale, "integral", DoubleToString(integral));
+
                 std::string scale = "1./(" + inputScale + ")";
-                hist.histo->Scale(StringToDouble(EvaluateExpression(scale)));
+                hist.histo->Scale(StringToDouble(EvaluateExpression(scale)));  // -1 if 'scale' isn't valid
             }
 
             // Add histos to the THStack


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Medium: 159](https://badgen.net/badge/PR%20Size/Medium%3A%20159/orange) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=aezquerro_dsPlot)](https://github.com/rest-for-physics/framework/commits/aezquerro_dsPlot) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- Extended the _scale_ option to use any mathematical expression in combination with the special keywords.
New keywords:
  - _entries_
  - _runLength_
  - _integral_

- Add _cuts_, _cutNames_, _panelCut_ and _panelCutNames_ to paramMap to be able to show them in the panel (in the same way as _meanRate_ for example). Also add RESTinfo message to output the global and additional panel cuts applied.

- EnableMultiThreading when handling the TRestDataSet (avoids annoying _"Warning in <ROOT_TImplicitMT_DisableImplicitMT>: Implicit multi-threading is already disabled"_ message)

- Added new key _expression_ in panel definition to parse a mathematical expression that can contain any of the previous key values (variable, metadata and observable). It is a generalization of these previous keys, so this new _expression_ key could replace them for good but I keep them for retrocompatibility.