### PR TITLE
Small fix in TRestMetadata and TRestCut

### DIFF
--- a/source/framework/core/inc/TRestCut.h
+++ b/source/framework/core/inc/TRestCut.h
@@ -56,6 +56,7 @@ class TRestCut : public TRestMetadata {
     TRestCut& operator=(TRestCut& cut);
 
     void PrintMetadata() override;
+    void Print();
 
     Int_t Write(const char* name, Int_t option, Int_t bufsize) override;
 

--- a/source/framework/core/src/TRestCut.cxx
+++ b/source/framework/core/src/TRestCut.cxx
@@ -162,10 +162,12 @@ void TRestCut::PrintMetadata() {
     TRestMetadata::PrintMetadata();
     RESTMetadata << " " << RESTendl;
     RESTMetadata << "Cuts added: " << RESTendl;
-    for (const auto& cut : fCuts) {
-        RESTMetadata << cut.GetName() << " " << cut.GetTitle() << RESTendl;
-    }
+    Print();
     RESTMetadata << "+++" << RESTendl;
+}
+
+void TRestCut::Print() {
+    for (const auto& cut : fCuts) RESTMetadata << cut.GetName() << " " << cut.GetTitle() << RESTendl;
 }
 
 Int_t TRestCut::Write(const char* name, Int_t option, Int_t bufsize) {

--- a/source/framework/core/src/TRestCut.cxx
+++ b/source/framework/core/src/TRestCut.cxx
@@ -66,7 +66,11 @@ ClassImp(TRestCut);
 
 TRestCut::TRestCut() { Initialize(); }
 
-void TRestCut::Initialize() { fCuts.clear(); }
+void TRestCut::Initialize() {
+    fCuts.clear();
+    fCutStrings.clear();
+    fParamCut.clear();
+}
 
 void TRestCut::InitFromConfigFile() {
     auto ele = GetElement("cut");

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -747,8 +747,8 @@ TRestMetadata* TRestMetadata::InstantiateChildMetadata(int index, std::string pa
                         md->SetConfigFile(fConfigFileName);
                         TiXmlElement* rootEle = GetElementFromFile(fConfigFileName);
                         TiXmlElement* Global = GetElement("globals", rootEle);
-                        md->LoadConfigFromElement(paraele, Global, {});
                         md->Initialize();
+                        md->LoadConfigFromElement(paraele, Global, {});
                         return md;
                     }
                 }

--- a/source/framework/core/src/TRestMetadata.cxx
+++ b/source/framework/core/src/TRestMetadata.cxx
@@ -798,8 +798,8 @@ TRestMetadata* TRestMetadata::InstantiateChildMetadata(std::string pattern, std:
                         TRestMetadata* md = (TRestMetadata*)c->New();
                         TiXmlElement* rootEle = GetElementFromFile(fConfigFileName);
                         TiXmlElement* Global = GetElement("globals", rootEle);
-                        md->LoadConfigFromElement(paraele, Global, {});
                         md->Initialize();
+                        md->LoadConfigFromElement(paraele, Global, {});
                         return md;
                     }
                 }


### PR DESCRIPTION
![AlvaroEzq](https://badgen.net/badge/PR%20submitted%20by%3A/AlvaroEzq/blue) ![Ok: 12](https://badgen.net/badge/PR%20Size/Ok%3A%2012/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=aezq_fixMetadataAndCut)](https://github.com/rest-for-physics/framework/commits/aezq_fixMetadataAndCut) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

PR to address issue #515