### PR TITLE
TRestDataSetPlot improvements

### DIFF
--- a/source/framework/core/inc/TRestDataSetPlot.h
+++ b/source/framework/core/inc/TRestDataSetPlot.h
@@ -96,7 +96,7 @@ class TRestDataSetPlot : public TRestMetadata {
         std::vector<std::pair<std::array<std::string, 3>, TVector2>> variablePos;
         std::vector<std::pair<std::array<std::string, 3>, TVector2>> metadataPos;
         std::vector<std::pair<std::array<std::string, 3>, TVector2>> obsPos;
-        std::vector<std::pair<std::array<std::string, 3>, TVector2>> expPos;
+        std::vector<std::pair<std::array<std::string, 4>, TVector2>> expPos;
 
         TRestCut* panelCut = nullptr;
 

--- a/source/framework/core/inc/TRestDataSetPlot.h
+++ b/source/framework/core/inc/TRestDataSetPlot.h
@@ -184,6 +184,6 @@ class TRestDataSetPlot : public TRestMetadata {
     TRestDataSetPlot(const char* configFilename, std::string name = "");
     ~TRestDataSetPlot();
 
-    ClassDefOverride(TRestDataSetPlot, 2);
+    ClassDefOverride(TRestDataSetPlot, 3);
 };
 #endif

--- a/source/framework/core/inc/TRestDataSetPlot.h
+++ b/source/framework/core/inc/TRestDataSetPlot.h
@@ -91,6 +91,7 @@ class TRestDataSetPlot : public TRestMetadata {
     struct PanelInfo {
         Float_t font_size;
         Int_t precision;
+        TString delimiter;
 
         std::vector<std::pair<std::array<std::string, 3>, TVector2>> variablePos;
         std::vector<std::pair<std::array<std::string, 3>, TVector2>> metadataPos;

--- a/source/framework/core/src/TRestDataSetPlot.cxx
+++ b/source/framework/core/src/TRestDataSetPlot.cxx
@@ -130,7 +130,8 @@
 ///          <observable value="alphaTrackAna_angle" label="Mean Angle" units="rad" x="0.25" y="0.01" />
 ///          <expression value="cos(alphaTrackAna_angle)^2" label="Cosine of the mean angle" units="" x="0.25"
 ///          y="0.12" precision="5" />
-///          <expression value="({[[meanRate]]*24*3600} #pm {sqrt([[entries]])/[[runLength]]*24})" label="Mean rate: "
+///          <expression value="({[[meanRate]]*24*3600} #pm {sqrt([[entries]])/[[runLength]]*24})" label="Mean
+///          rate: "
 ///              units="per day" x="0.05" y="0.54" precision="%g,%.1g" />
 ///          <addCut name="Fiducial"/>
 ///    </panel>
@@ -728,7 +729,7 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
                 }
                 if (!found) RESTWarning << "Variable " << variable << " not found" << RESTendl;
             }
-            if (isANumber(var)) { // if it is a number, convert it to number to apply precision
+            if (isANumber(var)) {  // if it is a number, convert it to number to apply precision
                 if (var.find('.') == std::string::npos) {
                     int dblVar = StringToInteger(var);
                     var = StringWithPrecision(dblVar, panel.precision);
@@ -799,11 +800,11 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
             }
             if (precisionParts.size() != subtexts.size()) {
                 RESTDebug << "Not enough precision values provided for the expression: `" << text
-                            << "`. Using " << precisionParts.back() << " for last subtexts." << RESTendl;
-                precisionParts.resize(subtexts.size(), precisionParts.back()); // fill with last value
+                          << "`. Using " << precisionParts.back() << " for last subtexts." << RESTendl;
+                precisionParts.resize(subtexts.size(), precisionParts.back());  // fill with last value
             }
 
-            size_t precisionIndex = precisionParts.size()-1;
+            size_t precisionIndex = precisionParts.size() - 1;
             for (const auto& subtext : subtexts) {
                 std::string subVar = subtext;
                 // replace variables
@@ -829,13 +830,13 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
                 if (isANumber(subVar)) {
                     double value = StringToDouble(subVar);
                     std::string prec = precisionParts[precisionIndex--];
-                    if (prec.find('%') != std::string::npos) { // it is a format e.g. %.2f
+                    if (prec.find('%') != std::string::npos) {  // it is a format e.g. %.2f
                         subVar = DoubleToString(value, prec);
-                    } else if (isANumber(prec)) { // it is a number
+                    } else if (isANumber(prec)) {  // it is a number
                         subVar = StringWithPrecision(value, StringToInteger(prec));
                     } else {
-                        RESTWarning << "Unknown precision format: " << prec << ". Using panels precision: "
-                                   << panel.precision << RESTendl;
+                        RESTWarning << "Unknown precision format: " << prec
+                                    << ". Using panels precision: " << panel.precision << RESTendl;
                         subVar = StringWithPrecision(value, panel.precision);
                     }
                 }
@@ -1103,8 +1104,8 @@ void TRestDataSetPlot::PrintMetadata() {
         for (auto& [key, posLabel] : panel.expPos) {
             auto&& [obs, label, units, precision] = key;
             RESTMetadata << "Label Expression " << obs << ", label " << label << ", units " << units
-                         << ", precision " << precision
-                         << " Pos (" << posLabel.X() << ", " << posLabel.Y() << ")" << RESTendl;
+                         << ", precision " << precision << " Pos (" << posLabel.X() << ", " << posLabel.Y()
+                         << ")" << RESTendl;
         }
         RESTMetadata << "****************" << RESTendl;
     }

--- a/source/framework/core/src/TRestDataSetPlot.cxx
+++ b/source/framework/core/src/TRestDataSetPlot.cxx
@@ -718,7 +718,8 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
                 }
                 if (!found) RESTWarning << "Variable " << variable << " not found" << RESTendl;
             }
-            std::string lab = label + panel.delimiter.Data() + StringWithPrecision(var, panel.precision) + " " + units;
+            std::string lab =
+                label + panel.delimiter.Data() + StringWithPrecision(var, panel.precision) + " " + units;
             panel.text.emplace_back(new TLatex(posLabel.X(), posLabel.Y(), lab.c_str()));
         }
 
@@ -736,7 +737,8 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
                 continue;
             }
 
-            std::string lab = label + panel.delimiter.Data() + StringWithPrecision(value, panel.precision) + " " + units;
+            std::string lab =
+                label + panel.delimiter.Data() + StringWithPrecision(value, panel.precision) + " " + units;
             panel.text.emplace_back(new TLatex(posLabel.X(), posLabel.Y(), lab.c_str()));
         }
 
@@ -745,7 +747,8 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
             auto&& [obs, label, units] = key;
             auto value = *dataFrame.Mean(obs);
 
-            std::string lab = label + panel.delimiter.Data() + StringWithPrecision(value, panel.precision) + " " + units;
+            std::string lab =
+                label + panel.delimiter.Data() + StringWithPrecision(value, panel.precision) + " " + units;
             panel.text.emplace_back(new TLatex(posLabel.X(), posLabel.Y(), lab.c_str()));
         }
 
@@ -760,8 +763,8 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
             }
             // replace metadata
             for (const auto& [name, quant] : quantity) {
-                var = Replace(var, "["+name+"]", quant.value); // metadata are surrounded by []
-                var = Replace(var, name, quant.value); // just in case ?
+                var = Replace(var, "[" + name + "]", quant.value);  // metadata are surrounded by []
+                var = Replace(var, name, quant.value);              // just in case ?
             }
             // replace observables
             for (const auto& obs : dataFrame.GetColumnNames()) {
@@ -774,7 +777,7 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
             var = Replace(var, "[", "(");
             var = Replace(var, "]", ")");
             var = EvaluateExpression(var);
-            if (isANumber(var)){
+            if (isANumber(var)) {
                 double value = StringToDouble(var);
                 var = StringWithPrecision(value, StringToInteger(precision));
             }

--- a/source/framework/core/src/TRestDataSetPlot.cxx
+++ b/source/framework/core/src/TRestDataSetPlot.cxx
@@ -760,7 +760,8 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
             }
             // replace metadata
             for (const auto& [name, quant] : quantity) {
-                var = Replace(var, name, quant.value);
+                var = Replace(var, "["+name+"]", quant.value); // metadata are surrounded by []
+                var = Replace(var, name, quant.value); // just in case ?
             }
             // replace observables
             for (const auto& obs : dataFrame.GetColumnNames()) {

--- a/source/framework/core/src/TRestDataSetPlot.cxx
+++ b/source/framework/core/src/TRestDataSetPlot.cxx
@@ -673,9 +673,9 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
         const int entries = *dataFrame.Count();
         const double meanRate = entries / duration;
         const double runLength = duration / 3600.;
-        paramMap["[[runLength]]"] = StringWithPrecision(runLength, panel.precision);
-        paramMap["[[entries]]"] = StringWithPrecision(entries, panel.precision);
-        paramMap["[[meanRate]]"] = StringWithPrecision(meanRate, panel.precision);
+        paramMap["[[runLength]]"] = DoubleToString(runLength, "%.9e");
+        paramMap["[[entries]]"] = IntegerToString(entries);
+        paramMap["[[meanRate]]"] = DoubleToString(meanRate, "%.9e");
 
         paramMap["[[cutNames]]"] = "";
         paramMap["[[cuts]]"] = "";
@@ -726,6 +726,15 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
                     }
                 }
                 if (!found) RESTWarning << "Variable " << variable << " not found" << RESTendl;
+            }
+            if (isANumber(var)) { // if it is a number, convert it to number to apply precision
+                if (var.find('.') == std::string::npos) {
+                    int dblVar = StringToInteger(var);
+                    var = StringWithPrecision(dblVar, panel.precision);
+                } else {
+                    double dblVar = StringToDouble(var);
+                    var = StringWithPrecision(dblVar, panel.precision);
+                }
             }
             std::string lab =
                 label + panel.delimiter.Data() + StringWithPrecision(var, panel.precision) + " " + units;

--- a/source/framework/core/src/TRestDataSetPlot.cxx
+++ b/source/framework/core/src/TRestDataSetPlot.cxx
@@ -359,6 +359,7 @@ void TRestDataSetPlot::ReadPanelInfo() {
         PanelInfo panel;
         panel.font_size = StringToDouble(GetParameter("font_size", panelele, "0.1"));
         panel.precision = StringToInteger(GetParameter("precision", panelele, "2"));
+        panel.delimiter = GetParameter("delimiter", panelele, ": ");
 
         panel.panelCut = ReadCut(panel.panelCut, panelele);
 
@@ -706,7 +707,7 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
                 }
                 if (!found) RESTWarning << "Variable " << variable << " not found" << RESTendl;
             }
-            std::string lab = label + ": " + StringWithPrecision(var, panel.precision) + " " + units;
+            std::string lab = label + panel.delimiter.Data() + StringWithPrecision(var, panel.precision) + " " + units;
             panel.text.emplace_back(new TLatex(posLabel.X(), posLabel.Y(), lab.c_str()));
         }
 
@@ -724,7 +725,7 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
                 continue;
             }
 
-            std::string lab = label + ": " + StringWithPrecision(value, panel.precision) + " " + units;
+            std::string lab = label + panel.delimiter.Data() + StringWithPrecision(value, panel.precision) + " " + units;
             panel.text.emplace_back(new TLatex(posLabel.X(), posLabel.Y(), lab.c_str()));
         }
 
@@ -733,7 +734,7 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
             auto&& [obs, label, units] = key;
             auto value = *dataFrame.Mean(obs);
 
-            std::string lab = label + ": " + StringWithPrecision(value, panel.precision) + " " + units;
+            std::string lab = label + panel.delimiter.Data() + StringWithPrecision(value, panel.precision) + " " + units;
             panel.text.emplace_back(new TLatex(posLabel.X(), posLabel.Y(), lab.c_str()));
         }
 
@@ -762,7 +763,7 @@ void TRestDataSetPlot::PlotCombinedCanvas() {
             var = Replace(var, "]", ")");
             var = EvaluateExpression(var);
 
-            std::string lab = label + ": " + var + " " + units;
+            std::string lab = label + panel.delimiter.Data() + var + " " + units;
             panel.text.emplace_back(new TLatex(posLabel.X(), posLabel.Y(), lab.c_str()));
         }
 

--- a/source/framework/core/src/TRestDataSetPlot.cxx
+++ b/source/framework/core/src/TRestDataSetPlot.cxx
@@ -46,8 +46,8 @@
 /// histogram level.
 ///
 /// ## Basic TRestDataSetPlot parameters
-/// * **name**: Name of the TRestDataSetPlot class and canvas
-/// * **title**: Title of the TRestDataSetPlot class and canvas
+/// * **name**: Name of the TRestDataSetPlot class and canvas.
+/// * **title**: Title of the TRestDataSetPlot class and canvas.
 /// * **dataSetName**: Name of the dataSet to be used to perform the plots. Note
 /// that if this variable is empty, it will use the name of the inputfile provided
 /// at restManager.
@@ -59,16 +59,17 @@
 /// * **previewPlot**: If true the plot (canvas) is displayed and can be modified before
 /// saving it.
 /// * **paletteStyle**: Style of the palette to be used in all the plots.
-/// * **legendX1**: Start position of the legend in the X axis
-/// * **legendY1**: Start position of the legend in the X axis
-/// * **legendX2**: End position of the legend in the X axis
-/// * **legendY2**: End position of the legend in the X axis
-/// * **canvasSize**: TVector2 with the size of the canvas in points
-/// * **canvasDivisions**: TVector2 with the divisions of the canvas e.g. (3, 2) --> 3 x 2
+/// * **legendX1**: Start position of the legend in the X axis.
+/// * **legendY1**: Start position of the legend in the Y axis.
+/// * **legendX2**: End position of the legend in the X axis.
+/// * **legendY2**: End position of the legend in the Y axis.
+/// * **canvasSize**: TVector2 with the size of the canvas in points.
+/// * **canvasDivisions**: TVector2 with the divisions of the canvas e.g. (3, 2) --> 3 x 2.
+///
 /// The key `addCut` can be povided in order to perform the cut to the entire dataSet. Note
 /// that the TRestCut must be defined inside the rml and several cuts can be added.
 ///
-/// Example of TRestDataSetPlot basic parameters with a set TRestCuts:
+/// Example of TRestDataSetPlot basic parameters with a set of TRestCuts:
 /// \code
 ///    <TRestDataSetPlot name="restplot" title="Basic Plots" previewPlot="true" canvasSize="(1200,1200)"
 ///    canvasDivisions="(2,2)" verboseLevel="info">
@@ -113,8 +114,8 @@
 /// * **units**: String with the units to be appended to the label.
 /// * **x**: X position of the label inside the pad
 /// * **y**: Y position of the label inside the pad
-/// * **precision**: Precision of the value to be written, by default is set to 2. Only valid
-/// for expression key. You can use a number or printf-style formatting specifier (e.g. `%.3f`).
+/// * **precision**: Precision of the value to be written, by default is set to the panel precision.
+/// Only valid for expression key. You can use a number or printf-style formatting specifier (e.g. `%.3f`).
 /// If the expression contains multiple values encapsulated with brace brackets, you can independently
 /// set the precision for each value by separating them with a comma, e.g. `2,%.3f`.
 ///
@@ -145,7 +146,7 @@
 /// * **gridX;gridY**: If true plot grid in the corresponding axis (X or Y)
 /// * **marginLeft;marginRight;marginTop;marginBottom**: Margins size
 /// * **legend**: If true/ON it plots the legend
-/// * **stackOption*: THStack draw option to be used, note that by default is set to `NOSTACK`
+/// * **stackOption**: THStack draw option to be used, note that by default is set to `NOSTACK`
 /// * **timeDisplay**: If true/ON time display is set in the X axis
 /// * **norm**: Normalization constant in which the plot will be normalized, e.g. use `1` in
 /// case you want to normalize by 1.

--- a/source/framework/core/src/TRestDataSetPlot.cxx
+++ b/source/framework/core/src/TRestDataSetPlot.cxx
@@ -32,21 +32,20 @@
 /// between metadata, variables or observable values.
 ///
 /// The rml file can be splitted in three main blocks that are detailed below;
-/// * Basic parameters: global variables to perform the plot such as canvas size,
+/// * Basic TRestDataSetPlot parameters: global variables to perform the plot such as canvas size,
 /// pad divisions, preview or outputFile info.
-/// * Panel parameters: A panel defines different labels that will be written in
+/// * Panel: it defines different labels that will be written in
 /// a pad, it accepts different parameters such as metadata info, variable values,
 /// and observable values, that can be written in the panel. A cut can be provided
 /// to a panel in order to print the info after appliying a particular cut.
-/// * Plot parameters: It contains the info to produce a plot at the pad level.
+/// * Plots: It contains the info to produce a plot at the pad level.
 /// A plot consists of a set of histograms that can be plot together using
 /// THStack, note that only 1D and 2D histograms are supported. The histograms
 /// are defined inside the plot metadata section and one or two variables must
 /// be provided (1D or 2D histos) besides the range, while a cut can be set at the
 /// histogram level.
 ///
-/// ### Parameters
-/// * Basic parameters of TRestDataSetPlot:
+/// ## Basic TRestDataSetPlot parameters
 /// * **name**: Name of the TRestDataSetPlot class and canvas
 /// * **title**: Title of the TRestDataSetPlot class and canvas
 /// * **dataSetName**: Name of the dataSet to be used to perform the plots. Note
@@ -85,18 +84,25 @@
 ///    </TRestDataSetPlot>
 /// \endcode
 ///
-/// * Panel parameters:
+/// ## Panel
 /// Basic panel parameters:
 /// * **font_size**: Font size of the entire panel.
 /// * **precision**: Precision for the values to be written.
-/// * **value**: If true/ON panel is displayed, otherwise is ignored
-/// Different keys are provided: `metadata` is meant for the metadata info inside the
-/// TRestDataSet (as a RelevantQuantity), `variable` for a predefined variable e.g. rate,
-/// `observable` for an observable value and `expression` for a mathematical expression
-/// that can contain any of the previous. Note that the time-related variables _startTime_,
-/// _endTime_ and _runLength_ (then _meanRate_ too) are obtained from the TRestDataSet and
+/// * **delimiter**: Delimiter to be used between the label and the value, by default is ": ".
+/// * **value**: If true/ON panel is displayed, otherwise is ignored.
+///
+/// ### Panel keys
+/// Different keys are provided:
+/// * **metadata** is meant for the metadata info inside the TRestDataSet (as a RelevantQuantity).
+/// * **variable** for a predefined variable.These can be any of _entries_, _runLength_ (in hours),
+/// _startTime_, _endTime_, _meanRate_ (in Hz), _cuts_, _panelCuts_, _cutNames_ or _panelCutNames_.
+/// * **observable** for the mean value of an observable.
+/// * **expression** for a mathematical expression that can contain any of the previous.
+///
+/// Note that the time-related variables _startTime_, _endTime_ and _runLength_
+/// (then _meanRate_ too) are obtained from the TRestDataSet and
 /// not the RDataFrame of the TRestDataSet, thus they are not afected by the cuts.
-/// All the keys have the same structure which is detailed below:
+/// All the keys have the following parameters:
 /// * **value**: Name of the metadata, variable or observable value.
 /// * **label**: String of the label that will be written before the observable value.
 /// * **units**: String with the units to be appended to the label.
@@ -120,7 +126,8 @@
 ///    </panel>
 /// \endcode
 ///
-/// * Plot parameters:
+/// ## Plot
+/// Basic plot parameters:
 /// * **name**: Name of the plot
 /// * **title**: Title of the plot
 /// * **xlabel**: Title of the label in the X axis
@@ -140,24 +147,26 @@
 /// * **value**: If true/ON plot is displayed, otherwise is ignored
 /// * **save**: String with the name of the output file in which the plot will be saved
 /// in a separated file, several formats are supported (root, pdf, eps, jpg,...)
-/// * Histogram parameters:
-/// Please, use the `histo` key inside `plot` to add the plot parameters. You can add as many
+///
+/// ### Histogram:
+/// Use the `histo` key inside `plot` to add the plot parameters. You can add as many
 /// histograms as you want but note that only 1D and 2D histograms are supported.
 /// * **name**: Name of the histogram
-/// * **option*: Draw option to be used, note that by default is set to `COLZ`
-/// * **lineColor*: Color of the line used in the histogram.
-/// * **lineWidth*: Width of the line used in the histogram.
-/// * **lineStyle*: Line style to be used in the histogram.
-/// * **fillStyle*: Fill style to used in the histogram.
-/// * **fillColor*: Fill color to used in the histogram.
-/// * **stats**: If true/ON it plots histogram statistics
+/// * **option**: Draw option to be used, note that by default is set to `COLZ`
+/// * **lineColor**: Color of the line used in the histogram.
+/// * **lineWidth**: Width of the line used in the histogram.
+/// * **lineStyle**: Line style to be used in the histogram.
+/// * **fillStyle**: Fill style to used in the histogram.
+/// * **fillColor**: Fill color to used in the histogram.
+/// * **stats**: If true/ON it plots histogram statistics.
+///
 /// In order to add one or two variables to the histogram please use the `variable` key.
 /// In order to perform a 2D plot you should add two variable` keys, where the first one
 /// corresponds to the X axis. The `variable` key has the following parameters:
-/// * **name*: Name of the observable to be plotted, the observable must be defined inside
+/// * **name**: Name of the observable to be plotted, the observable must be defined inside
 /// the dataSet.
-/// * **range*: TVector2 with the range of the variable to be plotted
-/// * **nBins*: Number of bins that will be used in the histogram.
+/// * **range**: TVector2 with the range of the variable to be plotted
+/// * **nBins**: Number of bins that will be used in the histogram.
 /// The key `addCut` can be povided in order to perform the cut to the histogram. Note
 /// that the TRestCut must be defined inside the rml.
 ///
@@ -173,7 +182,7 @@
 ///     </plot>
 /// \endcode
 ///
-/// ### Examples
+/// ## Full example
 /// Following example creates one panel and three plots including one or two histograms:
 /// \code
 ///  <TRestManager name="alphaTrack" title="alphaTrack" verboseLevel="info">


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Medium: 153](https://badgen.net/badge/PR%20Size/Medium%3A%20153/orange) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=aezq_dsplotImprovements)](https://github.com/rest-for-physics/framework/commits/aezq_dsplotImprovements) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Some small new customization features are added:
* Configurable delimiter for panel entries. Befores it was always added the string ": " between the label and the value. Now you can change it with the panel parameter `delimiter`.
* Precision parameter for each expression panel entry. Before, you could only set the precision of the panel globally. Now, upon this global panel precision, you can also modify the precision of a particular expression entry.
* Multiple mathematical expression in expression panel entries. With this new feature, you can build more complex labels. For example, to print a value with its error in the same label.

This new customization options are added to the documentation with some reorganization and fixes.