### PR TITLE
Fix memory leak in TRestRun::CloseFile

### DIFF
--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -1184,7 +1184,8 @@ void TRestRun::CloseFile() {
             }
         }
     }
-
+    delete fInputEvent;
+    fInputEvent = nullptr;
     if (fOutputFile != nullptr) {
         fOutputFile->Write(0, TObject::kOverwrite);
         fOutputFile->Close();


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Ok: 2](https://badgen.net/badge/PR%20Size/Ok%3A%202/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=cris_fix_restrun_memory_leak)](https://github.com/rest-for-physics/framework/commits/cris_fix_restrun_memory_leak) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Delete fInputEvent when closing the file to prevent a memory leak. Each call to CloseFile() was leaking the input event object,causing growing memory use when opening or closing multiple files.

Fixes issue rest-for-physics/framework#519 