### PR TITLE
Adding lock mechanism to check runNumber

### DIFF
--- a/source/framework/tools/src/TRestDataBase.cxx
+++ b/source/framework/tools/src/TRestDataBase.cxx
@@ -162,6 +162,10 @@ int TRestDataBase::get_lastrun() {
     string runFilename = REST_USER_PATH + "/runNumber";
     bool fileExist = TRestTools::fileExists(runFilename);
     int fd = open(runFilename.c_str(), O_RDWR | O_CREAT, 0666);
+    if (fd == -1) {
+        RESTError << "Error opening file " << runFilename << strerror(errno) << RESTendl;
+        return -1;
+    }
     flock(fd, LOCK_EX);
     if (!fileExist) {
         string newRun = to_string(runNr) + "\n";
@@ -193,7 +197,7 @@ int TRestDataBase::get_lastrun() {
 ///
 /// The method in derived class shall follow this rule.
 int TRestDataBase::set_run(DBEntry info, bool overwrite) {
-    int newRunNr;
+    int newRunNr = -1;
     if (info.runNr == 0) {
         newRunNr = get_lastrun() + 1;
     } else if (info.runNr > 0) {
@@ -205,6 +209,10 @@ int TRestDataBase::set_run(DBEntry info, bool overwrite) {
     string runFilename = REST_USER_PATH + "/runNumber";
     if (TRestTools::isPathWritable(REST_USER_PATH)) {
         int fd = open(runFilename.c_str(), O_RDWR | O_CREAT, 0666);
+        if (fd == -1) {
+            RESTError << "Error opening file " << runFilename << strerror(errno) << RESTendl;
+            return -1;
+        }
         flock(fd, LOCK_EX);
         string newRun = to_string(newRunNr + 1) + "\n";
         if (write(fd, newRun.c_str(), newRun.size()) == -1)

--- a/source/framework/tools/src/TRestDataBase.cxx
+++ b/source/framework/tools/src/TRestDataBase.cxx
@@ -165,15 +165,14 @@ int TRestDataBase::get_lastrun() {
     flock(fd, LOCK_EX);
     if (!fileExist) {
         string newRun = to_string(runNr) + "\n";
-        if(write(fd, newRun.c_str(), newRun.size()) == -1)
-            RESTError << "Error writing file " <<runFilename << strerror(errno) << RESTendl;
+        if (write(fd, newRun.c_str(), newRun.size()) == -1)
+            RESTError << "Error writing file " << runFilename << strerror(errno) << RESTendl;
         fsync(fd);
     } else {
         lseek(fd, 0, SEEK_SET);
         char buffer[64] = {0};
         ssize_t bytesReaded = read(fd, buffer, sizeof(buffer) - 1);
-        if (bytesReaded > 0)
-            runNr = std::atoi(buffer);
+        if (bytesReaded > 0) runNr = std::atoi(buffer);
     }
     flock(fd, LOCK_UN);
     close(fd);
@@ -208,8 +207,8 @@ int TRestDataBase::set_run(DBEntry info, bool overwrite) {
         int fd = open(runFilename.c_str(), O_RDWR | O_CREAT, 0666);
         flock(fd, LOCK_EX);
         string newRun = to_string(newRunNr + 1) + "\n";
-        if(write(fd, newRun.c_str(), newRun.size()) == -1)
-            RESTError << "Error writing file " <<runFilename << strerror(errno) << RESTendl;
+        if (write(fd, newRun.c_str(), newRun.size()) == -1)
+            RESTError << "Error writing file " << runFilename << strerror(errno) << RESTendl;
         fsync(fd);
         flock(fd, LOCK_UN);
         close(fd);

--- a/source/framework/tools/src/TRestDataBase.cxx
+++ b/source/framework/tools/src/TRestDataBase.cxx
@@ -1,12 +1,12 @@
 #include "TRestDataBase.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <stdio.h>
+#include <sys/file.h>
 #include <sys/stat.h>
 #include <sys/types.h>
-#include <sys/file.h>
 #include <unistd.h>
-#include <fcntl.h>
 
 #include <chrono>
 #include <thread>
@@ -158,7 +158,7 @@ TRestDataBase::TRestDataBase() {
 /// Note that this file saves run number of the **next** run. So it returns
 /// The run number -1.
 int TRestDataBase::get_lastrun() {
-    int runNr=1;
+    int runNr = 1;
     string runFilename = REST_USER_PATH + "/runNumber";
     bool fileExist = TRestTools::fileExists(runFilename);
     int fd = open(runFilename.c_str(), O_RDWR | O_CREAT, 0666);
@@ -209,8 +209,8 @@ int TRestDataBase::set_run(DBEntry info, bool overwrite) {
         write(fd, newRun.c_str(), newRun.size());
         fsync(fd);
         flock(fd, LOCK_UN);
-    close(fd);
-        
+        close(fd);
+
     } else {
         RESTWarning << "runNumber file not writable. auto run number "
                        "increment is disabled"


### PR DESCRIPTION
![juanangp](https://badgen.net/badge/PR%20submitted%20by%3A/juanangp/blue) ![Ok: 28](https://badgen.net/badge/PR%20Size/Ok%3A%2028/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=runNumberLock)](https://github.com/rest-for-physics/framework/commits/runNumberLock) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Added lock mechanism to check runNumber, it seems to be problematic while launching some processes in parallel.