### PR TITLE
TRestEventSelectionProcess upgrade

### DIFF
--- a/source/framework/analysis/inc/TRestEventSelectionProcess.h
+++ b/source/framework/analysis/inc/TRestEventSelectionProcess.h
@@ -24,17 +24,16 @@
 #define RestProcess_TRestEventSelectionProcess
 
 #include <TH1D.h>
+#include <TRestEventProcess.h>
 
 #include <iostream>
-
-#include "TRestEventProcess.h"
 
 //! A template process to serve as an example to create new TRestRawSignalEventProcess
 class TRestEventSelectionProcess : public TRestEventProcess {
    private:
     TRestEvent* fEvent;  //!
-    std::string fFileWithIDs = "";
-    std::string fConditions = "";
+    std::string fFileWithIDs;
+    std::string fConditions;
     std::vector<Int_t> fList;
 
     /// A list with the event ids that have been selected.

--- a/source/framework/analysis/src/TRestEventSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventSelectionProcess.cxx
@@ -123,7 +123,7 @@ void TRestEventSelectionProcess::InitProcess() {
         }
     } else if (TRestTools::GetFileNameExtension(fFileWithIDs) == "root") {
         TRestRun run(fFileWithIDs);
-        run.GetEventIdsWithConditions(fConditions);
+        fList = run.GetEventIdsWithConditions(fConditions);
     } else {
         RESTDebug << "TRestEventSelectionProcess: using the processing file itself." << RESTendl;
     }

--- a/source/framework/analysis/src/TRestEventSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventSelectionProcess.cxx
@@ -85,6 +85,7 @@
 #include "TRestEventSelectionProcess.h"
 
 using namespace std;
+
 ClassImp(TRestEventSelectionProcess);
 
 ///////////////////////////////////////////////
@@ -121,9 +122,8 @@ void TRestEventSelectionProcess::InitProcess() {
             File.close();
         }
     } else if (TRestTools::GetFileNameExtension(fFileWithIDs) == "root") {
-        TRestRun* run = new TRestRun(fFileWithIDs);
-        fList = run->GetEventIdsWithConditions(fConditions);
-        delete run;
+        TRestRun run(fFileWithIDs);
+        run.GetEventIdsWithConditions(fConditions);
     } else {
         RESTDebug << "TRestEventSelectionProcess: using the processing file itself." << RESTendl;
     }
@@ -136,11 +136,13 @@ TRestEvent* TRestEventSelectionProcess::ProcessEvent(TRestEvent* inputEvent) {
     fEvent = inputEvent;
 
     if (fFileWithIDs.empty()) {
-        if (this->GetAnalysisTree()->EvaluateCuts(fConditions)) return fEvent;
+        if (this->GetAnalysisTree()->EvaluateCuts(fConditions)) {
+            return fEvent;
+        }
     }
 
-    for (unsigned int i = 0; i < fList.size(); i++) {
-        if (fList[i] == fEvent->GetID()) {
+    for (auto id : fList) {
+        if (id == fEvent->GetID()) {
             return fEvent;
         }
     }


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 18](https://badgen.net/badge/PR%20Size/Ok%3A%2018/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=aezquerro_eventSel)](https://github.com/rest-for-physics/framework/commits/aezquerro_eventSel) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Adding new possibility of using the TRestEventSelectionProcess without an external fileWithIDs by evaluating the conditions on the TRestAnalysisTree of the processing file itself.