### PR TITLE
Add option to fix the first and last node in kMeansClustering

### DIFF
--- a/source/framework/core/inc/TRestVolumeHits.h
+++ b/source/framework/core/inc/TRestVolumeHits.h
@@ -69,7 +69,8 @@ class TRestVolumeHits : public TRestHits {
         return TMath::Sqrt(fSigmaX[n] * fSigmaX[n] + fSigmaY[n] * fSigmaY[n]);
     }
 
-    static void kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& vHits, int maxIt = 100, bool fixBoundaries = false);
+    static void kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& vHits, int maxIt = 100,
+                                 bool fixBoundaries = false);
 
     // Constructor & Destructor
     TRestVolumeHits();

--- a/source/framework/core/inc/TRestVolumeHits.h
+++ b/source/framework/core/inc/TRestVolumeHits.h
@@ -69,7 +69,7 @@ class TRestVolumeHits : public TRestHits {
         return TMath::Sqrt(fSigmaX[n] * fSigmaX[n] + fSigmaY[n] * fSigmaY[n]);
     }
 
-    static void kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& vHits, int maxIt = 100);
+    static void kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& vHits, int maxIt = 100, bool fixBoundaries = false);
 
     // Constructor & Destructor
     TRestVolumeHits();

--- a/source/framework/core/src/TRestVolumeHits.cxx
+++ b/source/framework/core/src/TRestVolumeHits.cxx
@@ -162,13 +162,14 @@ void TRestVolumeHits::PrintHits() const {
     }
 }
 
-void TRestVolumeHits::kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& vHits, int maxIt, bool fixBoundaries) {
+void TRestVolumeHits::kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& vHits, int maxIt,
+                                       bool fixBoundaries) {
     const int nodes = vHits.GetNumberOfHits();
     vector<TRestVolumeHits> volHits(nodes);
     // std::cout<<"Nhits "<<hits->GetNumberOfHits()<<" Nodes "<<nodes<<std::endl;
     TVector3 nullVector = TVector3(0, 0, 0);
     std::vector<TVector3> centroid(nodes);
-    std::vector<TVector3> centroidOld(nodes, nullVector); // used for iterations
+    std::vector<TVector3> centroidOld(nodes, nullVector);  // used for iterations
 
     for (int h = 0; h < nodes; h++) centroid[h] = vHits.GetPosition(h);
 
@@ -178,7 +179,7 @@ void TRestVolumeHits::kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& v
             double minDist = 1E9;
             int clIndex = -1;
             for (int n = 0; n < nodes; n++) {
-                if (fixBoundaries && (n == 0 || n == nodes - 1)) continue; // Skip fixed nodes
+                if (fixBoundaries && (n == 0 || n == nodes - 1)) continue;  // Skip fixed nodes
                 TVector3 hitPos = hits->GetPosition(i);
                 double dist = (centroid[n] - hitPos).Mag();
                 if (dist < minDist) {
@@ -193,7 +194,7 @@ void TRestVolumeHits::kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& v
         // Update centroids and check for convergence
         bool converge = true;
         for (int n = 0; n < nodes; n++) {
-            if ( fixBoundaries && (n == 0 || n == nodes - 1) ) continue; // Skip fixed nodes
+            if (fixBoundaries && (n == 0 || n == nodes - 1)) continue;  // Skip fixed nodes
             centroid[n] = volHits[n].GetMeanPosition();
             converge &= (centroid[n] == centroidOld[n]);
             centroidOld[n] = centroid[n];
@@ -210,8 +211,8 @@ void TRestVolumeHits::kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& v
             vHits.AddHit(centroid[n], 0, 0, vHits.GetType(n), sigma);
         } else {
             if (volHits[n].GetNumberOfHits() > 0)
-                vHits.AddHit(volHits[n].GetMeanPosition(), volHits[n].GetTotalEnergy(), 0, volHits[n].GetType(0),
-                            sigma);
+                vHits.AddHit(volHits[n].GetMeanPosition(), volHits[n].GetTotalEnergy(), 0,
+                             volHits[n].GetType(0), sigma);
         }
     }
 }

--- a/source/framework/core/src/TRestVolumeHits.cxx
+++ b/source/framework/core/src/TRestVolumeHits.cxx
@@ -162,13 +162,13 @@ void TRestVolumeHits::PrintHits() const {
     }
 }
 
-void TRestVolumeHits::kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& vHits, int maxIt) {
+void TRestVolumeHits::kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& vHits, int maxIt, bool fixBoundaries) {
     const int nodes = vHits.GetNumberOfHits();
     vector<TRestVolumeHits> volHits(nodes);
     // std::cout<<"Nhits "<<hits->GetNumberOfHits()<<" Nodes "<<nodes<<std::endl;
     TVector3 nullVector = TVector3(0, 0, 0);
     std::vector<TVector3> centroid(nodes);
-    std::vector<TVector3> centroidOld(nodes, nullVector);
+    std::vector<TVector3> centroidOld(nodes, nullVector); // used for iterations
 
     for (int h = 0; h < nodes; h++) centroid[h] = vHits.GetPosition(h);
 
@@ -178,6 +178,7 @@ void TRestVolumeHits::kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& v
             double minDist = 1E9;
             int clIndex = -1;
             for (int n = 0; n < nodes; n++) {
+                if (fixBoundaries && (n == 0 || n == nodes - 1)) continue; // Skip fixed nodes
                 TVector3 hitPos = hits->GetPosition(i);
                 double dist = (centroid[n] - hitPos).Mag();
                 if (dist < minDist) {
@@ -188,8 +189,11 @@ void TRestVolumeHits::kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& v
             // cout<<minDist<<" "<<clIndex<<endl;
             volHits[clIndex].AddHit(*hits, i);
         }
+
+        // Update centroids and check for convergence
         bool converge = true;
         for (int n = 0; n < nodes; n++) {
+            if ( fixBoundaries && (n == 0 || n == nodes - 1) ) continue; // Skip fixed nodes
             centroid[n] = volHits[n].GetMeanPosition();
             converge &= (centroid[n] == centroidOld[n]);
             centroidOld[n] = centroid[n];
@@ -202,8 +206,12 @@ void TRestVolumeHits::kMeansClustering(TRestVolumeHits* hits, TRestVolumeHits& v
     vHits.RemoveHits();
     const TVector3 sigma(0., 0., 0.);
     for (int n = 0; n < nodes; n++) {
-        if (volHits[n].GetNumberOfHits() > 0)
-            vHits.AddHit(volHits[n].GetMeanPosition(), volHits[n].GetTotalEnergy(), 0, volHits[n].GetType(0),
-                         sigma);
+        if (fixBoundaries && (n == 0 || n == nodes - 1)) {
+            vHits.AddHit(centroid[n], 0, 0, vHits.GetType(n), sigma);
+        } else {
+            if (volHits[n].GetNumberOfHits() > 0)
+                vHits.AddHit(volHits[n].GetMeanPosition(), volHits[n].GetTotalEnergy(), 0, volHits[n].GetType(0),
+                            sigma);
+        }
     }
 }


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 16](https://badgen.net/badge/PR%20Size/Ok%3A%2016/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=fixBoundariesMeansClustering)](https://github.com/rest-for-physics/framework/commits/fixBoundariesMeansClustering) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

When doing the linearization process of tracks for alpha analysis, the length is always a bit shorter than it should. This is due to the kMeansClustering algorithm that tends to pull the nodes position towards the center of the track. This effect is diminuished by adding more nodes, but this ends up messing the track reconstruction and length resolution. 

To avoid these, we can fix the position of the first and last node to be at the start and end of the track and not be changed during the kMeansClustering algorithm.

> [!IMPORTANT]
> This change is needed for [54](https://github.com/rest-for-physics/tracklib/pull/54).