### PR TITLE
Fix bug when selecting event by ID

### DIFF
--- a/source/framework/core/src/TRestBrowser.cxx
+++ b/source/framework/core/src/TRestBrowser.cxx
@@ -301,7 +301,7 @@ Bool_t TRestBrowser::LoadEventId(Int_t eventID, Int_t subEventID) {
 
     if (fRestRun->GetAnalysisTree() != nullptr && fRestRun->GetAnalysisTree()->GetEntries() > 0) {
         TRestEvent* event = fRestRun->GetEventWithID(eventID, subEventID);
-        if (event != nullptr) {
+        if (event == nullptr) {
             RESTWarning << "Event ID : " << eventID << " with sub ID : " << subEventID << " not found!"
                         << RESTendl;
             return kFALSE;


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 1](https://badgen.net/badge/PR%20Size/Ok%3A%201/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=alvaroezq_browserBugFix)](https://github.com/rest-for-physics/framework/commits/alvaroezq_browserBugFix) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

There is a bug when using the macro REST_ViewEvents that didn't allow to select an event by their event ID. I found that is cause by a simple typo in TRestBrowser class. This PR fixes the bug.