### PR TITLE
Adding IAXO sensitivity examples and updating sensitivity classes when necessary

### DIFF
--- a/source/framework/sensitivity/inc/TRestComponent.h
+++ b/source/framework/sensitivity/inc/TRestComponent.h
@@ -55,6 +55,18 @@ class TRestComponent : public TRestMetadata {
     /// It defines the nodes of the parameterization (Initialized by the dataset)
     std::vector<Double_t> fParameterizationNodes;  //<
 
+	/// It defines the first parametric node value in case of automatic parameter generation
+	Double_t fFirstParameterValue = 0;
+	
+	/// It defines the upper limit for the automatic parametric node values generation
+	Double_t fLastParameterValue = 0;
+
+	/// It defines the increasing step for automatic parameter list generation
+	Double_t fStepParameterValue = 0;
+
+	/// It true the parametric values automatically generated will grow exponentially
+	Bool_t fExponential = false;
+	
     /// It is used to define the node that will be accessed for rate retrieval
     Int_t fActiveNode = -1;  //<
 

--- a/source/framework/sensitivity/inc/TRestComponent.h
+++ b/source/framework/sensitivity/inc/TRestComponent.h
@@ -56,16 +56,16 @@ class TRestComponent : public TRestMetadata {
     std::vector<Double_t> fParameterizationNodes;  //<
 
 	/// It defines the first parametric node value in case of automatic parameter generation
-	Double_t fFirstParameterValue = 0;
+	Double_t fFirstParameterValue = 0; //<
 	
 	/// It defines the upper limit for the automatic parametric node values generation
-	Double_t fLastParameterValue = 0;
+	Double_t fLastParameterValue = 0; //<
 
 	/// It defines the increasing step for automatic parameter list generation
-	Double_t fStepParameterValue = 0;
+	Double_t fStepParameterValue = 0; //<
 
 	/// It true the parametric values automatically generated will grow exponentially
-	Bool_t fExponential = false;
+	Bool_t fExponential = false; //<
 	
     /// It is used to define the node that will be accessed for rate retrieval
     Int_t fActiveNode = -1;  //<

--- a/source/framework/sensitivity/inc/TRestComponent.h
+++ b/source/framework/sensitivity/inc/TRestComponent.h
@@ -101,6 +101,8 @@ class TRestComponent : public TRestMetadata {
     void Initialize() override;
     void RegenerateHistograms(UInt_t seed = 0);
 
+	void RegenerateParametricNodes(Double_t from, Double_t to, Double_t step, Bool_t expIncrease = false);
+
     /// It returns true if any nodes have been defined.
     Bool_t HasNodes() { return !fParameterizationNodes.empty(); }
 

--- a/source/framework/sensitivity/inc/TRestComponent.h
+++ b/source/framework/sensitivity/inc/TRestComponent.h
@@ -55,18 +55,18 @@ class TRestComponent : public TRestMetadata {
     /// It defines the nodes of the parameterization (Initialized by the dataset)
     std::vector<Double_t> fParameterizationNodes;  //<
 
-	/// It defines the first parametric node value in case of automatic parameter generation
-	Double_t fFirstParameterValue = 0; //<
-	
-	/// It defines the upper limit for the automatic parametric node values generation
-	Double_t fLastParameterValue = 0; //<
+    /// It defines the first parametric node value in case of automatic parameter generation
+    Double_t fFirstParameterValue = 0;  //<
 
-	/// It defines the increasing step for automatic parameter list generation
-	Double_t fStepParameterValue = 0; //<
+    /// It defines the upper limit for the automatic parametric node values generation
+    Double_t fLastParameterValue = 0;  //<
 
-	/// It true the parametric values automatically generated will grow exponentially
-	Bool_t fExponential = false; //<
-	
+    /// It defines the increasing step for automatic parameter list generation
+    Double_t fStepParameterValue = 0;  //<
+
+    /// It true the parametric values automatically generated will grow exponentially
+    Bool_t fExponential = false;  //<
+
     /// It is used to define the node that will be accessed for rate retrieval
     Int_t fActiveNode = -1;  //<
 
@@ -113,7 +113,7 @@ class TRestComponent : public TRestMetadata {
     void Initialize() override;
     void RegenerateHistograms(UInt_t seed = 0);
 
-	void RegenerateParametricNodes(Double_t from, Double_t to, Double_t step, Bool_t expIncrease = false);
+    void RegenerateParametricNodes(Double_t from, Double_t to, Double_t step, Bool_t expIncrease = false);
 
     /// It returns true if any nodes have been defined.
     Bool_t HasNodes() { return !fParameterizationNodes.empty(); }
@@ -126,11 +126,11 @@ class TRestComponent : public TRestMetadata {
     size_t GetDimensions() { return fVariables.size(); }
     Int_t GetSamples() { return fSamples; }
     Int_t GetActiveNode() { return fActiveNode; }
-    Double_t GetActiveNodeValue() { 
-		if( fActiveNode >= 0 && fActiveNode < (Int_t) fParameterizationNodes.size() )
-		   	return fParameterizationNodes[fActiveNode]; 
-		return 0; 
-	}
+    Double_t GetActiveNodeValue() {
+        if (fActiveNode >= 0 && fActiveNode < (Int_t)fParameterizationNodes.size())
+            return fParameterizationNodes[fActiveNode];
+        return 0;
+    }
     std::vector<Double_t> GetParameterizationNodes() { return fParameterizationNodes; }
 
     std::vector<std::string> GetVariables() const { return fVariables; }
@@ -139,8 +139,8 @@ class TRestComponent : public TRestMetadata {
 
     Double_t GetRawRate(std::vector<Double_t> point);
     Double_t GetTotalRate();
-	Double_t GetMaxRate();
-	Double_t GetAllNodesIntegratedRate();
+    Double_t GetMaxRate();
+    Double_t GetAllNodesIntegratedRate();
     Double_t GetNormalizedRate(std::vector<Double_t> point);
     Double_t GetRate(std::vector<Double_t> point);
 

--- a/source/framework/sensitivity/inc/TRestComponent.h
+++ b/source/framework/sensitivity/inc/TRestComponent.h
@@ -189,6 +189,6 @@ class TRestComponent : public TRestMetadata {
     TRestComponent();
     ~TRestComponent();
 
-    ClassDefOverride(TRestComponent, 5);
+    ClassDefOverride(TRestComponent, 6);
 };
 #endif

--- a/source/framework/sensitivity/inc/TRestComponent.h
+++ b/source/framework/sensitivity/inc/TRestComponent.h
@@ -115,7 +115,7 @@ class TRestComponent : public TRestMetadata {
     Int_t GetSamples() { return fSamples; }
     Int_t GetActiveNode() { return fActiveNode; }
     Double_t GetActiveNodeValue() { 
-		if( fActiveNode >= 0 && fActiveNode < fParameterizationNodes.size() )
+		if( fActiveNode >= 0 && fActiveNode < (Int_t) fParameterizationNodes.size() )
 		   	return fParameterizationNodes[fActiveNode]; 
 		return 0; 
 	}

--- a/source/framework/sensitivity/inc/TRestComponent.h
+++ b/source/framework/sensitivity/inc/TRestComponent.h
@@ -139,6 +139,8 @@ class TRestComponent : public TRestMetadata {
 
     Double_t GetRawRate(std::vector<Double_t> point);
     Double_t GetTotalRate();
+	Double_t GetMaxRate();
+	Double_t GetAllNodesIntegratedRate();
     Double_t GetNormalizedRate(std::vector<Double_t> point);
     Double_t GetRate(std::vector<Double_t> point);
 

--- a/source/framework/sensitivity/inc/TRestComponent.h
+++ b/source/framework/sensitivity/inc/TRestComponent.h
@@ -112,7 +112,11 @@ class TRestComponent : public TRestMetadata {
     size_t GetDimensions() { return fVariables.size(); }
     Int_t GetSamples() { return fSamples; }
     Int_t GetActiveNode() { return fActiveNode; }
-    Double_t GetActiveNodeValue() { return fParameterizationNodes[fActiveNode]; }
+    Double_t GetActiveNodeValue() { 
+		if( fActiveNode >= 0 && fActiveNode < fParameterizationNodes.size() )
+		   	return fParameterizationNodes[fActiveNode]; 
+		return 0; 
+	}
     std::vector<Double_t> GetParameterizationNodes() { return fParameterizationNodes; }
 
     std::vector<std::string> GetVariables() const { return fVariables; }

--- a/source/framework/sensitivity/inc/TRestComponentFormula.h
+++ b/source/framework/sensitivity/inc/TRestComponentFormula.h
@@ -35,7 +35,7 @@ class TRestComponentFormula : public TRestComponent {
     std::vector<TFormula> fFormulas;
 
     /// The formulas should be expressed in the following units
-    std::string fUnits = "cm^-2*keV^-1";  //<
+    std::string fFormulaUnits = "cm^-2*keV^-1";  //<
 
    protected:
     void InitFromConfigFile() override;

--- a/source/framework/sensitivity/inc/TRestExperiment.h
+++ b/source/framework/sensitivity/inc/TRestExperiment.h
@@ -52,7 +52,7 @@ class TRestExperiment : public TRestMetadata {
 
     /// Only if it is true we will be able to calculate the LogLikelihood
     Bool_t fDataReady = false;  //<
-								
+
     /// The mock dataset will be generated using the mean counts instead of a real MonteCarlo
     Bool_t fUseAverage = false;  //<
 
@@ -69,7 +69,7 @@ class TRestExperiment : public TRestMetadata {
     void InitFromConfigFile() override;
 
    public:
-    void GenerateMockDataSet( Bool_t useAverage = false);
+    void GenerateMockDataSet(Bool_t useAverage = false);
     Int_t GetExperimentalCounts() const { return fExperimentalCounts; }
 
     Bool_t IsMockData() const { return fMockData; }

--- a/source/framework/sensitivity/inc/TRestExperiment.h
+++ b/source/framework/sensitivity/inc/TRestExperiment.h
@@ -52,6 +52,9 @@ class TRestExperiment : public TRestMetadata {
 
     /// Only if it is true we will be able to calculate the LogLikelihood
     Bool_t fDataReady = false;  //<
+								
+    /// The mock dataset will be generated using the mean counts instead of a real MonteCarlo
+    Bool_t fUseAverage = false;  //<
 
     /// It keeps track on the number of counts inside the dataset
     Int_t fExperimentalCounts = 0;  //<
@@ -66,7 +69,7 @@ class TRestExperiment : public TRestMetadata {
     void InitFromConfigFile() override;
 
    public:
-    void GenerateMockDataSet();
+    void GenerateMockDataSet( Bool_t useAverage = false);
     Int_t GetExperimentalCounts() const { return fExperimentalCounts; }
 
     Bool_t IsMockData() const { return fMockData; }
@@ -94,6 +97,6 @@ class TRestExperiment : public TRestMetadata {
     TRestExperiment();
     ~TRestExperiment();
 
-    ClassDefOverride(TRestExperiment, 1);
+    ClassDefOverride(TRestExperiment, 2);
 };
 #endif

--- a/source/framework/sensitivity/inc/TRestExperimentList.h
+++ b/source/framework/sensitivity/inc/TRestExperimentList.h
@@ -62,7 +62,7 @@ class TRestExperimentList : public TRestMetadata {
     /// In case an exposure time is given it defines how to assign time to each experiment (equal/ksvz).
     std::string fExposureStrategy = "equal";
 
-	/// The factor used on the exponential exposure time as a function of the experiment number
+    /// The factor used on the exponential exposure time as a function of the experiment number
     Double_t fExposureFactor = 0;
 
     /// If not null this will be the common signal used in each experiment

--- a/source/framework/sensitivity/inc/TRestExperimentList.h
+++ b/source/framework/sensitivity/inc/TRestExperimentList.h
@@ -53,11 +53,17 @@ class TRestExperimentList : public TRestMetadata {
     /// The fusioned list of parameterization nodes found at each experiment signal
     std::vector<Double_t> fParameterizationNodes;  //<
 
+    /// The mock dataset will be generated using the mean counts instead of a real MonteCarlo
+    Bool_t fUseAverage = false;  //<
+
     /// If not zero this will be the common exposure time in micro-seconds (standard REST units)
     Double_t fExposureTime = 0;
 
-    /// In case an exposure time is given it defines how to assign time to each experiment (unique/ksvz).
-    std::string fExposureStrategy = "unique";
+    /// In case an exposure time is given it defines how to assign time to each experiment (equal/ksvz).
+    std::string fExposureStrategy = "equal";
+
+	/// The factor used on the exponential exposure time as a function of the experiment number
+    Double_t fExposureFactor = 0;
 
     /// If not null this will be the common signal used in each experiment
     TRestComponent* fSignal = nullptr;  //<
@@ -98,6 +104,6 @@ class TRestExperimentList : public TRestMetadata {
     TRestExperimentList();
     ~TRestExperimentList();
 
-    ClassDefOverride(TRestExperimentList, 1);
+    ClassDefOverride(TRestExperimentList, 2);
 };
 #endif

--- a/source/framework/sensitivity/inc/TRestSensitivity.h
+++ b/source/framework/sensitivity/inc/TRestSensitivity.h
@@ -61,6 +61,7 @@ class TRestSensitivity : public TRestMetadata {
 
     Double_t GetCoupling(Double_t node, Double_t sigma = 2, Double_t precision = 0.01);
     void AddCurve(const std::vector<Double_t>& curve) { fCurves.push_back(curve); }
+    void ImportCurve(const std::vector<Double_t>& curve) { AddCurve(curve); }
     void GenerateCurve();
     void GenerateCurves(Int_t N);
 

--- a/source/framework/sensitivity/src/TRestComponent.cxx
+++ b/source/framework/sensitivity/src/TRestComponent.cxx
@@ -296,13 +296,27 @@ Double_t TRestComponent::GetRawRate(std::vector<Double_t> point) {
 ///
 Double_t TRestComponent::GetTotalRate() {
     THnD* dHist = GetDensityForActiveNode();
+    if ( !dHist) return 0;
 
     Double_t integral = 0;
-    if (dHist != nullptr) {
-        TH1D* h1 = dHist->Projection(0);
-        integral = h1->Integral();
-        delete h1;
-    }
+	for (Int_t n = 0; n < dHist->GetNbins(); ++n) {
+
+		Int_t centerBin[GetDimensions()];
+		std::vector <Double_t> point;
+
+		Double_t centralDensity = dHist->GetBinContent(n, centerBin);
+		for (Int_t d = 0; d < GetDimensions(); ++d)
+			point.push_back( GetBinCenter( d, centerBin[d] ) );
+
+		Bool_t skip = false;
+		for (Int_t d = 0; d < GetDimensions(); ++d)
+		{
+			if( point[d] < fRanges[d].X() || point[d] > fRanges[d].Y() )
+				skip = true;
+		}
+		if( !skip )
+			integral += GetRate( point );
+	}
 
     return integral;
 }

--- a/source/framework/sensitivity/src/TRestComponent.cxx
+++ b/source/framework/sensitivity/src/TRestComponent.cxx
@@ -86,6 +86,9 @@ TRestComponent::~TRestComponent() {}
 void TRestComponent::Initialize() {
     //   SetSectionName(this->ClassName());
 
+	/// Avoiding double initialization
+	if( !fNodeDensity.empty() && fRandom ) return;
+
     if (!fRandom) {
         delete fRandom;
         fRandom = nullptr;
@@ -97,10 +100,11 @@ void TRestComponent::Initialize() {
 	if( fStepParameterValue > 0 )
 	{
 		RegenerateParametricNodes( fFirstParameterValue, fLastParameterValue, fStepParameterValue, fExponential );
-		RegenerateHistograms( fSeed );
 	}
 	else
-		FillHistograms();
+	{
+		if( !fParameterizationNodes.empty() ) FillHistograms();
+	}
 }
 
 /////////////////////////////////////////////
@@ -123,6 +127,11 @@ void TRestComponent::RegenerateHistograms(UInt_t seed) {
 ///
 void TRestComponent::RegenerateParametricNodes(Double_t from, Double_t to, Double_t step, Bool_t expIncrease )
 {
+	fStepParameterValue = step;
+	fFirstParameterValue = from;
+	fLastParameterValue = to;
+	fExponential = expIncrease;
+
 	fParameterizationNodes.clear();
 
 	if( expIncrease ) {
@@ -135,6 +144,7 @@ void TRestComponent::RegenerateParametricNodes(Double_t from, Double_t to, Doubl
 			fParameterizationNodes.push_back(p);
 	}
 
+	if( fParameterizationNodes.empty() ) return;
 	RegenerateHistograms( fSeed );
 }
 
@@ -610,7 +620,7 @@ void TRestComponent::PrintMetadata() {
         }
     }
 
-    if (!fParameter.empty()) {
+    if (!fParameterizationNodes.empty()) {
         RESTMetadata << " " << RESTendl;
         RESTMetadata << " === Parameterization === " << RESTendl;
         RESTMetadata << "- Parameter : " << fParameter << RESTendl;

--- a/source/framework/sensitivity/src/TRestComponent.cxx
+++ b/source/framework/sensitivity/src/TRestComponent.cxx
@@ -110,6 +110,28 @@ void TRestComponent::RegenerateHistograms(UInt_t seed) {
     FillHistograms();
 }
 
+/////////////////////////////////////////////
+/// \brief It allows to produce a parameter nodes list providing the initial
+/// value, the final value and the step. We might chose the step growing in
+/// linear increase steps or exponential. Linear is the default value.
+///
+void TRestComponent::RegenerateParametricNodes(Double_t from, Double_t to, Double_t step, Bool_t expIncrease )
+{
+	fParameterizationNodes.clear();
+
+	if( expIncrease ) {
+		for( double p = from; p < to; p *= step )
+			fParameterizationNodes.push_back(p); 
+	}
+	else
+	{
+		for( double p = from; p < to; p += step )
+			fParameterizationNodes.push_back(p);
+	}
+
+	RegenerateHistograms( fSeed );
+}
+
 ///////////////////////////////////////////
 /// \brief It returns the position of the fVariable element for the variable
 /// name given by argument.

--- a/source/framework/sensitivity/src/TRestComponent.cxx
+++ b/source/framework/sensitivity/src/TRestComponent.cxx
@@ -114,8 +114,6 @@ void TRestComponent::RegenerateHistograms(UInt_t seed) {
 
     fSeed = seed;
     TRestComponent::Initialize();
-
-    FillHistograms();
 }
 
 /////////////////////////////////////////////

--- a/source/framework/sensitivity/src/TRestComponent.cxx
+++ b/source/framework/sensitivity/src/TRestComponent.cxx
@@ -113,7 +113,7 @@ void TRestComponent::RegenerateHistograms(UInt_t seed) {
     fNodeDensity.clear();
 
     fSeed = seed;
-    TRestComponent::Initialize();
+	FillHistograms();
 }
 
 /////////////////////////////////////////////

--- a/source/framework/sensitivity/src/TRestComponent.cxx
+++ b/source/framework/sensitivity/src/TRestComponent.cxx
@@ -287,7 +287,7 @@ Double_t TRestComponent::GetRawRate(std::vector<Double_t> point) {
     // In 3-dimensions we got 8 points to interpolate
     // In 4-dimensions we would get 16 points to interpolate
     // ...
-    Int_t nPoints = (Int_t)TMath::Power(2, (Int_t)GetDimensions());
+    Int_t nPoints = (Int_t)TMath::Power(2, (Int_t) GetDimensions());
 
     Double_t sum = 0;
     for (int n = 0; n < nPoints; n++) {
@@ -326,12 +326,12 @@ Double_t TRestComponent::GetTotalRate() {
 		Int_t centerBin[GetDimensions()];
 		std::vector <Double_t> point;
 
-		Double_t centralDensity = dHist->GetBinContent(n, centerBin);
-		for (Int_t d = 0; d < GetDimensions(); ++d)
+		dHist->GetBinContent(n, centerBin);
+		for (size_t d = 0; d < GetDimensions(); ++d)
 			point.push_back( GetBinCenter( d, centerBin[d] ) );
 
 		Bool_t skip = false;
-		for (Int_t d = 0; d < GetDimensions(); ++d)
+		for (size_t d = 0; d < GetDimensions(); ++d)
 		{
 			if( point[d] < fRanges[d].X() || point[d] > fRanges[d].Y() )
 				skip = true;

--- a/source/framework/sensitivity/src/TRestComponent.cxx
+++ b/source/framework/sensitivity/src/TRestComponent.cxx
@@ -360,6 +360,35 @@ Double_t TRestComponent::GetTotalRate() {
 }
 
 ///////////////////////////////////////////////
+/// \brief This method returns the total rate for the node that has the highest contribution
+/// The result will be returned in s-1.
+///
+Double_t TRestComponent::GetMaxRate() {
+	Double_t maxRate = 0;
+	for( size_t n = 0; n < fParameterizationNodes.size(); n++ )
+	{
+		SetActiveNode((Int_t) n);
+		Double_t rate = GetTotalRate();
+		if( rate > maxRate ) maxRate = rate;
+	}
+	return maxRate;
+}
+
+///////////////////////////////////////////////
+/// \brief This method returns the integrated total rate for all the nodes 
+/// The result will be returned in s-1.
+///
+Double_t TRestComponent::GetAllNodesIntegratedRate() {
+	Double_t rate = 0;
+	for( size_t n = 0; n < fParameterizationNodes.size(); n++ )
+	{
+		SetActiveNode((Int_t) n);
+		rate += GetTotalRate();
+	}
+	return rate;
+}
+
+///////////////////////////////////////////////
 /// \brief It returns the bin center of the given component dimension.
 ///
 /// It required implementation since I did not find a method inside THnD. Surprising.

--- a/source/framework/sensitivity/src/TRestComponent.cxx
+++ b/source/framework/sensitivity/src/TRestComponent.cxx
@@ -232,6 +232,13 @@ Double_t TRestComponent::GetRawRate(std::vector<Double_t> point) {
         return 0;
     }
 
+	for( size_t n = 0; n < point.size(); n++ )
+	{
+		// The point is outside boundaries
+		if( point[n] < fRanges[n].X() || point[n] > fRanges[n].Y() )
+			return 0;
+	}
+
     Int_t centerBin[GetDimensions()];
     Double_t centralDensity = GetDensity()->GetBinContent(GetDensity()->GetBin(point.data()), centerBin);
     if (!Interpolation()) return centralDensity;

--- a/source/framework/sensitivity/src/TRestComponent.cxx
+++ b/source/framework/sensitivity/src/TRestComponent.cxx
@@ -93,6 +93,14 @@ void TRestComponent::Initialize() {
 
     fRandom = new TRandom3(fSeed);
     fSeed = fRandom->TRandom::GetSeed();
+
+	if( fStepParameterValue > 0 )
+	{
+		RegenerateParametricNodes( fFirstParameterValue, fLastParameterValue, fStepParameterValue, fExponential );
+		RegenerateHistograms( fSeed );
+	}
+	else
+		FillHistograms();
 }
 
 /////////////////////////////////////////////
@@ -612,6 +620,19 @@ void TRestComponent::PrintMetadata() {
         RESTMetadata << " - Number of parametric nodes : " << fParameterizationNodes.size() << RESTendl;
         RESTMetadata << " " << RESTendl;
         RESTMetadata << " Use : PrintNodes() for additional info" << RESTendl;
+
+		if( fStepParameterValue > 0 )
+		{
+			RESTMetadata << " " << RESTendl;
+			RESTMetadata << " Nodes were automatically generated using these parameters" << RESTendl;
+			RESTMetadata << " - First node : " << fFirstParameterValue << RESTendl;
+			RESTMetadata << " - Upper limit node : " << fLastParameterValue << RESTendl;
+			RESTMetadata << " - Increasing step : " << fStepParameterValue << RESTendl;
+			if( fExponential ) 
+				RESTMetadata << " - Increases exponentially" << RESTendl;
+			else
+				RESTMetadata << " - Increases linearly" << RESTendl;
+		}
     }
 
     if (fResponse) {

--- a/source/framework/sensitivity/src/TRestComponentFormula.cxx
+++ b/source/framework/sensitivity/src/TRestComponentFormula.cxx
@@ -149,12 +149,11 @@ Double_t TRestComponentFormula::GetFormulaRate(std::vector<Double_t> point) {
 void TRestComponentFormula::FillHistograms() {
     if (fFormulas.empty()) return;
 
-	if( GetDimensions() == 0 ) 
-	{
-		RESTError << "TRestComponentFormula::FillHistograms. No variables defined!" << RESTendl;
-		RESTError << "Did you add a <cVariable entry?" << RESTendl;
-		return;
-	}
+    if (GetDimensions() == 0) {
+        RESTError << "TRestComponentFormula::FillHistograms. No variables defined!" << RESTendl;
+        RESTError << "Did you add a <cVariable entry?" << RESTendl;
+        return;
+    }
 
     RESTInfo << "Generating N-dim histogram for " << GetName() << RESTendl;
 
@@ -238,8 +237,8 @@ void TRestComponentFormula::InitFromConfigFile() {
 
     if (!fFormulas.empty()) return;
 
-	/// For some reason I need to do this manually. Dont understand why!
-	fFormulaUnits = GetParameter("formulaUnits");
+    /// For some reason I need to do this manually. Dont understand why!
+    fFormulaUnits = GetParameter("formulaUnits");
 
     auto ele = GetElement("formula");
     while (ele != nullptr) {

--- a/source/framework/sensitivity/src/TRestComponentFormula.cxx
+++ b/source/framework/sensitivity/src/TRestComponentFormula.cxx
@@ -131,7 +131,7 @@ Double_t TRestComponentFormula::GetFormulaRate(std::vector<Double_t> point) {
         normFactor *= (fRanges[n].Y() - fRanges[n].X()) / fNbins[n];
     }
 
-    return normFactor * result / units(fUnits);
+    return normFactor * result / units(fFormulaUnits);
 }
 
 /////////////////////////////////////////////
@@ -148,6 +148,13 @@ Double_t TRestComponentFormula::GetFormulaRate(std::vector<Double_t> point) {
 ///
 void TRestComponentFormula::FillHistograms() {
     if (fFormulas.empty()) return;
+
+	if( GetDimensions() == 0 ) 
+	{
+		RESTError << "TRestComponentFormula::FillHistograms. No variables defined!" << RESTendl;
+		RESTError << "Did you add a <cVariable entry?" << RESTendl;
+		return;
+	}
 
     RESTInfo << "Generating N-dim histogram for " << GetName() << RESTendl;
 
@@ -208,7 +215,7 @@ void TRestComponentFormula::PrintMetadata() {
     TRestComponent::PrintMetadata();
 
     RESTMetadata << " " << RESTendl;
-    RESTMetadata << "Formula units: " << fUnits << RESTendl;
+    RESTMetadata << "Formula units: " << fFormulaUnits << RESTendl;
 
     if (!fFormulas.empty()) {
         RESTMetadata << " " << RESTendl;
@@ -230,6 +237,9 @@ void TRestComponentFormula::InitFromConfigFile() {
     TRestComponent::InitFromConfigFile();
 
     if (!fFormulas.empty()) return;
+
+	/// For some reason I need to do this manually. Dont understand why!
+	fFormulaUnits = GetParameter("formulaUnits");
 
     auto ele = GetElement("formula");
     while (ele != nullptr) {

--- a/source/framework/sensitivity/src/TRestExperiment.cxx
+++ b/source/framework/sensitivity/src/TRestExperiment.cxx
@@ -153,18 +153,23 @@ void TRestExperiment::InitFromConfigFile() {
     TRestMetadata::InitFromConfigFile();
 
     int cont = 0;
-    TRestComponent* comp = (TRestComponent*)this->InstantiateChildMetadata(cont, "Component");
-    while (comp != nullptr) {
-        if (ToLower(comp->GetNature()) == "background")
-            fBackground = comp;
-        else if (ToLower(comp->GetNature()) == "signal")
-            fSignal = comp;
-        else
-            RESTWarning << "TRestExperiment::InitFromConfigFile. Unknown component!" << RESTendl;
+    TRestMetadata* md = (TRestMetadata*) this->InstantiateChildMetadata(cont);
+	while (md != nullptr) {
 
-        cont++;
-        comp = (TRestComponent*)this->InstantiateChildMetadata(cont, "Component");
-    }
+		if (md->InheritsFrom("TRestComponent")  )
+		{
+			TRestComponent *comp = (TRestComponent *) md;
+			if (ToLower(comp->GetNature()) == "background")
+				fBackground = comp;
+			else if (ToLower(comp->GetNature()) == "signal")
+				fSignal = comp;
+			else
+				RESTWarning << "TRestExperiment::InitFromConfigFile. Unknown component!" << RESTendl;
+
+		}
+		cont++;
+		md = (TRestMetadata*)this->InstantiateChildMetadata(cont);
+	}
 
     auto ele = GetElement("addComponent");
     if (ele != nullptr) {

--- a/source/framework/sensitivity/src/TRestExperiment.cxx
+++ b/source/framework/sensitivity/src/TRestExperiment.cxx
@@ -88,7 +88,7 @@ void TRestExperiment::Initialize() {
 }
 
 void TRestExperiment::GenerateMockDataSet(Bool_t useAverage) {
-	fUseAverage = useAverage;
+    fUseAverage = useAverage;
 
     if (!fBackground) {
         RESTError << "TRestExperiment::GenerateMockData. Background component was not initialized!"
@@ -104,7 +104,7 @@ void TRestExperiment::GenerateMockDataSet(Bool_t useAverage) {
     Double_t meanCounts = GetBackground()->GetTotalRate() * fExposureTime * units("s");
 
     Int_t N = fRandom->Poisson(meanCounts);
-	if( fUseAverage ) N = (Int_t) meanCounts;
+    if (fUseAverage) N = (Int_t)meanCounts;
     RESTInfo << "Experiment: " << GetName() << " Generating mock dataset. Counts: " << N << RESTendl;
 
     ROOT::RDF::RNode df = fBackground->GetMonteCarloDataFrame(N);
@@ -156,23 +156,20 @@ void TRestExperiment::InitFromConfigFile() {
     TRestMetadata::InitFromConfigFile();
 
     int cont = 0;
-    TRestMetadata* md = (TRestMetadata*) this->InstantiateChildMetadata(cont);
-	while (md != nullptr) {
-
-		if (md->InheritsFrom("TRestComponent")  )
-		{
-			TRestComponent *comp = (TRestComponent *) md;
-			if (ToLower(comp->GetNature()) == "background")
-				fBackground = comp;
-			else if (ToLower(comp->GetNature()) == "signal")
-				fSignal = comp;
-			else
-				RESTWarning << "TRestExperiment::InitFromConfigFile. Unknown component!" << RESTendl;
-
-		}
-		cont++;
-		md = (TRestMetadata*)this->InstantiateChildMetadata(cont);
-	}
+    TRestMetadata* md = (TRestMetadata*)this->InstantiateChildMetadata(cont);
+    while (md != nullptr) {
+        if (md->InheritsFrom("TRestComponent")) {
+            TRestComponent* comp = (TRestComponent*)md;
+            if (ToLower(comp->GetNature()) == "background")
+                fBackground = comp;
+            else if (ToLower(comp->GetNature()) == "signal")
+                fSignal = comp;
+            else
+                RESTWarning << "TRestExperiment::InitFromConfigFile. Unknown component!" << RESTendl;
+        }
+        cont++;
+        md = (TRestMetadata*)this->InstantiateChildMetadata(cont);
+    }
 
     auto ele = GetElement("addComponent");
     if (ele != nullptr) {
@@ -206,7 +203,7 @@ void TRestExperiment::InitFromConfigFile() {
             }
         }
     }
-	
+
     if (fExposureTime > 0 && fExperimentalDataSet.empty()) {
         GenerateMockDataSet(fUseAverage);
     } else if (fExposureTime == 0 && !fExperimentalDataSet.empty()) {
@@ -286,14 +283,14 @@ void TRestExperiment::PrintMetadata() {
 
     if (fMockData) {
         RESTMetadata << " " << RESTendl;
-        if (fMockData)
-		{
+        if (fMockData) {
             RESTMetadata << "The dataset was MC-generated" << RESTendl;
-			if( fUseAverage ) 
-				RESTMetadata << " - The number of counts in dataset was generated with the mean background counts" << RESTendl;
+            if (fUseAverage)
+                RESTMetadata
+                    << " - The number of counts in dataset was generated with the mean background counts"
+                    << RESTendl;
 
-		}
-        else {
+        } else {
             RESTMetadata << "The dataset was loaded from an existing dataset file" << RESTendl;
             if (!fExperimentalDataSet.empty())
                 RESTMetadata << " - Experimental dataset file : " << fExperimentalDataSet << RESTendl;

--- a/source/framework/sensitivity/src/TRestExperimentList.cxx
+++ b/source/framework/sensitivity/src/TRestExperimentList.cxx
@@ -117,7 +117,8 @@ void TRestExperimentList::InitFromConfigFile() {
 
         if (nExpectedColumns == 0) {
             RESTError << "TRestExperimentList::InitFromConfigFile. At least one free parameter required! "
-                         "(Exposure/Background/Signal)" << RESTendl;
+                         "(Exposure/Background/Signal)"
+                      << RESTendl;
             return;
         }
 
@@ -134,7 +135,8 @@ void TRestExperimentList::InitFromConfigFile() {
             }
 
             RESTError << "TRestExperimentList::InitFromConfigFile. Number of expected columns does not match "
-                         "the number of table columns" << RESTendl;
+                         "the number of table columns"
+                      << RESTendl;
             RESTError << "Number of table columns : " << nTableColumns << RESTendl;
             RESTError << "Number of expected columns : " << nExpectedColumns << RESTendl;
             RESTError << "Expected columns : " << expectedColumns << RESTendl;

--- a/source/framework/sensitivity/src/TRestExperimentList.cxx
+++ b/source/framework/sensitivity/src/TRestExperimentList.cxx
@@ -80,191 +80,192 @@ void TRestExperimentList::Initialize() { SetSectionName(this->ClassName()); }
 /// \brief It customizes the retrieval of XML data values of this class
 ///
 void TRestExperimentList::InitFromConfigFile() {
-    TRestMetadata::InitFromConfigFile();
+	TRestMetadata::InitFromConfigFile();
 
-    if (!fExperimentsFile.empty() && fExperiments.empty()) {
-        TRestTools::ReadASCIITable(fExperimentsFile, fExperimentsTable);
+	if (!fExperimentsFile.empty() && fExperiments.empty()) {
+		TRestTools::ReadASCIITable(fExperimentsFile, fExperimentsTable);
 
-        for (auto& row : fExperimentsTable)
-            for (auto& el : row) el = REST_StringHelper::ReplaceMathematicalExpressions(el);
+		for (auto& row : fExperimentsTable)
+			for (auto& el : row) el = REST_StringHelper::ReplaceMathematicalExpressions(el);
 
-        if (fExperimentsTable.empty()) {
-            RESTError << "TRestExperimentList::InitFromConfigFile. The experiments table is empty!"
-                      << RESTendl;
-            return;
-        }
+		if (fExperimentsTable.empty()) {
+			RESTError << "TRestExperimentList::InitFromConfigFile. The experiments table is empty!"
+				<< RESTendl;
+			return;
+		}
 
-        Int_t nTableColumns = fExperimentsTable[0].size();
+		Int_t nTableColumns = fExperimentsTable[0].size();
 
-        int cont = 0;
-        TRestComponent* comp = (TRestComponent*)this->InstantiateChildMetadata(cont, "Component");
-        while (comp != nullptr) {
-            if (ToLower(comp->GetNature()) == "background")
-                fBackground = comp;
-            else if (ToLower(comp->GetNature()) == "signal")
-                fSignal = comp;
-            else
-                RESTWarning << "TRestExperimentList::InitFromConfigFile. Unknown component!" << RESTendl;
+		int cont = 0;
+		TRestComponent* comp = (TRestComponent*)this->InstantiateChildMetadata(cont, "Component");
+		while (comp != nullptr) {
+			if (ToLower(comp->GetNature()) == "background")
+				fBackground = comp;
+			else if (ToLower(comp->GetNature()) == "signal")
+				fSignal = comp;
+			else
+				RESTWarning << "TRestExperimentList::InitFromConfigFile. Unknown component!" << RESTendl;
 
-            cont++;
-            comp = (TRestComponent*)this->InstantiateChildMetadata(cont, "Component");
-        }
+			cont++;
+			comp = (TRestComponent*)this->InstantiateChildMetadata(cont, "Component");
+		}
 
-        Int_t nExpectedColumns = 3;
-        if (fSignal) nExpectedColumns--;
-        if (fBackground) nExpectedColumns--;
-        if (fExposureTime > 0) nExpectedColumns--;
+		Int_t nExpectedColumns = 3;
+		if (fSignal) nExpectedColumns--;
+		if (fBackground) nExpectedColumns--;
+		if (fExposureTime > 0) nExpectedColumns--;
 
-        if (nExpectedColumns == 0) {
-            RESTError << "TRestExperimentList::InitFromConfigFile. At least one free parameter required! "
-                         "(Exposure/Background/Signal)"
-                      << RESTendl;
-            return;
-        }
+		if (nExpectedColumns == 0) {
+			RESTError << "TRestExperimentList::InitFromConfigFile. At least one free parameter required! "
+				"(Exposure/Background/Signal)"
+				<< RESTendl;
+			return;
+		}
 
-        if (nExpectedColumns != nTableColumns) {
-            std::string expectedColumns = "";
-            if (fExposureTime == 0) expectedColumns += "exposure";
-            if (!fSignal) {
-                if (fExposureTime == 0) expectedColumns += "/";
-                expectedColumns += "signal";
-            }
-            if (!fBackground) {
-                if (fExposureTime == 0 || !fSignal) expectedColumns += "/";
-                expectedColumns += "background";
-            }
+		if (nExpectedColumns != nTableColumns) {
+			std::string expectedColumns = "";
+			if (fExposureTime == 0) expectedColumns += "exposure";
+			if (!fSignal) {
+				if (fExposureTime == 0) expectedColumns += "/";
+				expectedColumns += "signal";
+			}
+			if (!fBackground) {
+				if (fExposureTime == 0 || !fSignal) expectedColumns += "/";
+				expectedColumns += "background";
+			}
 
-            RESTError << "TRestExperimentList::InitFromConfigFile. Number of expected columns does not match "
-                         "the number of table columns"
-                      << RESTendl;
-            RESTError << "Number of table columns : " << nTableColumns << RESTendl;
-            RESTError << "Number of expected columns : " << nExpectedColumns << RESTendl;
-            RESTError << "Expected columns : " << expectedColumns << RESTendl;
-            return;
-        }
+			RESTError << "TRestExperimentList::InitFromConfigFile. Number of expected columns does not match "
+				"the number of table columns"
+				<< RESTendl;
+			RESTError << "Number of table columns : " << nTableColumns << RESTendl;
+			RESTError << "Number of expected columns : " << nExpectedColumns << RESTendl;
+			RESTError << "Expected columns : " << expectedColumns << RESTendl;
+			return;
+		}
 
-        fComponentFiles = TRestTools::GetFilesMatchingPattern(fComponentPattern);
+		fComponentFiles = TRestTools::GetFilesMatchingPattern(fComponentPattern);
 
-        Bool_t generateMockData = false;
-        for (const auto& experimentRow : fExperimentsTable) {
-            TRestExperiment* experiment = new TRestExperiment();
+		Bool_t generateMockData = false;
+		for (const auto& experimentRow : fExperimentsTable) {
+			TRestExperiment* experiment = new TRestExperiment();
 
-            std::string rowStr = "";
-            for (const auto& el : experimentRow) {
-                rowStr += el + " ";
-            }
+			std::string rowStr = "";
+			for (const auto& el : experimentRow) {
+				rowStr += el + " ";
+			}
 
-            RESTInfo << "TRestExperimentList. Loading experiment: " << rowStr << RESTendl;
+			RESTInfo << "TRestExperimentList. Loading experiment: " << rowStr << RESTendl;
 
-            int column = 0;
-            if (fExposureTime == 0) {
-                if (REST_StringHelper::isANumber(experimentRow[column])) {
-                    experiment->SetExposureInSeconds(
-                        REST_StringHelper::StringToDouble(experimentRow[column]));
-                    // We will generate mock data once we load the background component
-                    generateMockData = true;
-                } else if (TRestTools::isRootFile(experimentRow[column])) {
-                    // We load the file with the dataset into the experimental data
-                    std::string fname = SearchFile(experimentRow[column]);
-                    experiment->SetExperimentalDataSet(fname);
-                    RESTWarning << "Loading experimental data havent been tested yet!" << RESTendl;
-                    RESTWarning
-                        << "It might require further development. Remove these lines once it works smooth!"
-                        << RESTendl;
-                } else {
-                    RESTError << experimentRow[column] << " is not a exposure time or an experimental dataset"
-                              << RESTendl;
-                }
-                column++;
-            } else {
-                if (ToLower(fExposureStrategy) == "unique") {
-                    experiment->SetExposureInSeconds(fExposureTime * units("s"));
-                    // We will generate mock data once we load the background component
-                    generateMockData = true;
-                }
-            }
+			int column = 0;
+			if (fExposureTime == 0) {
+				if (REST_StringHelper::isANumber(experimentRow[column])) {
+					experiment->SetExposureInSeconds(
+							REST_StringHelper::StringToDouble(experimentRow[column]));
+					// We will generate mock data once we load the background component
+					generateMockData = true;
+				} else if (TRestTools::isRootFile(experimentRow[column])) {
+					// We load the file with the dataset into the experimental data
+					std::string fname = SearchFile(experimentRow[column]);
+					experiment->SetExperimentalDataSet(fname);
+					RESTWarning << "Loading experimental data havent been tested yet!" << RESTendl;
+					RESTWarning
+						<< "It might require further development. Remove these lines once it works smooth!"
+						<< RESTendl;
+				} else {
+					RESTError << experimentRow[column] << " is not a exposure time or an experimental dataset"
+						<< RESTendl;
+				}
+				column++;
+			} else {
+				if (ToLower(fExposureStrategy) == "unique") {
+					experiment->SetExposureInSeconds(fExposureTime * units("s"));
+					// We will generate mock data once we load the background component
+					generateMockData = true;
+				}
+			}
 
-            if (!fSignal) {
-                if (GetComponent(experimentRow[column])) {
-                    TRestComponent* sgnl = (TRestComponent*)GetComponent(experimentRow[column])->Clone();
-                    sgnl->SetName((TString)experimentRow[column]);
-                    experiment->SetSignal(sgnl);
-                } else {
-                    RESTError << "TRestExperimentList. Signal component : " << experimentRow[column]
-                              << " not found!" << RESTendl;
-                }
-                column++;
-            } else {
-                experiment->SetSignal(fSignal);
-            }
+			if (!fSignal) {
+				if (GetComponent(experimentRow[column])) {
+					TRestComponent* sgnl = (TRestComponent*)GetComponent(experimentRow[column])->Clone();
+					sgnl->SetName((TString)experimentRow[column]);
+					experiment->SetSignal(sgnl);
+				} else {
+					RESTError << "TRestExperimentList. Signal component : " << experimentRow[column]
+						<< " not found!" << RESTendl;
+				}
+				column++;
+			} else {
+				experiment->SetSignal(fSignal);
+			}
 
-            if (!fBackground) {
-                if (GetComponent(experimentRow[column])) {
-                    TRestComponent* bck = (TRestComponent*)GetComponent(experimentRow[column])->Clone();
-                    experiment->SetBackground(bck);
-                } else {
-                    RESTError << "TRestExperimentList. Background component : " << experimentRow[column]
-                              << " not found!" << RESTendl;
-                }
-            } else {
-                experiment->SetBackground(fBackground);
-            }
+			if (!fBackground) {
+				if (GetComponent(experimentRow[column])) {
+					TRestComponent* bck = (TRestComponent*)GetComponent(experimentRow[column])->Clone();
+					experiment->SetBackground(bck);
+				} else {
+					RESTError << "TRestExperimentList. Background component : " << experimentRow[column]
+						<< " not found!" << RESTendl;
+				}
+			} else {
+				experiment->SetBackground(fBackground);
+			}
 
-            if (generateMockData) {
-                RESTInfo << "TRestExperimentList. Generating mock dataset" << RESTendl;
-                experiment->GenerateMockDataSet();
-            }
+			if (generateMockData) {
+				RESTInfo << "TRestExperimentList. Generating mock dataset" << RESTendl;
+				experiment->GenerateMockDataSet(fUseAverage);
+			}
 
-            if (experiment->GetSignal() && experiment->GetBackground()) {
-                experiment->SetName(experiment->GetSignal()->GetName());
-                fExperiments.push_back(experiment);
-            }
-        }
+			if (experiment->GetSignal() && experiment->GetBackground()) {
+				experiment->SetName(experiment->GetSignal()->GetName());
+				fExperiments.push_back(experiment);
+			}
+	 	}
 
-        /// TODO. I am being lazy here. It would be more appropriate that
-        /// I create a TRestAxionExperimentList::TRestExperimentList
-        /// that implements this axion dedicated piece of code
-        if (fExposureTime > 0 && ToLower(fExposureStrategy) == "ksvz") {
-            ExtractExperimentParameterizationNodes();
+		std::cout << "Total exposure time: " << fExposureTime * units("day") << " days" << std::endl;
 
-            Double_t Coefficient = 0;
-            for (const auto& node : fParameterizationNodes) {
-                Double_t expectedRate = 0;
-                for (const auto& experiment : fExperiments) {
-                    Int_t nd = experiment->GetSignal()->FindActiveNode(node);
-                    if (nd >= 0) {
-                        experiment->GetSignal()->SetActiveNode(nd);
-                        expectedRate += experiment->GetSignal()->GetTotalRate();
-                    }
-                }
+		if (fExposureTime > 0 && ToLower(fExposureStrategy) == "exp") {
+			ExtractExperimentParameterizationNodes();
 
-                Coefficient += 1. / node / expectedRate;
-            }
+			Double_t sum = 0;
+			for( int n = 0; n < fExperiments.size(); n++ )
+				sum += TMath::Exp( (double) n * fExposureFactor );
 
-            Double_t expectedRate = 0;
-            for (const auto& experiment : fExperiments) {
-                // We consider the contribution to each node for a given experiment
-                for (const auto& node : fParameterizationNodes) {
-                    Int_t nd = experiment->GetSignal()->FindActiveNode(node);
-                    if (nd >= 0) {
-                        experiment->GetSignal()->SetActiveNode(nd);
-                        expectedRate += node * experiment->GetSignal()->GetTotalRate();
-                    }
-                }
-                Double_t experimentTime = fExposureTime / Coefficient / expectedRate;
-                experiment->SetExposureInSeconds(experimentTime * units("s"));
-            }
+			Double_t A = fExposureTime * units("s") / sum;
+			for( int n = 0; n < fExperiments.size(); n++ )
+			{
+				fExperiments[n]->SetExposureInSeconds( A * TMath::Exp( (double) n * fExposureFactor ));
+				fExperiments[n]->GenerateMockDataSet(fUseAverage);
+			}
+		}
 
-            Double_t totalExp = 0;
-            for (const auto& experiment : fExperiments) totalExp += experiment->GetExposureInSeconds();
+		Int_t offset = 5;
+		if (fExposureTime > 0 && ToLower(fExposureStrategy) == "power") {
+			ExtractExperimentParameterizationNodes();
 
-            for (const auto& experiment : fExperiments) {
-                Double_t xp = experiment->GetExposureInSeconds();
-                experiment->SetExposureInSeconds(xp * fExposureTime * units("s") / totalExp);
-                experiment->GenerateMockDataSet();
-            }
-        }
-    }
+			Double_t sum = 0;
+			for( int n = 0; n < fExperiments.size(); n++ )
+				sum += TMath::Power( (double) (n+offset), fExposureFactor );
+
+			Double_t A = fExposureTime * units("s") / sum;
+			for( int n = 0; n < fExperiments.size(); n++ )
+			{
+				fExperiments[n]->SetExposureInSeconds( A * TMath::Power( (double) (n+offset), fExposureFactor ));
+				std::cout << "Time: " << A * TMath::Power( (double) (n+offset), fExposureFactor)/3600. << std::endl;
+				if( fUseAverage ) std::cout << "B Using average" << std::endl;
+				fExperiments[n]->GenerateMockDataSet(fUseAverage);
+			}
+		}
+
+		if (fExposureTime > 0 && ToLower(fExposureStrategy) == "equal") {
+			ExtractExperimentParameterizationNodes();
+
+			for( int n = 0; n < fExperiments.size(); n++ )
+			{
+				fExperiments[n]->SetExposureInSeconds( fExposureTime * units("s") / fExperiments.size() );
+				fExperiments[n]->GenerateMockDataSet(fUseAverage);
+			}
+		}
+	}
 }
 
 /////////////////////////////////////////////
@@ -319,6 +320,9 @@ void TRestExperimentList::PrintMetadata() {
     TRestMetadata::PrintMetadata();
 
     RESTMetadata << "Number of experiments loaded: " << fExperiments.size() << RESTendl;
+
+	if( fUseAverage )
+		RESTMetadata << "Average MonteCarlo counts generation was enabled" << RESTendl;
 
     RESTMetadata << "----" << RESTendl;
 }

--- a/source/framework/sensitivity/src/TRestExperimentList.cxx
+++ b/source/framework/sensitivity/src/TRestExperimentList.cxx
@@ -80,192 +80,180 @@ void TRestExperimentList::Initialize() { SetSectionName(this->ClassName()); }
 /// \brief It customizes the retrieval of XML data values of this class
 ///
 void TRestExperimentList::InitFromConfigFile() {
-	TRestMetadata::InitFromConfigFile();
+    TRestMetadata::InitFromConfigFile();
 
-	if (!fExperimentsFile.empty() && fExperiments.empty()) {
-		TRestTools::ReadASCIITable(fExperimentsFile, fExperimentsTable);
+    if (!fExperimentsFile.empty() && fExperiments.empty()) {
+        TRestTools::ReadASCIITable(fExperimentsFile, fExperimentsTable);
 
-		for (auto& row : fExperimentsTable)
-			for (auto& el : row) el = REST_StringHelper::ReplaceMathematicalExpressions(el);
+        for (auto& row : fExperimentsTable)
+            for (auto& el : row) el = REST_StringHelper::ReplaceMathematicalExpressions(el);
 
-		if (fExperimentsTable.empty()) {
-			RESTError << "TRestExperimentList::InitFromConfigFile. The experiments table is empty!"
-				<< RESTendl;
-			return;
-		}
+        if (fExperimentsTable.empty()) {
+            RESTError << "TRestExperimentList::InitFromConfigFile. The experiments table is empty!"
+                      << RESTendl;
+            return;
+        }
 
-		Int_t nTableColumns = fExperimentsTable[0].size();
+        Int_t nTableColumns = fExperimentsTable[0].size();
 
-		int cont = 0;
-		TRestComponent* comp = (TRestComponent*)this->InstantiateChildMetadata(cont, "Component");
-		while (comp != nullptr) {
-			if (ToLower(comp->GetNature()) == "background")
-				fBackground = comp;
-			else if (ToLower(comp->GetNature()) == "signal")
-				fSignal = comp;
-			else
-				RESTWarning << "TRestExperimentList::InitFromConfigFile. Unknown component!" << RESTendl;
+        int cont = 0;
+        TRestComponent* comp = (TRestComponent*)this->InstantiateChildMetadata(cont, "Component");
+        while (comp != nullptr) {
+            if (ToLower(comp->GetNature()) == "background")
+                fBackground = comp;
+            else if (ToLower(comp->GetNature()) == "signal")
+                fSignal = comp;
+            else
+                RESTWarning << "TRestExperimentList::InitFromConfigFile. Unknown component!" << RESTendl;
 
-			cont++;
-			comp = (TRestComponent*)this->InstantiateChildMetadata(cont, "Component");
-		}
+            cont++;
+            comp = (TRestComponent*)this->InstantiateChildMetadata(cont, "Component");
+        }
 
-		Int_t nExpectedColumns = 3;
-		if (fSignal) nExpectedColumns--;
-		if (fBackground) nExpectedColumns--;
-		if (fExposureTime > 0) nExpectedColumns--;
+        Int_t nExpectedColumns = 3;
+        if (fSignal) nExpectedColumns--;
+        if (fBackground) nExpectedColumns--;
+        if (fExposureTime > 0) nExpectedColumns--;
 
-		if (nExpectedColumns == 0) {
-			RESTError << "TRestExperimentList::InitFromConfigFile. At least one free parameter required! "
-				"(Exposure/Background/Signal)"
-				<< RESTendl;
-			return;
-		}
+        if (nExpectedColumns == 0) {
+            RESTError << "TRestExperimentList::InitFromConfigFile. At least one free parameter required! "
+                         "(Exposure/Background/Signal)" << RESTendl;
+            return;
+        }
 
-		if (nExpectedColumns != nTableColumns) {
-			std::string expectedColumns = "";
-			if (fExposureTime == 0) expectedColumns += "exposure";
-			if (!fSignal) {
-				if (fExposureTime == 0) expectedColumns += "/";
-				expectedColumns += "signal";
-			}
-			if (!fBackground) {
-				if (fExposureTime == 0 || !fSignal) expectedColumns += "/";
-				expectedColumns += "background";
-			}
+        if (nExpectedColumns != nTableColumns) {
+            std::string expectedColumns = "";
+            if (fExposureTime == 0) expectedColumns += "exposure";
+            if (!fSignal) {
+                if (fExposureTime == 0) expectedColumns += "/";
+                expectedColumns += "signal";
+            }
+            if (!fBackground) {
+                if (fExposureTime == 0 || !fSignal) expectedColumns += "/";
+                expectedColumns += "background";
+            }
 
-			RESTError << "TRestExperimentList::InitFromConfigFile. Number of expected columns does not match "
-				"the number of table columns"
-				<< RESTendl;
-			RESTError << "Number of table columns : " << nTableColumns << RESTendl;
-			RESTError << "Number of expected columns : " << nExpectedColumns << RESTendl;
-			RESTError << "Expected columns : " << expectedColumns << RESTendl;
-			return;
-		}
+            RESTError << "TRestExperimentList::InitFromConfigFile. Number of expected columns does not match "
+                         "the number of table columns" << RESTendl;
+            RESTError << "Number of table columns : " << nTableColumns << RESTendl;
+            RESTError << "Number of expected columns : " << nExpectedColumns << RESTendl;
+            RESTError << "Expected columns : " << expectedColumns << RESTendl;
+            return;
+        }
 
-		fComponentFiles = TRestTools::GetFilesMatchingPattern(fComponentPattern);
+        fComponentFiles = TRestTools::GetFilesMatchingPattern(fComponentPattern);
 
-		Bool_t generateMockData = false;
-		for (const auto& experimentRow : fExperimentsTable) {
-			TRestExperiment* experiment = new TRestExperiment();
+        Bool_t generateMockData = false;
+        for (const auto& experimentRow : fExperimentsTable) {
+            TRestExperiment* experiment = new TRestExperiment();
 
-			std::string rowStr = "";
-			for (const auto& el : experimentRow) {
-				rowStr += el + " ";
-			}
+            std::string rowStr = "";
+            for (const auto& el : experimentRow) {
+                rowStr += el + " ";
+            }
 
-			RESTInfo << "TRestExperimentList. Loading experiment: " << rowStr << RESTendl;
+            RESTInfo << "TRestExperimentList. Loading experiment: " << rowStr << RESTendl;
 
-			int column = 0;
-			if (fExposureTime == 0) {
-				if (REST_StringHelper::isANumber(experimentRow[column])) {
-					experiment->SetExposureInSeconds(
-							REST_StringHelper::StringToDouble(experimentRow[column]));
-					// We will generate mock data once we load the background component
-					generateMockData = true;
-				} else if (TRestTools::isRootFile(experimentRow[column])) {
-					// We load the file with the dataset into the experimental data
-					std::string fname = SearchFile(experimentRow[column]);
-					experiment->SetExperimentalDataSet(fname);
-					RESTWarning << "Loading experimental data havent been tested yet!" << RESTendl;
-					RESTWarning
-						<< "It might require further development. Remove these lines once it works smooth!"
-						<< RESTendl;
-				} else {
-					RESTError << experimentRow[column] << " is not a exposure time or an experimental dataset"
-						<< RESTendl;
-				}
-				column++;
-			} else {
-				if (ToLower(fExposureStrategy) == "unique") {
-					experiment->SetExposureInSeconds(fExposureTime * units("s"));
-					// We will generate mock data once we load the background component
-					generateMockData = true;
-				}
-			}
+            int column = 0;
+            if (fExposureTime == 0) {
+                if (REST_StringHelper::isANumber(experimentRow[column])) {
+                    experiment->SetExposureInSeconds(
+                        REST_StringHelper::StringToDouble(experimentRow[column]));
+                    // We will generate mock data once we load the background component
+                    generateMockData = true;
+                } else if (TRestTools::isRootFile(experimentRow[column])) {
+                    // We load the file with the dataset into the experimental data
+                    std::string fname = SearchFile(experimentRow[column]);
+                    experiment->SetExperimentalDataSet(fname);
+                    RESTWarning << "Loading experimental data havent been tested yet!" << RESTendl;
+                    RESTWarning
+                        << "It might require further development. Remove these lines once it works smooth!"
+                        << RESTendl;
+                } else {
+                    RESTError << experimentRow[column] << " is not a exposure time or an experimental dataset"
+                              << RESTendl;
+                }
+                column++;
+            } else {
+                if (ToLower(fExposureStrategy) == "unique") {
+                    experiment->SetExposureInSeconds(fExposureTime * units("s"));
+                    // We will generate mock data once we load the background component
+                    generateMockData = true;
+                }
+            }
 
-			if (!fSignal) {
-				if (GetComponent(experimentRow[column])) {
-					TRestComponent* sgnl = (TRestComponent*)GetComponent(experimentRow[column])->Clone();
-					sgnl->SetName((TString)experimentRow[column]);
-					experiment->SetSignal(sgnl);
-				} else {
-					RESTError << "TRestExperimentList. Signal component : " << experimentRow[column]
-						<< " not found!" << RESTendl;
-				}
-				column++;
-			} else {
-				experiment->SetSignal(fSignal);
-			}
+            if (!fSignal) {
+                if (GetComponent(experimentRow[column])) {
+                    TRestComponent* sgnl = (TRestComponent*)GetComponent(experimentRow[column])->Clone();
+                    sgnl->SetName((TString)experimentRow[column]);
+                    experiment->SetSignal(sgnl);
+                } else {
+                    RESTError << "TRestExperimentList. Signal component : " << experimentRow[column]
+                              << " not found!" << RESTendl;
+                }
+                column++;
+            } else {
+                experiment->SetSignal(fSignal);
+            }
 
-			if (!fBackground) {
-				if (GetComponent(experimentRow[column])) {
-					TRestComponent* bck = (TRestComponent*)GetComponent(experimentRow[column])->Clone();
-					experiment->SetBackground(bck);
-				} else {
-					RESTError << "TRestExperimentList. Background component : " << experimentRow[column]
-						<< " not found!" << RESTendl;
-				}
-			} else {
-				experiment->SetBackground(fBackground);
-			}
+            if (!fBackground) {
+                if (GetComponent(experimentRow[column])) {
+                    TRestComponent* bck = (TRestComponent*)GetComponent(experimentRow[column])->Clone();
+                    experiment->SetBackground(bck);
+                } else {
+                    RESTError << "TRestExperimentList. Background component : " << experimentRow[column]
+                              << " not found!" << RESTendl;
+                }
+            } else {
+                experiment->SetBackground(fBackground);
+            }
 
-			if (generateMockData) {
-				RESTInfo << "TRestExperimentList. Generating mock dataset" << RESTendl;
-				experiment->GenerateMockDataSet(fUseAverage);
-			}
+            if (generateMockData) {
+                RESTInfo << "TRestExperimentList. Generating mock dataset" << RESTendl;
+                experiment->GenerateMockDataSet(fUseAverage);
+            }
 
-			if (experiment->GetSignal() && experiment->GetBackground()) {
-				experiment->SetName(experiment->GetSignal()->GetName());
-				fExperiments.push_back(experiment);
-			}
-	 	}
+            if (experiment->GetSignal() && experiment->GetBackground()) {
+                experiment->SetName(experiment->GetSignal()->GetName());
+                fExperiments.push_back(experiment);
+            }
+        }
 
-		std::cout << "Total exposure time: " << fExposureTime * units("day") << " days" << std::endl;
+        if (fExposureTime > 0 && ToLower(fExposureStrategy) == "exp") {
+            ExtractExperimentParameterizationNodes();
 
-		if (fExposureTime > 0 && ToLower(fExposureStrategy) == "exp") {
-			ExtractExperimentParameterizationNodes();
+            Double_t sum = 0;
+            for (size_t n = 0; n < fExperiments.size(); n++) sum += TMath::Exp((double)n * fExposureFactor);
 
-			Double_t sum = 0;
-			for( int n = 0; n < fExperiments.size(); n++ )
-				sum += TMath::Exp( (double) n * fExposureFactor );
+            Double_t A = fExposureTime * units("s") / sum;
+            for (size_t n = 0; n < fExperiments.size(); n++) {
+                fExperiments[n]->SetExposureInSeconds(A * TMath::Exp((double)n * fExposureFactor));
+                fExperiments[n]->GenerateMockDataSet(fUseAverage);
+            }
+        }
 
-			Double_t A = fExposureTime * units("s") / sum;
-			for( int n = 0; n < fExperiments.size(); n++ )
-			{
-				fExperiments[n]->SetExposureInSeconds( A * TMath::Exp( (double) n * fExposureFactor ));
-				fExperiments[n]->GenerateMockDataSet(fUseAverage);
-			}
-		}
+        if (fExposureTime > 0 && ToLower(fExposureStrategy) == "power") {
+            ExtractExperimentParameterizationNodes();
 
-		Int_t offset = 5;
-		if (fExposureTime > 0 && ToLower(fExposureStrategy) == "power") {
-			ExtractExperimentParameterizationNodes();
+            Double_t sum = 0;
+            for (size_t n = 0; n < fExperiments.size(); n++) sum += TMath::Power((double)n, fExposureFactor);
 
-			Double_t sum = 0;
-			for( int n = 0; n < fExperiments.size(); n++ )
-				sum += TMath::Power( (double) (n+offset), fExposureFactor );
+            Double_t A = fExposureTime * units("s") / sum;
+            for (size_t n = 0; n < fExperiments.size(); n++) {
+                fExperiments[n]->SetExposureInSeconds(A * TMath::Power((double)n, fExposureFactor));
+                fExperiments[n]->GenerateMockDataSet(fUseAverage);
+            }
+        }
 
-			Double_t A = fExposureTime * units("s") / sum;
-			for( int n = 0; n < fExperiments.size(); n++ )
-			{
-				fExperiments[n]->SetExposureInSeconds( A * TMath::Power( (double) (n+offset), fExposureFactor ));
-				std::cout << "Time: " << A * TMath::Power( (double) (n+offset), fExposureFactor)/3600. << std::endl;
-				if( fUseAverage ) std::cout << "B Using average" << std::endl;
-				fExperiments[n]->GenerateMockDataSet(fUseAverage);
-			}
-		}
+        if (fExposureTime > 0 && ToLower(fExposureStrategy) == "equal") {
+            ExtractExperimentParameterizationNodes();
 
-		if (fExposureTime > 0 && ToLower(fExposureStrategy) == "equal") {
-			ExtractExperimentParameterizationNodes();
-
-			for( int n = 0; n < fExperiments.size(); n++ )
-			{
-				fExperiments[n]->SetExposureInSeconds( fExposureTime * units("s") / fExperiments.size() );
-				fExperiments[n]->GenerateMockDataSet(fUseAverage);
-			}
-		}
-	}
+            for (size_t n = 0; n < fExperiments.size(); n++) {
+                fExperiments[n]->SetExposureInSeconds(fExposureTime * units("s") / fExperiments.size());
+                fExperiments[n]->GenerateMockDataSet(fUseAverage);
+            }
+        }
+    }
 }
 
 /////////////////////////////////////////////
@@ -321,8 +309,7 @@ void TRestExperimentList::PrintMetadata() {
 
     RESTMetadata << "Number of experiments loaded: " << fExperiments.size() << RESTendl;
 
-	if( fUseAverage )
-		RESTMetadata << "Average MonteCarlo counts generation was enabled" << RESTendl;
+    if (fUseAverage) RESTMetadata << "Average MonteCarlo counts generation was enabled" << RESTendl;
 
     RESTMetadata << "----" << RESTendl;
 }

--- a/source/framework/sensitivity/src/TRestSensitivity.cxx
+++ b/source/framework/sensitivity/src/TRestSensitivity.cxx
@@ -131,10 +131,12 @@ void TRestSensitivity::GenerateCurve() {
 }
 
 void TRestSensitivity::GenerateCurves(Int_t N) {
+	/*
 	std::cout << "TRestSensitivity::GenerateCurves." << std::endl;
 	std::cout << "There is a potential memory leak when generating several curves." << std::endl;
 	std::cout << "This code needs to be reviewed" << std::endl;
 	return;
+	*/
 
     for (int n = 0; n < N; n++) GenerateCurve();
 }
@@ -261,13 +263,22 @@ Double_t TRestSensitivity::UnbinnedLogLikelihood(const TRestExperiment* experime
         return lhood;
     }
 
+	if ( !experiment->GetSignal()->HasNodes() ) 
+	{
+		RESTError << "Experiment signal : " << experiment->GetSignal()->GetName() << " has no nodes!" << RESTendl;
+		return lhood;
+	}
+
     /// We check if the signal component is sensitive to that particular node
     /// If not, this experiment will not contribute to that node
     Int_t nd = experiment->GetSignal()->FindActiveNode(node);
     if (nd >= 0)
         experiment->GetSignal()->SetActiveNode(nd);
     else
+	{
+		RESTWarning << "Node : " << node << " not found in signal : " << experiment->GetSignal()->GetName() << RESTendl;
         return 0.0;
+	}
 
     /// We could check if background has also components, but for the moment we do not have a background
     /// for each node, although it could be the case, if for example the background depends on the detector

--- a/source/framework/sensitivity/src/TRestSensitivity.cxx
+++ b/source/framework/sensitivity/src/TRestSensitivity.cxx
@@ -131,6 +131,11 @@ void TRestSensitivity::GenerateCurve() {
 }
 
 void TRestSensitivity::GenerateCurves(Int_t N) {
+	std::cout << "TRestSensitivity::GenerateCurves." << std::endl;
+	std::cout << "There is a potential memory leak when generating several curves." << std::endl;
+	std::cout << "This code needs to be reviewed" << std::endl;
+	return;
+
     for (int n = 0; n < N; n++) GenerateCurve();
 }
 

--- a/source/framework/sensitivity/src/TRestSensitivity.cxx
+++ b/source/framework/sensitivity/src/TRestSensitivity.cxx
@@ -131,12 +131,12 @@ void TRestSensitivity::GenerateCurve() {
 }
 
 void TRestSensitivity::GenerateCurves(Int_t N) {
-	/*
-	std::cout << "TRestSensitivity::GenerateCurves." << std::endl;
-	std::cout << "There is a potential memory leak when generating several curves." << std::endl;
-	std::cout << "This code needs to be reviewed" << std::endl;
-	return;
-	*/
+    /*
+    std::cout << "TRestSensitivity::GenerateCurves." << std::endl;
+    std::cout << "There is a potential memory leak when generating several curves." << std::endl;
+    std::cout << "This code needs to be reviewed" << std::endl;
+    return;
+    */
 
     for (int n = 0; n < N; n++) GenerateCurve();
 }
@@ -263,22 +263,22 @@ Double_t TRestSensitivity::UnbinnedLogLikelihood(const TRestExperiment* experime
         return lhood;
     }
 
-	if ( !experiment->GetSignal()->HasNodes() ) 
-	{
-		RESTError << "Experiment signal : " << experiment->GetSignal()->GetName() << " has no nodes!" << RESTendl;
-		return lhood;
-	}
+    if (!experiment->GetSignal()->HasNodes()) {
+        RESTError << "Experiment signal : " << experiment->GetSignal()->GetName() << " has no nodes!"
+                  << RESTendl;
+        return lhood;
+    }
 
     /// We check if the signal component is sensitive to that particular node
     /// If not, this experiment will not contribute to that node
     Int_t nd = experiment->GetSignal()->FindActiveNode(node);
     if (nd >= 0)
         experiment->GetSignal()->SetActiveNode(nd);
-    else
-	{
-		RESTWarning << "Node : " << node << " not found in signal : " << experiment->GetSignal()->GetName() << RESTendl;
+    else {
+        RESTWarning << "Node : " << node << " not found in signal : " << experiment->GetSignal()->GetName()
+                    << RESTendl;
         return 0.0;
-	}
+    }
 
     /// We could check if background has also components, but for the moment we do not have a background
     /// for each node, although it could be the case, if for example the background depends on the detector


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Large: 209](https://badgen.net/badge/PR%20Size/Large%3A%20209/red) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_bIAXO_example)](https://github.com/rest-for-physics/framework/commits/jgalan_bIAXO_example) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->
 
Some fixes I had to add in order to properly calculate the axion helioscope sensitivity in the axionlib PR.

Some new features:
- Now a `TRestComponent` may initialize parameterization nodes using initial/final values and a step. Linear o logarithmic scales are allowed.
- `TRestExperiment::GenerateMockDataSet` might receive a boolean, when it is true, the number of counts of the mock dataset will be generated with the exact average from background, instead of performing a Poissonian MC-distribution.
- Added `fUseAverage` member to `TRestExperimentList` and `TRestExperiment` so that we can enable/disable this feature.


This PR is related to PR https://github.com/rest-for-physics/axionlib/pull/93