### PR TITLE
Fix TREX-DM test

### DIFF
--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -227,14 +227,9 @@ jobs:
     name: "TREX-DM"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
+      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
     needs: [ framework-install ]
     steps:
-      - name: Fix TLS certificates
-        run: |
-          apt-get update
-          apt-get install -y --reinstall ca-certificates openssl
-          update-ca-certificates --fresh
       - uses: actions/checkout@v4
         with:
           repository: rest-for-physics/framework

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -273,8 +273,8 @@ jobs:
         run: |
           source ${{ env.REST_PATH }}/thisREST.sh
           cd framework/pipeline/analysisPlot/
-          wget https://sultan.unizar.es/rest_pipeline/v2.3.8_10852.root
-          wget https://sultan.unizar.es/rest_pipeline/v2.4.0_10964.root
+          wget -nv https://sultan.unizar.es/rest_pipeline/v2.3.8_10852.root
+          wget -nv https://sultan.unizar.es/rest_pipeline/v2.4.0_10964.root
           restManager --batch --c classify.rml
           restRoot -b -q ValidateClassify.C
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -32,7 +32,7 @@ jobs:
     name: Build and run tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
       - uses: actions/checkout@v4
       - name: Build and install
@@ -51,7 +51,7 @@ jobs:
     name: Build and cache installation
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     steps:
       - uses: actions/checkout@v4
       - name: Build and install
@@ -83,7 +83,7 @@ jobs:
     name: "Previous Version File Compatibility"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
     name: "Macros with clean error output"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v4
@@ -134,7 +134,7 @@ jobs:
     name: "PyROOT"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install ]
     steps:
       - name: Restore cache
@@ -152,7 +152,7 @@ jobs:
     name: "Metadata"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v4
@@ -196,7 +196,7 @@ jobs:
     name: "PandaX-III"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v4
@@ -227,7 +227,7 @@ jobs:
     name: "TREX-DM"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v4
@@ -269,6 +269,11 @@ jobs:
           source ${{ env.REST_PATH }}/thisREST.sh
           cd framework/pipeline/analysisPlot/
           restManager --c summary.rml --f ../trex/Hits_01928.root
+      - name: Import sultan certificates
+        run: |
+          openssl s_client -connect sultan.unizar.es:443 -showcerts < /dev/null > cert.pem
+          cp cert.pem /usr/local/share/ca-certificates/custom-cert.crt
+          update-ca-certificates
       - name: AnalysisPlot2
         run: |
           source ${{ env.REST_PATH }}/thisREST.sh
@@ -283,7 +288,7 @@ jobs:
     name: Run examples
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
+      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -32,7 +32,7 @@ jobs:
     name: Build and run tests
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
+      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
     steps:
       - uses: actions/checkout@v4
       - name: Build and install
@@ -51,7 +51,7 @@ jobs:
     name: Build and cache installation
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
+      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
     steps:
       - uses: actions/checkout@v4
       - name: Build and install
@@ -83,7 +83,7 @@ jobs:
     name: "Previous Version File Compatibility"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
+      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v4
@@ -106,7 +106,7 @@ jobs:
     name: "Macros with clean error output"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
+      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v4
@@ -134,7 +134,7 @@ jobs:
     name: "PyROOT"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
+      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
     needs: [ framework-install ]
     steps:
       - name: Restore cache
@@ -152,7 +152,7 @@ jobs:
     name: "Metadata"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
+      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v4
@@ -196,7 +196,7 @@ jobs:
     name: "PandaX-III"
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
+      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v4
@@ -280,7 +280,7 @@ jobs:
     name: Run examples
     runs-on: ubuntu-latest
     container:
-      image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
+      image: ghcr.io/alvaroezq/root-geant4-garfield:rest-for-physics-sultancertificate
     needs: [ framework-install ]
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -230,6 +230,11 @@ jobs:
       image: ghcr.io/lobis/root-geant4-garfield:rest-for-physics
     needs: [ framework-install ]
     steps:
+      - name: Fix TLS certificates
+        run: |
+          apt-get update
+          apt-get install -y --reinstall ca-certificates openssl
+          update-ca-certificates --fresh
       - uses: actions/checkout@v4
         with:
           repository: rest-for-physics/framework

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -273,6 +273,8 @@ jobs:
         run: |
           source ${{ env.REST_PATH }}/thisREST.sh
           cd framework/pipeline/analysisPlot/
+          wget https://sultan.unizar.es/rest_pipeline/v2.3.8_10852.root
+          wget https://sultan.unizar.es/rest_pipeline/v2.4.0_10964.root
           restManager --batch --c classify.rml
           restRoot -b -q ValidateClassify.C
 

--- a/.github/workflows/validation.yml
+++ b/.github/workflows/validation.yml
@@ -273,8 +273,9 @@ jobs:
         run: |
           source ${{ env.REST_PATH }}/thisREST.sh
           cd framework/pipeline/analysisPlot/
+          echo "Downloading files from sultan"
           wget -nv https://sultan.unizar.es/rest_pipeline/v2.3.8_10852.root
-          wget -nv https://sultan.unizar.es/rest_pipeline/v2.4.0_10964.root
+          wget -nv https://sultan.unizar.es/rest_pipeline/v2.3.8_10964.root
           restManager --batch --c classify.rml
           restRoot -b -q ValidateClassify.C
 

--- a/pipeline/analysisPlot/classify.rml
+++ b/pipeline/analysisPlot/classify.rml
@@ -17,8 +17,8 @@
 
     <TRestAnalysisPlot name="CalToBackComp" title="Calibration and background comparison" previewPlot="false" verboseLevel="info">
 
-		<addFile name="https://sultan.unizar.es/rest_pipeline/v2.3.8_${RUN1}.root"/>
-		<addFile name="https://sultan.unizar.es/rest_pipeline/v2.3.8_${RUN2}.root"/>
+		<addFile name="v2.3.8_${RUN1}.root"/>
+		<addFile name="v2.3.8_${RUN2}.root"/>
 
 		<canvas size="(800,600)" divide="(1,1)" save="/tmp/canvas.root" />
 


### PR DESCRIPTION
![AlvaroEzq](https://img.shields.io/badge/PR_submitted_by%3A-AlvaroEzq-blue?logo=) ![Ok: 10](https://img.shields.io/badge/PR_Size-Ok%3A_10-green?logo=) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=aezq_fixCertificatesCI)](https://github.com/rest-for-physics/framework/commits/aezq_fixCertificatesCI) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

The new sultan certificate has to be imported manually into the docker image. So I created a clone of @lobis 's one and add to it the import of the current sultan CA certificate.

Even doing this, ROOT cannot download it (although wget yes) because ROOT uses Davix for remote HTTPS access, but Davix relies on the CA bundle that was compiled into the ROOT binary. In our environment, the Sultan institutional certificates are not included in that bundle, and there’s no runtime way to add them without rebuilding ROOT. As a result, attempts to open the file directly in ROOT fail with certificate verification errors. That's why I move the download of the files outside ROOT from the [classify.rml](pipeline/analysisPlot/classify.rml) file

EDIT: at the end the new image is not needed so I go back to lobis one. It is just needed to manually import the sultan certificates.