### PR TITLE
Explicitly include unistd.h

### DIFF
--- a/source/framework/core/inc/TRestMetadata.h
+++ b/source/framework/core/inc/TRestMetadata.h
@@ -43,6 +43,10 @@
 #include "TRestVersion.h"
 #include "tinyxml.h"
 
+#ifndef WIN32
+#include <unistd.h>
+#endif
+
 /* We keep using REST_RELEASE, REST_VERSION(2,X,Y) and REST_VERSION_CODE
    to determine the installed REST version and avoid too much prototyping
 

--- a/source/framework/core/src/TRestGDMLParser.cxx
+++ b/source/framework/core/src/TRestGDMLParser.cxx
@@ -1,9 +1,6 @@
 #include "TRestGDMLParser.h"
 
 #include <filesystem>
-#ifdef __APPLE__
-#include <unistd.h>
-#endif
 
 using namespace std;
 

--- a/source/framework/core/src/startup.cpp
+++ b/source/framework/core/src/startup.cpp
@@ -4,10 +4,6 @@
 #include <Windows.h>
 #endif  // WIN32
 
-#ifdef __APPLE__
-#include <unistd.h>
-#endif
-
 #include "RVersion.h"
 #include "TEnv.h"
 #include "TRestDataBase.h"

--- a/source/framework/tools/inc/TRestTools.h
+++ b/source/framework/tools/inc/TRestTools.h
@@ -42,6 +42,10 @@
 #define EXTERN_IMP
 #endif
 
+#ifndef WIN32
+#include <unistd.h>
+#endif
+
 const std::string PARAMETER_NOT_FOUND_STR = "NO_SUCH_PARA";
 const double PARAMETER_NOT_FOUND_DBL = -99999999;
 

--- a/source/framework/tools/src/TRestStringOutput.cxx
+++ b/source/framework/tools/src/TRestStringOutput.cxx
@@ -1,5 +1,4 @@
 #include "TRestStringOutput.h"
-
 #include "TRestStringHelper.h"
 
 using namespace std;
@@ -8,10 +7,6 @@ using namespace std;
 #include <Windows.h>
 #include <conio.h>
 #endif  // WIN32
-
-#ifdef __APPLE__
-#include <unistd.h>
-#endif
 
 int Console::GetWidth() {
 #ifdef WIN32


### PR DESCRIPTION
I installed rest-for-physics in WSL Ubuntu 24.04 and I needed to include this header explicitly, probably due to the version of the compiler or something of that nature. This PR makes sure it's added regardless.