### PR TITLE
Update TRestDataSetOdds.cxx

### DIFF
--- a/source/framework/analysis/inc/TRestDataSetOdds.h
+++ b/source/framework/analysis/inc/TRestDataSetOdds.h
@@ -66,6 +66,7 @@ class TRestDataSetOdds : public TRestMetadata {
     std::string GetOddsFile() { return fOddsFile; }
     std::string GetDataSetName() { return fDataSetName; }
     std::string GetOutputFileName() { return fOutputFileName; }
+    const std::map<std::string, TH1F*>& GetHistos() const { return fHistos; }
     TRestCut* GetCut() { return fCut; }
 
     inline void SetDataSetName(const std::string& dSName) { fDataSetName = dSName; }
@@ -74,6 +75,7 @@ class TRestDataSetOdds : public TRestMetadata {
     inline void SetCut(TRestCut* cut) { fCut = cut; }
     void SetOddsObservables(const std::vector<std::tuple<std::string, TVector2, int>>& obs);
     void AddOddsObservable(const std::string& name, const TVector2& range, int nbins);
+    void WriteHistograms(TFile* f) const;
 
     TRestDataSetOdds();
     TRestDataSetOdds(const char* configFilename, std::string name = "");

--- a/source/framework/analysis/src/TRestDataSetOdds.cxx
+++ b/source/framework/analysis/src/TRestDataSetOdds.cxx
@@ -213,7 +213,7 @@ void TRestDataSetOdds::ComputeLogOdds() {
         for (size_t i = 0; i < fObsName.size(); i++) {
             const std::string obsName = fObsName[i];
             const TVector2 range = fObsRange[i];
-            const std::string histName = "h" + obsName;
+            const std::string histName = "h" + std::string(GetName()) + obsName;
             const int nBins = fObsNbins[i];
             RESTDebug << "\tGenerating PDF for " << obsName << " with range: (" << range.X() << ", "
                       << range.Y() << ") and nBins: " << nBins << RESTendl;
@@ -233,7 +233,7 @@ void TRestDataSetOdds::ComputeLogOdds() {
         RESTInfo << "Opening " << fOddsFile << " as oddsFile." << RESTendl;
         for (size_t i = 0; i < fObsName.size(); i++) {
             const std::string obsName = fObsName[i];
-            const std::string histName = "h" + obsName;
+            const std::string histName = "h" + std::string(GetName()) + obsName;
             TH1F* h = (TH1F*)f->Get(histName.c_str());
             fHistos[obsName] = h;
         }

--- a/source/framework/analysis/src/TRestDataSetOdds.cxx
+++ b/source/framework/analysis/src/TRestDataSetOdds.cxx
@@ -28,7 +28,8 @@
 /// log(1. - odds) - log(odds) obtaining a number which is proportional to
 /// how likely is an event with respect the desired distribution; lower the number,
 /// more likely is the event to the input distribution. New observables are created in
-/// the output dataSet odds_obserbable and the addition of all of them in odds_total.
+/// the output dataSet odds_obserbable and the addition of all of them in odds_total, 
+/// where odds represents the TRestDataSetOdds name.
 /// If an input odds file is provided, the different PDFs are retrieved from the input
 /// file.
 ///
@@ -199,7 +200,7 @@ void TRestDataSetOdds::InitFromConfigFile() {
 /// observables. Otherwise, it takes the PDF from the
 /// input file. This function generate different observables
 /// odds_obsName and the addition of all of them for a further
-/// processing, which is stored in odds_total observable.
+/// processing, which is stored in odds_total observable, where odds is the TRestDataSetOdds name.
 ///
 void TRestDataSetOdds::ComputeLogOdds() {
     PrintMetadata();
@@ -304,6 +305,14 @@ void TRestDataSetOdds::SetOddsObservables(const std::vector<std::tuple<std::stri
     fObsRange.clear();
     fObsNbins.clear();
     for (const auto& [name, range, nbins] : obs) AddOddsObservable(name, range, nbins);
+}
+
+void TRestDataSetOdds::WriteHistograms(TFile* f) const {
+    if (!f) return;
+    f->cd();
+    for (const auto& [name, histo] : fHistos) {
+        if (histo) histo->Write();
+    }
 }
 
 /////////////////////////////////////////////

--- a/source/framework/analysis/src/TRestDataSetOdds.cxx
+++ b/source/framework/analysis/src/TRestDataSetOdds.cxx
@@ -213,7 +213,7 @@ void TRestDataSetOdds::ComputeLogOdds() {
         for (size_t i = 0; i < fObsName.size(); i++) {
             const std::string obsName = fObsName[i];
             const TVector2 range = fObsRange[i];
-            const std::string histName = "h" + std::string(GetName()) + obsName;
+            const std::string histName = "h" + std::string(GetName()) + "_" + obsName;
             const int nBins = fObsNbins[i];
             RESTDebug << "\tGenerating PDF for " << obsName << " with range: (" << range.X() << ", "
                       << range.Y() << ") and nBins: " << nBins << RESTendl;
@@ -233,7 +233,7 @@ void TRestDataSetOdds::ComputeLogOdds() {
         RESTInfo << "Opening " << fOddsFile << " as oddsFile." << RESTendl;
         for (size_t i = 0; i < fObsName.size(); i++) {
             const std::string obsName = fObsName[i];
-            const std::string histName = "h" + std::string(GetName()) + obsName;
+            const std::string histName = "h" + std::string(GetName()) + "_" + obsName;
             TH1F* h = (TH1F*)f->Get(histName.c_str());
             fHistos[obsName] = h;
         }

--- a/source/framework/analysis/src/TRestDataSetOdds.cxx
+++ b/source/framework/analysis/src/TRestDataSetOdds.cxx
@@ -28,7 +28,7 @@
 /// log(1. - odds) - log(odds) obtaining a number which is proportional to
 /// how likely is an event with respect the desired distribution; lower the number,
 /// more likely is the event to the input distribution. New observables are created in
-/// the output dataSet odds_obserbable and the addition of all of them in odds_total, 
+/// the output dataSet odds_obserbable and the addition of all of them in odds_total,
 /// where odds represents the TRestDataSetOdds name.
 /// If an input odds file is provided, the different PDFs are retrieved from the input
 /// file.

--- a/source/framework/analysis/src/TRestDataSetOdds.cxx
+++ b/source/framework/analysis/src/TRestDataSetOdds.cxx
@@ -243,7 +243,7 @@ void TRestDataSetOdds::ComputeLogOdds() {
     std::string totName = "";
     RESTDebug << "Computing log odds from " << fDataSetName << RESTendl;
     for (const auto& [obsName, histo] : fHistos) {
-        const std::string oddsName = "odds_" + obsName;
+        const std::string oddsName = std::string(GetName()) + "_" + obsName;
         auto GetLogOdds = [&histo = histo](double val) {
             double odds = histo->GetBinContent(histo->GetXaxis()->FindBin(val));
             if (odds == 0) return 1000.;
@@ -264,7 +264,7 @@ void TRestDataSetOdds::ComputeLogOdds() {
 
     RESTDebug << "Computing total log odds" << RESTendl;
     RESTDebug << "\tTotal log odds = " << totName << RESTendl;
-    df = df.Define("odds_total", totName);
+    df = df.Define(std::string(GetName()) + "_total", totName);
 
     dataSet.SetDataFrame(df);
 


### PR DESCRIPTION
![Anakintana](https://img.shields.io/badge/PR_submitted_by%3A-Anakintana-blue?logo=) ![Ok: 17](https://img.shields.io/badge/PR_Size-Ok%3A_17-green?logo=) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=Anakintana-patch-1)](https://github.com/rest-for-physics/framework/commits/Anakintana-patch-1) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

- Now the observables will be called after the name of the TRestDataSetOdds "logOddsName_"+obsName, instead of always be "odds_"+obsName
- New methods `const std::map<std::string, TH1F*>& GetHistos()` to get and  `TRestDataSetOdds::WriteHistograms(TFile* f)` to export fHistos 