### PR TITLE
Remove initialization message on startup

### DIFF
--- a/source/framework/core/src/startup.cpp
+++ b/source/framework/core/src/startup.cpp
@@ -80,7 +80,7 @@ struct __REST_CONST_INIT {
         if (_REST_USERHOME == nullptr) {
             _REST_USERHOME = getenv("HOME");
         } else {
-            cout << "REST_HOME is set to " << _REST_USERHOME << endl;
+            // cout << "REST_HOME is set to " << _REST_USERHOME << endl;
             // create the directory if it does not exist
             std::filesystem::create_directories(_REST_USERHOME);
         }


### PR DESCRIPTION
![lobis](https://badgen.net/badge/PR%20submitted%20by%3A/lobis/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=startup-message-rest-home)](https://github.com/rest-for-physics/framework/commits/startup-message-rest-home) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

This PR removes an initialization message on startup.cpp

When the python REST library is imported this message is printed. We don't want to spam the stdout on imports which may have unintended consecuences (trying to capture the stdout of a program, etc.).

If we want this message to be displayed perhaps a better place is the dialog after initializing `restRoot`.