### PR TITLE
Component and dataset upgrades

### DIFF
--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -138,7 +138,8 @@ class TRestDataSet : public TRestMetadata {
     TTree* GetTree() const {
         if (fTree == nullptr && fExternal) {
             RESTInfo << "The tree is not accessible. Only GetDataFrame can be used in an externally "
-                        "generated dataset" << RESTendl;
+                        "generated dataset"
+                     << RESTendl;
             RESTInfo << "You may write a tree using GetDataFrame()->Snapshot(\"MyTree\", \"output.root\");"
                      << RESTendl;
             return fTree;

--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -122,6 +122,8 @@ class TRestDataSet : public TRestMetadata {
    protected:
     virtual std::vector<std::string> FileSelection();
 
+    void RegenerateTree(std::vector<std::string> finalList = {});
+
    public:
     /// Gives access to the RDataFrame
     ROOT::RDF::RNode GetDataFrame() const {

--- a/source/framework/core/inc/TRestDataSet.h
+++ b/source/framework/core/inc/TRestDataSet.h
@@ -112,7 +112,7 @@ class TRestDataSet : public TRestMetadata {
     Bool_t fExternal = false;  //<
 
     /// The resulting RDF::RNode object after initialization
-    ROOT::RDF::RNode fDataSet = ROOT::RDataFrame(0);  //!
+    ROOT::RDF::RNode fDataFrame = ROOT::RDataFrame(0);  //!
 
     /// A pointer to the generated tree
     TChain* fTree = nullptr;  //!
@@ -127,7 +127,7 @@ class TRestDataSet : public TRestMetadata {
     ROOT::RDF::RNode GetDataFrame() const {
         if (!fExternal && fTree == nullptr)
             RESTWarning << "DataFrame has not been yet initialized" << RESTendl;
-        return fDataSet;
+        return fDataFrame;
     }
 
     void EnableMultiThreading(Bool_t enable = true) { fMT = enable; }
@@ -136,8 +136,7 @@ class TRestDataSet : public TRestMetadata {
     TTree* GetTree() const {
         if (fTree == nullptr && fExternal) {
             RESTInfo << "The tree is not accessible. Only GetDataFrame can be used in an externally "
-                        "generated dataset"
-                     << RESTendl;
+                        "generated dataset" << RESTendl;
             RESTInfo << "You may write a tree using GetDataFrame()->Snapshot(\"MyTree\", \"output.root\");"
                      << RESTendl;
             return fTree;
@@ -152,7 +151,7 @@ class TRestDataSet : public TRestMetadata {
     }
 
     /// Number of variables (or observables)
-    size_t GetNumberOfColumns() { return fDataSet.GetColumnNames().size(); }
+    size_t GetNumberOfColumns() { return fDataFrame.GetColumnNames().size(); }
 
     /// Number of variables (or observables)
     size_t GetNumberOfBranches() { return GetNumberOfColumns(); }
@@ -187,7 +186,7 @@ class TRestDataSet : public TRestMetadata {
 
     void SetTotalTimeInSeconds(Double_t seconds) { fTotalDuration = seconds; }
     void SetDataFrame(const ROOT::RDF::RNode& dS) {
-        fDataSet = dS;
+        fDataFrame = dS;
         fExternal = true;
     }
 
@@ -198,7 +197,11 @@ class TRestDataSet : public TRestMetadata {
     void Export(const std::string& filename, std::vector<std::string> excludeColumns = {});
 
     ROOT::RDF::RNode MakeCut(const TRestCut* cut);
+    ROOT::RDF::RNode ApplyRange(size_t from, size_t to);
+    ROOT::RDF::RNode Range(size_t from, size_t to);
     ROOT::RDF::RNode DefineColumn(const std::string& columnName, const std::string& formula);
+
+    size_t GetEntries();
 
     void PrintMetadata() override;
     void Initialize() override;
@@ -209,6 +212,6 @@ class TRestDataSet : public TRestMetadata {
     TRestDataSet(const char* cfgFileName, const std::string& name = "");
     ~TRestDataSet();
 
-    ClassDefOverride(TRestDataSet, 7);
+    ClassDefOverride(TRestDataSet, 8);
 };
 #endif

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -394,18 +394,28 @@ void TRestDataSet::GenerateDataSet() {
         fDataFrame = DefineColumn(cName, cExpression);
     }
 
+    RegenerateTree(finalList);
+
+    RESTInfo << " - Dataset generated!" << RESTendl;
+}
+
+///////////////////////////////////////////////
+/// \brief It regenerates the tree so that it is an exact copy of the present DataFrame
+///
+void TRestDataSet::RegenerateTree(std::vector<std::string> finalList) {
     RESTInfo << "Generating snapshot." << RESTendl;
     std::string user = getenv("USER");
     std::string fOutName = "/tmp/rest_output_" + user + ".root";
-    fDataFrame.Snapshot("AnalysisTree", fOutName, finalList);
+    if (!finalList.empty())
+        fDataFrame.Snapshot("AnalysisTree", fOutName, finalList);
+    else
+        fDataFrame.Snapshot("AnalysisTree", fOutName);
 
     RESTInfo << "Re-importing analysis tree." << RESTendl;
     fDataFrame = ROOT::RDataFrame("AnalysisTree", fOutName);
 
     TFile* f = TFile::Open(fOutName.c_str());
     fTree = (TChain*)f->Get("AnalysisTree");
-
-    RESTInfo << " - Dataset generated!" << RESTendl;
 }
 
 ///////////////////////////////////////////////
@@ -530,6 +540,7 @@ ROOT::RDF::RNode TRestDataSet::Range(size_t from, size_t to) { return fDataFrame
 ///
 ROOT::RDF::RNode TRestDataSet::ApplyRange(size_t from, size_t to) {
     fDataFrame = fDataFrame.Range(from, to);
+    RegenerateTree();
     return fDataFrame;
 }
 

--- a/source/framework/core/src/TRestDataSet.cxx
+++ b/source/framework/core/src/TRestDataSet.cxx
@@ -388,7 +388,7 @@ void TRestDataSet::GenerateDataSet() {
     fDataFrame = MakeCut(fCut);
 
     // Adding new user columns added to the dataset
-    for (const auto & [ cName, cExpression ] : fColumnNameExpressions) {
+    for (const auto& [cName, cExpression] : fColumnNameExpressions) {
         RESTInfo << "Adding column to dataset: " << cName << RESTendl;
         finalList.emplace_back(cName);
         fDataFrame = DefineColumn(cName, cExpression);
@@ -429,7 +429,8 @@ std::vector<std::string> TRestDataSet::FileSelection() {
 
     if (!time_stamp_end || !time_stamp_start) {
         RESTError << "TRestDataSet::FileSelect. Start or end dates not properly formed. Please, check "
-                     "REST_StringHelper::StringToTimeStamp documentation for valid formats" << RESTendl;
+                     "REST_StringHelper::StringToTimeStamp documentation for valid formats"
+                  << RESTendl;
         return fFileSelection;
     }
 
@@ -482,7 +483,7 @@ std::vector<std::string> TRestDataSet::FileSelection() {
         if (!accept) continue;
 
         Double_t acc = 0;
-        for (auto & [ name, properties ] : fQuantity) {
+        for (auto& [name, properties] : fQuantity) {
             std::string value = run.ReplaceMetadataMembers(properties.metadata);
             const Double_t val = REST_StringHelper::StringToDouble(value);
 
@@ -557,7 +558,7 @@ ROOT::RDF::RNode TRestDataSet::MakeCut(const TRestCut* cut) {
 
     auto paramCut = cut->GetParamCut();
     auto obsList = df.GetColumnNames();
-    for (const auto & [ param, condition ] : paramCut) {
+    for (const auto& [param, condition] : paramCut) {
         if (std::find(obsList.begin(), obsList.end(), param) != obsList.end()) {
             std::string pCut = param + condition;
             RESTDebug << "Applying cut " << pCut << RESTendl;
@@ -618,7 +619,7 @@ ROOT::RDF::RNode TRestDataSet::DefineColumn(const std::string& columnName, const
     auto df = fDataFrame;
 
     std::string evalFormula = formula;
-    for (auto const & [ name, properties ] : fQuantity)
+    for (auto const& [name, properties] : fQuantity)
         evalFormula = REST_StringHelper::Replace(evalFormula, name, properties.value);
 
     df = df.Define(columnName, evalFormula);
@@ -684,7 +685,7 @@ void TRestDataSet::PrintMetadata() {
         RESTMetadata << " Relevant quantities: " << RESTendl;
         RESTMetadata << " -------------------- " << RESTendl;
 
-        for (auto const & [ name, properties ] : fQuantity) {
+        for (auto const& [name, properties] : fQuantity) {
             RESTMetadata << " - Name : " << name << ". Value : " << properties.value
                          << ". Strategy: " << properties.strategy << RESTendl;
             RESTMetadata << " - Metadata: " << properties.metadata << RESTendl;
@@ -696,7 +697,7 @@ void TRestDataSet::PrintMetadata() {
     if (!fColumnNameExpressions.empty()) {
         RESTMetadata << " New columns added to generated dataframe: " << RESTendl;
         RESTMetadata << " ---------------------------------------- " << RESTendl;
-        for (const auto & [ cName, cExpression ] : fColumnNameExpressions) {
+        for (const auto& [cName, cExpression] : fColumnNameExpressions) {
             RESTMetadata << " - Name : " << cName << RESTendl;
             RESTMetadata << " - Expression: " << cExpression << RESTendl;
             RESTMetadata << " " << RESTendl;
@@ -862,10 +863,11 @@ void TRestDataSet::Export(const std::string& filename, std::vector<std::string> 
 
     std::vector<std::string> columns = fDataFrame.GetColumnNames();
     if (!excludeColumns.empty()) {
-        columns.erase(std::remove_if(columns.begin(), columns.end(), [&excludeColumns](std::string elem) {
-                          return std::find(excludeColumns.begin(), excludeColumns.end(), elem) !=
-                                 excludeColumns.end();
-                      }),
+        columns.erase(std::remove_if(columns.begin(), columns.end(),
+                                     [&excludeColumns](std::string elem) {
+                                         return std::find(excludeColumns.begin(), excludeColumns.end(),
+                                                          elem) != excludeColumns.end();
+                                     }),
                       columns.end());
 
         RESTInfo << "Re-Generating snapshot." << RESTendl;
@@ -900,7 +902,8 @@ void TRestDataSet::Export(const std::string& filename, std::vector<std::string> 
             if (type != "Double_t" && type != "Int_t") {
                 RESTError << "Branch name : " << bName << " is type : " << type << RESTendl;
                 RESTError << "Only Int_t and Double_t types are allowed for "
-                             "exporting to ASCII table" << RESTendl;
+                             "exporting to ASCII table"
+                          << RESTendl;
                 RESTError << "File will not be generated" << RESTendl;
                 return;
             }
@@ -935,7 +938,7 @@ void TRestDataSet::Export(const std::string& filename, std::vector<std::string> 
         }
         fprintf(f, "###\n");
         fprintf(f, "### Relevant quantities: \n");
-        for (auto & [ name, properties ] : fQuantity) {
+        for (auto& [name, properties] : fQuantity) {
             fprintf(f, "### - %s : %s - %s\n", name.c_str(), properties.value.c_str(),
                     properties.description.c_str());
         }

--- a/source/framework/sensitivity/inc/TRestComponentDataSet.h
+++ b/source/framework/sensitivity/inc/TRestComponentDataSet.h
@@ -54,6 +54,9 @@ class TRestComponentDataSet : public TRestComponent {
     /// The dataset used to initialize the distribution
     TRestDataSet fDataSet;  //!
 
+    /// It helps to split large datasets when extracting the parameterization nodes
+    long long unsigned int fSplitEntries = 600000000;
+
     /// It is true of the dataset was loaded without issues
     Bool_t fDataSetLoaded = false;  //!
 
@@ -84,6 +87,6 @@ class TRestComponentDataSet : public TRestComponent {
     TRestComponentDataSet(const char* cfgFileName, const std::string& name);
     ~TRestComponentDataSet();
 
-    ClassDefOverride(TRestComponentDataSet, 3);
+    ClassDefOverride(TRestComponentDataSet, 4);
 };
 #endif

--- a/source/framework/sensitivity/inc/TRestComponentDataSet.h
+++ b/source/framework/sensitivity/inc/TRestComponentDataSet.h
@@ -57,6 +57,9 @@ class TRestComponentDataSet : public TRestComponent {
     /// It helps to split large datasets when extracting the parameterization nodes
     long long unsigned int fSplitEntries = 600000000;
 
+    /// It creates a sample subset using a range definition
+    TVector2 fDFRange = TVector2(0, 0);
+
     /// It is true of the dataset was loaded without issues
     Bool_t fDataSetLoaded = false;  //!
 

--- a/source/framework/sensitivity/src/TRestComponentDataSet.cxx
+++ b/source/framework/sensitivity/src/TRestComponentDataSet.cxx
@@ -148,6 +148,11 @@ void TRestComponentDataSet::PrintMetadata() {
         RESTMetadata << " " << RESTendl;
     }
 
+    if (fDFRange.X() != 0 || fDFRange.Y() != 0) {
+        RESTMetadata << " DataFrame range: ( " << fDFRange.X() << ", " << fDFRange.Y() << ")" << RESTendl;
+        RESTMetadata << " " << RESTendl;
+    }
+
     if (!fParameter.empty() && fParameterizationNodes.empty()) {
         RESTMetadata << "This component has no nodes!" << RESTendl;
         RESTMetadata << " Use: LoadDataSets() to initialize the nodes" << RESTendl;
@@ -477,6 +482,9 @@ Bool_t TRestComponentDataSet::LoadDataSets() {
 
     fDataSet.Import(fullFileNames);
     fDataSetLoaded = true;
+
+    if (fDFRange.X() != 0 || fDFRange.Y() != 0)
+        fDataSet.ApplyRange((size_t)fDFRange.X(), (size_t)fDFRange.Y());
 
     if (fDataSet.GetTree() == nullptr) {
         RESTError << "Problem loading dataset from file list :" << RESTendl;

--- a/source/framework/sensitivity/src/TRestComponentDataSet.cxx
+++ b/source/framework/sensitivity/src/TRestComponentDataSet.cxx
@@ -440,7 +440,7 @@ std::vector<Int_t> TRestComponentDataSet::ExtractNodeStatistics() {
             nEv = fDataSet.GetDataFrame().Filter(filter).Range(fSamples).Count();
         }
 
-        if ((Int_t) * nEv < fSamples) {
+        if ((Int_t)*nEv < fSamples) {
             RESTWarning << "The number of requested samples (" << fSamples
                         << ") is higher than the number of dataset entries (" << *nEv << ")" << RESTendl;
         }


### PR DESCRIPTION
![jgalan](https://badgen.net/badge/PR%20submitted%20by%3A/jgalan/blue) ![Medium: 100](https://badgen.net/badge/PR%20Size/Medium%3A%20100/orange) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=jgalan_dataset_updates)](https://github.com/rest-for-physics/framework/commits/jgalan_dataset_updates) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

- Added new methods `Range` and `ApplyRange` to `TRestDataSet` they allow to define a sample subset range from the dataset. When we use `ApplyRange` the internal data frame will be updated too. If we only invoke `Range` a `RDF::Node` with the specified range will be returned, but no internal modification will happen.

- Solving an issue in `ExtractParametricNodes` appearing when the dataset is too large, of the order of 1500M entries. The, `fSplitEntries=600,000` divides the operation of node extraction into several steps. See also ROOT-forum entry: https://root-forum.cern.ch/t/problem-with-large-number-of-entries-inside-rdataframe/59632

- `TRestComponentDataSet::fDFRange` data member added. It allows to control the range of the dataset entries that will be used to generate the component.

- In a component we can re-scale the distribution using `weights`, for the moment the weights were a column from the dataFrame, but now it is allowed also to write down a constant. 

In this example, the distribution will be built with 2*Ngamma, where Ngamma is the rate contribution from each event.

```
<parameter name="weights" value="{NGamma,2}"/>
```