### PR TITLE
Improve TRestEventTimeSelectionProcess

### DIFF
--- a/source/framework/analysis/inc/TRestEventTimeSelectionProcess.h
+++ b/source/framework/analysis/inc/TRestEventTimeSelectionProcess.h
@@ -27,6 +27,8 @@
 
 #include <iostream>
 
+using Interval = std::pair<TTimeStamp, TTimeStamp>;
+
 class TRestEventTimeSelectionProcess : public TRestEventProcess {
    private:
     TRestEvent* fEvent;  //!
@@ -36,7 +38,7 @@ class TRestEventTimeSelectionProcess : public TRestEventProcess {
     Long_t fTimeOffsetInSeconds;
     Long_t fTimeStartMarginInSeconds;
     Long_t fTimeEndMarginInSeconds;
-    std::vector<std::pair<std::string, std::string>> fStartEndTimes;
+    std::vector<Interval> fStartEndTimes;
 
     /// Information about the events processed
 
@@ -69,7 +71,7 @@ class TRestEventTimeSelectionProcess : public TRestEventProcess {
     Bool_t GetIsActiveTime() const { return fIsActiveTime; }
     Char_t GetDelimiter() const { return fDelimiter; }
 
-    std::vector<std::pair<std::string, std::string>> GetStartEndTimes() const { return fStartEndTimes; }
+    std::vector<Interval> GetStartEndTimes() const { return fStartEndTimes; }
     std::string GetTimeStampCut(std::string timeStampObsName = "timeStamp", Bool_t useOffset = true,
                                 Bool_t useMargins = true, Int_t nTimes = -1);
     Int_t GetNEventsRejected() const { return fNEventsRejected; }
@@ -80,7 +82,7 @@ class TRestEventTimeSelectionProcess : public TRestEventProcess {
     Long_t GetTimeEndMarginInSeconds() const { return fTimeEndMarginInSeconds; }
 
     Double_t CalculateTotalTimeInSeconds();
-    static std::vector<std::pair<std::string, std::string>> ReadFileWithTimes(std::string fileWithTimes,
+    static std::vector<Interval> ReadFileWithTimes(std::string fileWithTimes,
                                                                               Char_t delimiter = ',');
 
     void SetAsActiveTime() { fIsActiveTime = true; }
@@ -88,7 +90,7 @@ class TRestEventTimeSelectionProcess : public TRestEventProcess {
     void SetFileWithTimes(const std::string& fileWithTimes) { fFileWithTimes = fileWithTimes; }
     void SetIsActiveTime(Bool_t isActiveTime) { fIsActiveTime = isActiveTime; }
     void SetDelimiter(Char_t delimiter) { fDelimiter = delimiter; }
-    void SetStartEndTimes(const std::vector<std::pair<std::string, std::string>>& startEndTimes) {
+    void SetStartEndTimes(const std::vector<Interval>& startEndTimes) {
         fStartEndTimes = startEndTimes;
     }
     void SetTimeOffsetInSeconds(Long_t timeOffsetInSeconds) { fTimeOffsetInSeconds = timeOffsetInSeconds; }

--- a/source/framework/analysis/inc/TRestEventTimeSelectionProcess.h
+++ b/source/framework/analysis/inc/TRestEventTimeSelectionProcess.h
@@ -39,6 +39,7 @@ class TRestEventTimeSelectionProcess : public TRestEventProcess {
     Long_t fTimeStartMarginInSeconds;
     Long_t fTimeEndMarginInSeconds;
     std::vector<Interval> fStartEndTimes;
+    Bool_t fUseRunStartAndEndTimes;
 
     /// Information about the events processed
 
@@ -84,6 +85,8 @@ class TRestEventTimeSelectionProcess : public TRestEventProcess {
     Double_t CalculateTotalTimeInSeconds();
     static std::vector<Interval> ReadFileWithTimes(std::string fileWithTimes,
                                                                               Char_t delimiter = ',');
+    void ApplyStartRunTime(const TTimeStamp& runStartTime);
+    void ApplyEndRunTime(const TTimeStamp& runEndTime);
 
     void SetAsActiveTime() { fIsActiveTime = true; }
     void SetAsDeadTime() { fIsActiveTime = false; }
@@ -101,6 +104,6 @@ class TRestEventTimeSelectionProcess : public TRestEventProcess {
         fTimeEndMarginInSeconds = timeEndMarginInSeconds;
     }
 
-    ClassDefOverride(TRestEventTimeSelectionProcess, 1);
+    ClassDefOverride(TRestEventTimeSelectionProcess, 2);
 };
 #endif

--- a/source/framework/analysis/inc/TRestEventTimeSelectionProcess.h
+++ b/source/framework/analysis/inc/TRestEventTimeSelectionProcess.h
@@ -83,8 +83,7 @@ class TRestEventTimeSelectionProcess : public TRestEventProcess {
     Long_t GetTimeEndMarginInSeconds() const { return fTimeEndMarginInSeconds; }
 
     Double_t CalculateTotalTimeInSeconds();
-    static std::vector<Interval> ReadFileWithTimes(std::string fileWithTimes,
-                                                                              Char_t delimiter = ',');
+    static std::vector<Interval> ReadFileWithTimes(std::string fileWithTimes, Char_t delimiter = ',');
     void ApplyStartRunTime(const TTimeStamp& runStartTime);
     void ApplyEndRunTime(const TTimeStamp& runEndTime);
 
@@ -93,9 +92,7 @@ class TRestEventTimeSelectionProcess : public TRestEventProcess {
     void SetFileWithTimes(const std::string& fileWithTimes) { fFileWithTimes = fileWithTimes; }
     void SetIsActiveTime(Bool_t isActiveTime) { fIsActiveTime = isActiveTime; }
     void SetDelimiter(Char_t delimiter) { fDelimiter = delimiter; }
-    void SetStartEndTimes(const std::vector<Interval>& startEndTimes) {
-        fStartEndTimes = startEndTimes;
-    }
+    void SetStartEndTimes(const std::vector<Interval>& startEndTimes) { fStartEndTimes = startEndTimes; }
     void SetTimeOffsetInSeconds(Long_t timeOffsetInSeconds) { fTimeOffsetInSeconds = timeOffsetInSeconds; }
     void SetTimeStartMarginInSeconds(Long_t timeStartMarginInSeconds) {
         fTimeStartMarginInSeconds = timeStartMarginInSeconds;

--- a/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
@@ -176,6 +176,10 @@ std::vector<Interval> TRestEventTimeSelectionProcess::ReadFileWithTimes(
         }
         file.close();
     }
+
+    // sort by start time and then by end time (lexicographically)
+    std::sort(startEndTimes.begin(), startEndTimes.end());
+
     return startEndTimes;
 }
 

--- a/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
@@ -131,6 +131,7 @@ void TRestEventTimeSelectionProcess::Initialize() {
     fTimeOffsetInSeconds = 0;
     fTimeStartMarginInSeconds = 0;
     fTimeEndMarginInSeconds = 0;
+    fUseRunStartAndEndTimes = false;
     fNEventsRejected = 0;
     fNEventsSelected = 0;
     fTotalTimeInSeconds = 0;
@@ -144,6 +145,17 @@ void TRestEventTimeSelectionProcess::InitProcess() {
     // Read the file with the time ranges
     if (!fFileWithTimes.empty()) {
         fStartEndTimes = ReadFileWithTimes(fFileWithTimes, fDelimiter);
+    }
+    if (fUseRunStartAndEndTimes) {
+        TRestRun* run = GetRunInfo();
+        if (run) {
+            auto startTimeStamp = run->GetStartTimestamp();
+            auto endTimeStamp = run->GetEndTimestamp();
+            ApplyStartRunTime(startTimeStamp);
+            ApplyEndRunTime(endTimeStamp);
+        } else {
+            RESTWarning << "No run information available to get TRestRun start and end times." << RESTendl;
+        }
     }
     fTotalTimeInSeconds = CalculateTotalTimeInSeconds();
     fNEventsRejected = 0;
@@ -263,6 +275,63 @@ void TRestEventTimeSelectionProcess::EndProcess() {
     // Write here the jobs to do when all the events are processed
 }
 
+void TRestEventTimeSelectionProcess::ApplyStartRunTime(const TTimeStamp& runStart) {
+    size_t startIndex = 0;
+    bool isInsideTimeRange = false;
+    for (auto se : fStartEndTimes) {
+        TTimeStamp s = se.first;
+        TTimeStamp e = se.second;
+
+        if (runStart < s) {
+            isInsideTimeRange = false;
+            break;
+        }
+
+        if (runStart >= s && runStart <= e) {
+            isInsideTimeRange = true;
+            break;
+        }
+
+        startIndex++;
+    }
+
+    // remove all intervals before the run start time
+    fStartEndTimes.erase(fStartEndTimes.begin(), fStartEndTimes.begin() + startIndex);
+    if (isInsideTimeRange) {
+        // modify the start time of the found interval
+        fStartEndTimes[startIndex].first = runStart;
+    }
+
+}
+
+void TRestEventTimeSelectionProcess::ApplyEndRunTime(const TTimeStamp& runEnd) {
+    size_t endIndex = 0;
+    bool isInsideTimeRange = false;
+    for (auto se : fStartEndTimes) {
+        TTimeStamp s = se.first;
+        TTimeStamp e = se.second;
+
+        if (runEnd < s) {
+            isInsideTimeRange = false;
+            break;
+        }
+
+        if (runEnd >= s && runEnd <= e) {
+            isInsideTimeRange = true;
+            break;
+        }
+
+        endIndex++;
+    }
+
+    // remove all intervals after the run end time
+    fStartEndTimes.erase(fStartEndTimes.begin() + endIndex + 1, fStartEndTimes.end());
+    if (isInsideTimeRange) {
+        // modify the end time of the found interval
+        fStartEndTimes[endIndex].second = runEnd;
+    }
+}
+
 ///////////////////////////////////////////////
 /// \brief Function to get the cut string that reproduce the time selection
 /// done by this process (useful for TRestDataSet::MakeCut() for example).
@@ -331,6 +400,7 @@ void TRestEventTimeSelectionProcess::PrintMetadata() {
 
     RESTMetadata << "File with times: " << fFileWithTimes << RESTendl;
     // print periods
+    RESTMetadata << "Use run start and end: " << (fUseRunStartAndEndTimes ? "true" : "false") << RESTendl;
     RESTMetadata << "Offset time: " << fTimeOffsetInSeconds << " seconds" << RESTendl;
     RESTMetadata << "Start margin time: " << fTimeStartMarginInSeconds << " seconds" << RESTendl;
     RESTMetadata << "End margin time: " << fTimeEndMarginInSeconds << " seconds" << RESTendl;

--- a/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
@@ -295,12 +295,12 @@ void TRestEventTimeSelectionProcess::ApplyStartRunTime(const TTimeStamp& runStar
         startIndex++;
     }
 
-    // remove all intervals before the run start time
-    fStartEndTimes.erase(fStartEndTimes.begin(), fStartEndTimes.begin() + startIndex);
     if (isInsideTimeRange) {
         // modify the start time of the found interval
         fStartEndTimes[startIndex].first = runStart;
     }
+    // remove all intervals before the run start time
+    fStartEndTimes.erase(fStartEndTimes.begin(), fStartEndTimes.begin() + startIndex);
 }
 
 void TRestEventTimeSelectionProcess::ApplyEndRunTime(const TTimeStamp& runEnd) {
@@ -323,12 +323,13 @@ void TRestEventTimeSelectionProcess::ApplyEndRunTime(const TTimeStamp& runEnd) {
         endIndex++;
     }
 
-    // remove all intervals after the run end time
-    fStartEndTimes.erase(fStartEndTimes.begin() + endIndex + 1, fStartEndTimes.end());
     if (isInsideTimeRange) {
         // modify the end time of the found interval
         fStartEndTimes[endIndex].second = runEnd;
+        endIndex++; // to erase from the next interval
     }
+    // remove all intervals after the run end time
+    fStartEndTimes.erase(fStartEndTimes.begin() + endIndex, fStartEndTimes.end());
 }
 
 ///////////////////////////////////////////////

--- a/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
@@ -61,8 +61,12 @@
 /// before checking if it is within the time ranges.
 /// * **startMarginTimeInSeconds**: margin time in seconds to be added to the start time of the time ranges
 /// (default is 0). This is useful to consider the events that are close to the start time of the time ranges.
+/// Meant to be a positive number, as the process will take care of adding or subtracting it if the time ranges
+/// represent active or dead periods of time respectively.
 /// * **endMarginTimeInSeconds**: margin time in seconds to be subtracted from the end time of the time ranges
 /// (default is 0). This is useful to consider the events that are close to the end time of the time ranges.
+/// Meant to be a positive number, as the process will take care of subtracting or adding it if the time ranges
+/// represent active or dead periods of time respectively.
 ///* **useRunStartAndEndTimes**: if `true` (default) the start and end times of the TRestRun
 /// will be used to restrict the time ranges to those involved (those that are between the run start and end
 /// times).

--- a/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
@@ -61,12 +61,12 @@
 /// before checking if it is within the time ranges.
 /// * **startMarginTimeInSeconds**: margin time in seconds to be added to the start time of the time ranges
 /// (default is 0). This is useful to consider the events that are close to the start time of the time ranges.
-/// Meant to be a positive number, as the process will take care of adding or subtracting it if the time ranges
-/// represent active or dead periods of time respectively.
+/// Meant to be a positive number, as the process will take care of adding or subtracting it if the time
+/// ranges represent active or dead periods of time respectively.
 /// * **endMarginTimeInSeconds**: margin time in seconds to be subtracted from the end time of the time ranges
 /// (default is 0). This is useful to consider the events that are close to the end time of the time ranges.
-/// Meant to be a positive number, as the process will take care of subtracting or adding it if the time ranges
-/// represent active or dead periods of time respectively.
+/// Meant to be a positive number, as the process will take care of subtracting or adding it if the time
+/// ranges represent active or dead periods of time respectively.
 ///* **useRunStartAndEndTimes**: if `true` (default) the start and end times of the TRestRun
 /// will be used to restrict the time ranges to those involved (those that are between the run start and end
 /// times).

--- a/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
@@ -326,7 +326,7 @@ void TRestEventTimeSelectionProcess::ApplyEndRunTime(const TTimeStamp& runEnd) {
     if (isInsideTimeRange) {
         // modify the end time of the found interval
         fStartEndTimes[endIndex].second = runEnd;
-        endIndex++; // to erase from the next interval
+        endIndex++;  // to erase from the next interval
     }
     // remove all intervals after the run end time
     fStartEndTimes.erase(fStartEndTimes.begin() + endIndex, fStartEndTimes.end());

--- a/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
@@ -150,9 +150,9 @@ void TRestEventTimeSelectionProcess::InitProcess() {
     fNEventsSelected = 0;
 }
 
-std::vector<std::pair<std::string, std::string>> TRestEventTimeSelectionProcess::ReadFileWithTimes(
+std::vector<Interval> TRestEventTimeSelectionProcess::ReadFileWithTimes(
     std::string fileWithTimes, Char_t delimiter) {
-    std::vector<std::pair<std::string, std::string>> startEndTimes;
+    std::vector<Interval> startEndTimes;
     string line;
     ifstream file(fileWithTimes);
     if (file.is_open()) {
@@ -169,8 +169,9 @@ std::vector<std::pair<std::string, std::string>> TRestEventTimeSelectionProcess:
                 if (StringToTimeStamp(startDate) < 0 || StringToTimeStamp(endDate) < 0) {
                     continue;
                 }
-
-                startEndTimes.emplace_back(startDate, endDate);
+                TTimeStamp sts = StringToTimeStamp(startDate);
+                TTimeStamp ets = StringToTimeStamp(endDate);
+                startEndTimes.emplace_back(sts, ets);
             }
         }
         file.close();
@@ -185,15 +186,15 @@ std::vector<std::pair<std::string, std::string>> TRestEventTimeSelectionProcess:
 ///
 Double_t TRestEventTimeSelectionProcess::CalculateTotalTimeInSeconds() {
     Double_t totalTime = 0;
-    for (auto id : fStartEndTimes) {
-        TTimeStamp startTime = TTimeStamp(StringToTimeStamp(id.first), 0);
-        TTimeStamp endTime = TTimeStamp(StringToTimeStamp(id.second), 0);
+    for (auto se : fStartEndTimes) {
+        TTimeStamp startTime = se.first;
+        TTimeStamp endTime = se.second;
         // Reduce the time by the margin in both sides
         startTime.Add(TTimeStamp(fTimeStartMarginInSeconds));
         endTime.Add(TTimeStamp(-fTimeEndMarginInSeconds));
         auto timeDiff = endTime.AsDouble() - startTime.AsDouble();
         if (timeDiff < 0) {
-            RESTDebug << "End time is before start time in time range: " << id.first << " to " << id.second
+            RESTDebug << "End time is before start time in time range: " << se.first << " to " << se.second
                       << RESTendl;
             continue;
         }
@@ -212,12 +213,13 @@ TRestEvent* TRestEventTimeSelectionProcess::ProcessEvent(TRestEvent* inputEvent)
     eventTime.Add(TTimeStamp(fTimeOffsetInSeconds));
 
     Bool_t isInsideAnyTimeRange = false;
-    for (auto id : fStartEndTimes) {
-        TTimeStamp startTime = TTimeStamp(StringToTimeStamp(id.first), 0);
-        TTimeStamp endTime = TTimeStamp(StringToTimeStamp(id.second), 0);
-        // Reduce the time by the margin in both sides
+    for (auto se : fStartEndTimes) {
+        TTimeStamp startTime = se.first;
+        TTimeStamp endTime = se.second;
+        // Reduce the active time window by the margin in both sides
         startTime.Add(TTimeStamp(fTimeStartMarginInSeconds));
         endTime.Add(TTimeStamp(-fTimeEndMarginInSeconds));
+
         if (eventTime >= startTime && eventTime <= endTime) {
             isInsideAnyTimeRange = true;
             break;
@@ -272,14 +274,14 @@ std::string TRestEventTimeSelectionProcess::GetTimeStampCut(std::string timeStam
     }
     if (nTimes < 0) nTimes = fStartEndTimes.size();
     Int_t c = 0;
-    for (auto id : fStartEndTimes) {
+    for (auto se : fStartEndTimes) {
         if (c++ >= nTimes) break;
-        auto startTime = StringToTimeStamp(id.first);
-        auto endTime = StringToTimeStamp(id.second);
+        auto startTime = se.first;
+        auto endTime = se.second;
         // Reduce the time by the margin in both sides
         if (useMargins) {
-            startTime += fTimeStartMarginInSeconds;
-            endTime -= fTimeEndMarginInSeconds;
+            startTime.Add(fTimeStartMarginInSeconds);
+            endTime.Add(fTimeEndMarginInSeconds);
         }
 
         if (startTime >= endTime) {
@@ -316,17 +318,17 @@ void TRestEventTimeSelectionProcess::PrintMetadata() {
     RESTMetadata << "Start margin time: " << fTimeStartMarginInSeconds << " seconds" << RESTendl;
     RESTMetadata << "End margin time: " << fTimeEndMarginInSeconds << " seconds" << RESTendl;
     RESTMetadata << typeOfTime << " time periods: " << RESTendl;
-    for (auto id : fStartEndTimes) {
-        RESTMetadata << id.first << " to " << id.second << RESTendl;
-        TTimeStamp startTime = TTimeStamp(StringToTimeStamp(id.first), 0);
-        TTimeStamp endTime = TTimeStamp(StringToTimeStamp(id.second), 0);
+    for (auto se : fStartEndTimes) {
+        std::string startStr = ToDateTimeString(se.first);
+        std::string endStr = ToDateTimeString(se.second);
+        RESTMetadata << startStr << " to " << endStr << RESTendl;
     }
 
     // Get total time in seconds
     TTimeStamp totalTime = TTimeStamp(fTotalTimeInSeconds, 0);
     if (!fStartEndTimes.empty()) {
-        TTimeStamp firstTime = TTimeStamp(StringToTimeStamp(fStartEndTimes.front().first), 0);
-        TTimeStamp lastTime = TTimeStamp(StringToTimeStamp(fStartEndTimes.back().second), 0);
+        TTimeStamp firstTime = fStartEndTimes.front().first;
+        TTimeStamp lastTime = fStartEndTimes.back().second;
         totalTime = lastTime - firstTime;
     }
 

--- a/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
@@ -64,7 +64,8 @@
 /// * **endMarginTimeInSeconds**: margin time in seconds to be subtracted from the end time of the time ranges
 /// (default is 0). This is useful to consider the events that are close to the end time of the time ranges.
 ///* **useRunStartAndEndTimes**: if `true` (default) the start and end times of the TRestRun
-/// will be used to restrict the time ranges to those involved (those that are between the run start and end times).
+/// will be used to restrict the time ranges to those involved (those that are between the run start and end
+/// times).
 ///
 /// ### Observables
 /// The process does not produce event observables but it keeps track of the number of events selected and

--- a/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
@@ -63,6 +63,8 @@
 /// (default is 0). This is useful to consider the events that are close to the start time of the time ranges.
 /// * **endMarginTimeInSeconds**: margin time in seconds to be subtracted from the end time of the time ranges
 /// (default is 0). This is useful to consider the events that are close to the end time of the time ranges.
+///* **useRunStartAndEndTimes**: if `true` (default) the start and end times of the TRestRun
+/// will be used to restrict the time ranges to those involved (those that are between the run start and end times).
 ///
 /// ### Observables
 /// The process does not produce event observables but it keeps track of the number of events selected and
@@ -131,7 +133,7 @@ void TRestEventTimeSelectionProcess::Initialize() {
     fTimeOffsetInSeconds = 0;
     fTimeStartMarginInSeconds = 0;
     fTimeEndMarginInSeconds = 0;
-    fUseRunStartAndEndTimes = false;
+    fUseRunStartAndEndTimes = true;
     fNEventsRejected = 0;
     fNEventsSelected = 0;
     fTotalTimeInSeconds = 0;

--- a/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
@@ -162,8 +162,8 @@ void TRestEventTimeSelectionProcess::InitProcess() {
     fNEventsSelected = 0;
 }
 
-std::vector<Interval> TRestEventTimeSelectionProcess::ReadFileWithTimes(
-    std::string fileWithTimes, Char_t delimiter) {
+std::vector<Interval> TRestEventTimeSelectionProcess::ReadFileWithTimes(std::string fileWithTimes,
+                                                                        Char_t delimiter) {
     std::vector<Interval> startEndTimes;
     string line;
     ifstream file(fileWithTimes);
@@ -301,7 +301,6 @@ void TRestEventTimeSelectionProcess::ApplyStartRunTime(const TTimeStamp& runStar
         // modify the start time of the found interval
         fStartEndTimes[startIndex].first = runStart;
     }
-
 }
 
 void TRestEventTimeSelectionProcess::ApplyEndRunTime(const TTimeStamp& runEnd) {

--- a/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
+++ b/source/framework/analysis/src/TRestEventTimeSelectionProcess.cxx
@@ -220,9 +220,15 @@ TRestEvent* TRestEventTimeSelectionProcess::ProcessEvent(TRestEvent* inputEvent)
     for (auto se : fStartEndTimes) {
         TTimeStamp startTime = se.first;
         TTimeStamp endTime = se.second;
-        // Reduce the active time window by the margin in both sides
-        startTime.Add(TTimeStamp(fTimeStartMarginInSeconds));
-        endTime.Add(TTimeStamp(-fTimeEndMarginInSeconds));
+        if (fIsActiveTime) {
+            // Reduce the active time window by the margin in both sides
+            startTime.Add(TTimeStamp(fTimeStartMarginInSeconds));
+            endTime.Add(TTimeStamp(-fTimeEndMarginInSeconds));
+        } else {
+            // Increase the dead time window by the margin in both sides
+            startTime.Add(TTimeStamp(-fTimeStartMarginInSeconds));
+            endTime.Add(TTimeStamp(fTimeEndMarginInSeconds));
+        }
 
         if (eventTime >= startTime && eventTime <= endTime) {
             isInsideAnyTimeRange = true;
@@ -284,8 +290,15 @@ std::string TRestEventTimeSelectionProcess::GetTimeStampCut(std::string timeStam
         auto endTime = se.second;
         // Reduce the time by the margin in both sides
         if (useMargins) {
-            startTime.Add(fTimeStartMarginInSeconds);
-            endTime.Add(fTimeEndMarginInSeconds);
+            if (fIsActiveTime) {
+                // Reduce the active time window by the margin in both sides
+                startTime.Add(fTimeStartMarginInSeconds);
+                endTime.Add(-fTimeEndMarginInSeconds);
+            } else {
+                // Increase the dead time window by the margin in both sides
+                startTime.Add(-fTimeStartMarginInSeconds);
+                endTime.Add(fTimeEndMarginInSeconds);
+            }
         }
 
         if (startTime >= endTime) {


### PR DESCRIPTION
![AlvaroEzq](https://img.shields.io/badge/PR_submitted_by%3A-AlvaroEzq-blue?logo=) ![Medium: 125](https://img.shields.io/badge/PR_Size-Medium%3A_125-orange?logo=) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=aezq_improveEvTimeSel)](https://github.com/rest-for-physics/framework/commits/aezq_improveEvTimeSel) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->

Changes:

- Save the times as TTimestamp instead of std::string.
- Add option to use the run start and end times to restrict the time intervals given to the process. This is very useful so we can input the same file of time intervals to several runs and the process handles itself the intervals which are outside the run.