### PR TITLE
Add secondary spatial observable for generation of gain map of TRestDataSetGainMap

### DIFF
--- a/source/framework/analysis/inc/TRestDataSetGainMap.h
+++ b/source/framework/analysis/inc/TRestDataSetGainMap.h
@@ -253,7 +253,8 @@ class TRestDataSetGainMap : public TRestMetadata {
         void DrawLinearFit(const TVector2& position, TCanvas* c = nullptr);
         void DrawLinearFit(const int index_x, const int index_y, TCanvas* c = nullptr);
 
-        void DrawGainMap(const int peakNumber = 0, const bool fullModuleAsRef = true, const bool showText = true);
+        void DrawGainMap(const int peakNumber = 0, const bool fullModuleAsRef = true,
+                         const bool showText = true);
 
         void Refit(const TVector2& position, const double energy, const TVector2& range);
         void Refit(const size_t x, const size_t y, const size_t peakNumber, const TVector2& range);

--- a/source/framework/analysis/inc/TRestDataSetGainMap.h
+++ b/source/framework/analysis/inc/TRestDataSetGainMap.h
@@ -52,6 +52,12 @@ class TRestDataSetGainMap : public TRestMetadata {
     /// Observable that will be used to segmentize the gain map in the y direction
     std::string fSpatialObservableY = "";  //<
 
+    /// Secondary observable that will be used to segmentize the gain map in the x direction (if needed)
+    std::string fSpatialObservableXSecondary = "";  //<
+
+    /// Secondary observable that will be used to segmentize the gain map in the y direction (if needed)
+    std::string fSpatialObservableYSecondary = "";  //<
+
     /// List of modules
     std::vector<Module> fModulesCal = {};  //<
 
@@ -83,6 +89,8 @@ class TRestDataSetGainMap : public TRestMetadata {
     std::string GetObservable() const { return fObservable; }
     std::string GetSpatialObservableX() const { return fSpatialObservableX; }
     std::string GetSpatialObservableY() const { return fSpatialObservableY; }
+    std::string GetSpatialObservableXSecondary() const { return fSpatialObservableXSecondary; }
+    std::string GetSpatialObservableYSecondary() const { return fSpatialObservableYSecondary; }
     TRestCut* GetCut() const { return fCut; }
 
     Module* GetModule(const size_t index = 0);
@@ -119,7 +127,7 @@ class TRestDataSetGainMap : public TRestMetadata {
     TRestDataSetGainMap(const char* configFilename, std::string name = "");
     ~TRestDataSetGainMap();
 
-    ClassDefOverride(TRestDataSetGainMap, 2);
+    ClassDefOverride(TRestDataSetGainMap, 3);
 
     class Module {
        private:
@@ -223,6 +231,8 @@ class TRestDataSetGainMap : public TRestMetadata {
         std::string GetObservable() const { return p->fObservable; }
         std::string GetSpatialObservableX() const { return p->fSpatialObservableX; }
         std::string GetSpatialObservableY() const { return p->fSpatialObservableY; }
+        std::string GetSpatialObservableXSecondary() const { return p->fSpatialObservableXSecondary; }
+        std::string GetSpatialObservableYSecondary() const { return p->fSpatialObservableYSecondary; }
         inline std::string GetModuleDefinitionCut() const { return fDefinitionCut; }
         Int_t GetNumberOfSegmentsX() const { return fNumberOfSegmentsX; }
         Int_t GetNumberOfSegmentsY() const { return fNumberOfSegmentsY; }

--- a/source/framework/analysis/inc/TRestDataSetGainMap.h
+++ b/source/framework/analysis/inc/TRestDataSetGainMap.h
@@ -253,7 +253,7 @@ class TRestDataSetGainMap : public TRestMetadata {
         void DrawLinearFit(const TVector2& position, TCanvas* c = nullptr);
         void DrawLinearFit(const int index_x, const int index_y, TCanvas* c = nullptr);
 
-        void DrawGainMap(const int peakNumber = 0, const bool fullModuleAsRef = true);
+        void DrawGainMap(const int peakNumber = 0, const bool fullModuleAsRef = true, const bool showText = true);
 
         void Refit(const TVector2& position, const double energy, const TVector2& range);
         void Refit(const size_t x, const size_t y, const size_t peakNumber, const TVector2& range);

--- a/source/framework/analysis/src/TRestDataSetGainMap.cxx
+++ b/source/framework/analysis/src/TRestDataSetGainMap.cxx
@@ -430,6 +430,8 @@ TRestDataSetGainMap& TRestDataSetGainMap::operator=(TRestDataSetGainMap& src) {
     fObservable = src.GetObservable();
     fSpatialObservableX = src.GetSpatialObservableX();
     fSpatialObservableY = src.GetSpatialObservableY();
+    fSpatialObservableXSecondary = src.GetSpatialObservableXSecondary();
+    fSpatialObservableYSecondary = src.GetSpatialObservableYSecondary();
     fCut = src.GetCut();
     fModulesCal.clear();
     for (auto pID : src.GetPlaneIDs())
@@ -531,6 +533,10 @@ void TRestDataSetGainMap::PrintMetadata() {
     RESTMetadata << " Calibration observable: " << fObservable << RESTendl;
     RESTMetadata << " Spatial observable X: " << fSpatialObservableX << RESTendl;
     RESTMetadata << " Spatial observable Y: " << fSpatialObservableY << RESTendl;
+    if (!fSpatialObservableXSecondary.empty())
+        RESTMetadata << " Secondary spatial observable X: " << fSpatialObservableXSecondary << RESTendl;
+    if (!fSpatialObservableYSecondary.empty())
+        RESTMetadata << " Secondary spatial observable Y: " << fSpatialObservableYSecondary << RESTendl;
     RESTMetadata << "-----------------------------------------------" << RESTendl;
     for (auto& i : fModulesCal) i.Print();
     RESTMetadata << "***********************************************" << RESTendl;
@@ -729,6 +735,10 @@ void TRestDataSetGainMap::Module::GenerateGainMap() {
         obsList.push_back(p->GetObservable());
         obsList.push_back(p->GetSpatialObservableX());
         obsList.push_back(p->GetSpatialObservableY());
+        if (!p->GetSpatialObservableXSecondary().empty())
+            obsList.push_back(p->GetSpatialObservableXSecondary());
+        if (!p->GetSpatialObservableYSecondary().empty())
+            obsList.push_back(p->GetSpatialObservableYSecondary());
 
         // look for observables (characterized by having a _ in the name) in the definition cut
         auto modDefCutObs = TRestTools::GetObservablesInString(fDefinitionCut, true);
@@ -831,6 +841,12 @@ void TRestDataSetGainMap::Module::GenerateGainMap() {
             if (!GetSpatialObservableY().empty())
                 segment_cut += "&&" + GetSpatialObservableY() + ">=" + std::to_string(yLower) + "&&" +
                                GetSpatialObservableY() + "<" + std::to_string(yUpper);
+            if (!GetSpatialObservableXSecondary().empty())
+                segment_cut += "&&" + GetSpatialObservableXSecondary() + ">=" + std::to_string(xLower) +
+                               "&&" + GetSpatialObservableXSecondary() + "<" + std::to_string(xUpper);
+            if (!GetSpatialObservableYSecondary().empty())
+                segment_cut += "&&" + GetSpatialObservableYSecondary() + ">=" + std::to_string(yLower) +
+                               "&&" + GetSpatialObservableYSecondary() + "<" + std::to_string(yUpper);
             if (!fDefinitionCut.empty()) segment_cut += "&&" + fDefinitionCut;
             if (segment_cut.empty()) segment_cut = "1";
             RESTExtreme << "Segment[" << i << "][" << j << "] cut: " << segment_cut << p->RESTendl;

--- a/source/framework/analysis/src/TRestDataSetGainMap.cxx
+++ b/source/framework/analysis/src/TRestDataSetGainMap.cxx
@@ -1458,7 +1458,8 @@ void TRestDataSetGainMap::Module::DrawLinearFit(TCanvas* c) {
 /// as reference.
 /// \param showText If true, it will show the gain value in each segment.
 ///
-void TRestDataSetGainMap::Module::DrawGainMap(const int peakNumber, const bool fullModuleAsRef, const bool showText) {
+void TRestDataSetGainMap::Module::DrawGainMap(const int peakNumber, const bool fullModuleAsRef,
+                                              const bool showText) {
     if (peakNumber < 0 || peakNumber >= (int)fEnergyPeaks.size()) {
         RESTError << "Peak number out of range (peakNumber should be between 0 and "
                   << fEnergyPeaks.size() - 1 << " )" << p->RESTendl;

--- a/source/framework/analysis/src/TRestDataSetGainMap.cxx
+++ b/source/framework/analysis/src/TRestDataSetGainMap.cxx
@@ -1456,8 +1456,9 @@ void TRestDataSetGainMap::Module::DrawLinearFit(TCanvas* c) {
 /// \param fullModuleAsRef If true, it will use the peak position at the full module spectrum
 /// as reference for the gain map. If false, it will use the centered segment of the module
 /// as reference.
+/// \param showText If true, it will show the gain value in each segment.
 ///
-void TRestDataSetGainMap::Module::DrawGainMap(const int peakNumber, bool fullModuleAsRef) {
+void TRestDataSetGainMap::Module::DrawGainMap(const int peakNumber, const bool fullModuleAsRef, const bool showText) {
     if (peakNumber < 0 || peakNumber >= (int)fEnergyPeaks.size()) {
         RESTError << "Peak number out of range (peakNumber should be between 0 and "
                   << fEnergyPeaks.size() - 1 << " )" << p->RESTendl;
@@ -1509,7 +1510,9 @@ void TRestDataSetGainMap::Module::DrawGainMap(const int peakNumber, bool fullMod
     hGainMap->SetStats(0);
     hGainMap->Draw("colz");
     hGainMap->SetBarOffset(0.2);
-    hGainMap->Draw("TEXT SAME");
+    if (showText) {
+        hGainMap->Draw("TEXT SAME");
+    }
 }
 
 /////////////////////////////////////////////


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 27](https://badgen.net/badge/PR%20Size/Ok%3A%2027/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=gmAddSecondarySpatialObservable)](https://github.com/rest-for-physics/framework/commits/gmAddSecondarySpatialObservable) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Add the possibility to give a second observable to constrain the events that are selected as part of a segment.

This is useful, for example, for the case of a gain map of alphas, where you want to only take into account for the spectrum of each segments the alphas which tracks are fully contained in the segment. With this change, you can achieve that by using the origin and end observables as spatialObservable and spatialObservableSecondary