### PR TITLE
TRestRun methods and cleanup

### DIFF
--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -176,6 +176,7 @@ class TRestRun : public TRestMetadata {
     std::vector<std::string> GetMetadataNames();
     std::vector<std::string> GetMetadataTitles();
     inline int GetNumberOfMetadata() const { return fMetadata.size(); }
+    Double_t GetElapsedTimeSeconds() const { return fEndTime - fStartTime; }
 
     inline std::string GetMetadataMember(const std::string& instr) { return ReplaceMetadataMember(instr); }
     std::string ReplaceMetadataMembers(const std::string& instr, Int_t precision = 8);
@@ -214,6 +215,7 @@ class TRestRun : public TRestMetadata {
     inline void SetNFilesSplit(int n) { fNFilesSplit = n; }
     inline void HangUpEndFile() { fHangUpEndFile = true; }
     inline void ReleaseEndFile() { fHangUpEndFile = false; }
+
     // Printers
     void PrintStartDate();
     void PrintEndDate();

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -143,7 +143,7 @@ class TRestRun : public TRestMetadata {
     inline TFile* GetInputFile() const { return fInputFile; }
     inline TFile* GetOutputFile() const { return fOutputFile; }
     inline int GetCurrentEntry() const { return fCurrentEvent; }
-    inline Long64_t GetBytesReaded() const { return fBytesRead; }
+    inline Long64_t GetBytesRead() const { return fBytesRead; }
     Long64_t GetTotalBytes();
     Long64_t GetEntries() const;
 

--- a/source/framework/core/inc/TRestRun.h
+++ b/source/framework/core/inc/TRestRun.h
@@ -90,8 +90,8 @@ class TRestRun : public TRestMetadata {
         GetEntry(fCurrentEvent + 1);
     }
 
-    TString FormFormat(const TString& FilenameFormat);
-    TFile* MergeToOutputFile(std::vector<std::string> filefullnames, std::string outputfilename = "");
+    TString FormFormat(const TString& filenameFormat);
+    TFile* MergeToOutputFile(std::vector<std::string> fileFullNames, std::string outputFileName = "");
     TFile* FormOutputFile();
     TFile* UpdateOutputFile();
 
@@ -191,7 +191,6 @@ class TRestRun : public TRestMetadata {
     inline void SetOutputFileName(const std::string& s) { fOutputFileName = s; }
     void SetExtProcess(TRestEventProcess* p);
     inline void SetCurrentEntry(int i) { fCurrentEvent = i; }
-    // void AddFileTask(TRestFileTask* t) { fFileTasks.push_back(t); }
     void SetInputEvent(TRestEvent* event);
     inline void SetRunNumber(Int_t number) { fRunNumber = number; }
     inline void SetParentRunNumber(Int_t number) { fParentRunNumber = number; }
@@ -222,7 +221,9 @@ class TRestRun : public TRestMetadata {
     void PrintMetadata() override;
     inline void PrintAllMetadata() {
         PrintMetadata();
-        for (unsigned int i = 0; i < fMetadata.size(); i++) fMetadata[i]->PrintMetadata();
+        for (unsigned int i = 0; i < fMetadata.size(); i++) {
+            fMetadata[i]->PrintMetadata();
+        }
     }
     inline void PrintTrees() const {
         if (fEventTree != nullptr) {
@@ -237,7 +238,9 @@ class TRestRun : public TRestMetadata {
         }
     }
     void PrintObservables() {
-        if (fAnalysisTree != nullptr) fAnalysisTree->PrintObservables();
+        if (fAnalysisTree != nullptr) {
+            fAnalysisTree->PrintObservables();
+        }
     }
 
     inline void PrintEvent() const { fInputEvent->PrintEvent(); }

--- a/source/framework/core/src/TRestProcessRunner.cxx
+++ b/source/framework/core/src/TRestProcessRunner.cxx
@@ -1090,7 +1090,7 @@ void TRestProcessRunner::PrintProcessedEvents(Int_t rateE) {
         if (fEventsToProcess == REST_MAXIMUM_EVENTS && fRunInfo->GetFileProcess() != nullptr)
         // Nevents is unknown, reading external data file
         {
-            prog = fRunInfo->GetBytesReaded() / (double)fRunInfo->GetTotalBytes() * 100;
+            prog = fRunInfo->GetBytesRead() / (double)fRunInfo->GetTotalBytes() * 100;
         } else if (fRunInfo->GetFileProcess() != nullptr)
         // Nevents is known, reading external data file
         {
@@ -1140,8 +1140,8 @@ void TRestProcessRunner::PrintProcessedEvents(Int_t rateE) {
             fflush(stdout);
         }
 
-        bytesAdded[poscalculated] = fRunInfo->GetBytesReaded() - bytesReaded_last;
-        bytesReaded_last = fRunInfo->GetBytesReaded();
+        bytesAdded[poscalculated] = fRunInfo->GetBytesRead() - bytesReaded_last;
+        bytesReaded_last = fRunInfo->GetBytesRead();
         progAdded[poscalculated] = prog - prog_last;
         prog_last = prog;
 


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 14](https://badgen.net/badge/PR%20Size/Ok%3A%2014/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=run-methods)](https://github.com/rest-for-physics/framework/commits/run-methods) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Add method to return run elapsed time.