### PR TITLE
Prevent hanging when opening old REST files with schema mismatches

### DIFF
--- a/macros/REST_OpenInputFile.C
+++ b/macros/REST_OpenInputFile.C
@@ -1,3 +1,16 @@
+bool gSchemaError = false;
+
+void SchemaErrorHandler(int level, Bool_t abort, const char* location, const char* msg) {
+    if (level >= kError) {
+        std::string loc(location);
+        if (loc.find("TBufferFile") != std::string::npos ||
+            loc.find("TStreamerInfo") != std::string::npos) {
+            gSchemaError = true;
+        }
+    }
+    DefaultErrorHandler(level, abort, location, msg);
+}
+
 TRestRun* run = nullptr;
 TRestAnalysisTree* ana_tree = nullptr;
 TTree* ev_tree = nullptr;
@@ -6,7 +19,10 @@ TRestDataSet* dSet = nullptr;
 void REST_OpenInputFile(const std::string& fileName) {
     if (TRestTools::isRunFile(fileName)) {
         printf("\n%s\n\n", "REST processed file identified. It contains a valid TRestRun.");
+        gSchemaError = false;
+        auto oldHandler = SetErrorHandler(SchemaErrorHandler);
         run = new TRestRun(fileName);
+        SetErrorHandler(oldHandler);
         // print number of entries in the run
         printf("\nThe run has %lld entries.\n", run->GetEntries());
         printf("\nAttaching TRestRun %s as run...\n", fileName.c_str());
@@ -17,7 +33,12 @@ void REST_OpenInputFile(const std::string& fileName) {
         std::string eventType = run->GetInputEvent()->ClassName();
         std::string evcmd = Form("%s* ev = (%s*)run->GetInputEvent();", eventType.c_str(), eventType.c_str());
         gROOT->ProcessLine(evcmd.c_str());
-        run->GetEntry(0);
+        if (gSchemaError) {
+            printf("\nWARNING: Schema errors were detected. This file was produced with an older REST version.\n");
+            printf("Event browsing is disabled to prevent hanging. You can still use ana_tree and metadata.\n\n");
+        } else {
+            run->GetEntry(0);
+        }
         printf("Attaching input event %s as ev...\n", eventType.c_str());
         for (int n = 0; n < run->GetNumberOfMetadata(); n++) {
             if (n == 0) printf("Attaching Metadata classes:\n");

--- a/macros/REST_OpenInputFile.C
+++ b/macros/REST_OpenInputFile.C
@@ -3,8 +3,7 @@ bool gSchemaError = false;
 void SchemaErrorHandler(int level, Bool_t abort, const char* location, const char* msg) {
     if (level >= kError) {
         std::string loc(location);
-        if (loc.find("TBufferFile") != std::string::npos ||
-            loc.find("TStreamerInfo") != std::string::npos) {
+        if (loc.find("TBufferFile") != std::string::npos || loc.find("TStreamerInfo") != std::string::npos) {
             gSchemaError = true;
         }
     }
@@ -34,8 +33,12 @@ void REST_OpenInputFile(const std::string& fileName) {
         std::string evcmd = Form("%s* ev = (%s*)run->GetInputEvent();", eventType.c_str(), eventType.c_str());
         gROOT->ProcessLine(evcmd.c_str());
         if (gSchemaError) {
-            printf("\nWARNING: Schema errors were detected. This file was produced with an older REST version.\n");
-            printf("Event browsing is disabled to prevent hanging. You can still use ana_tree and metadata.\n\n");
+            printf(
+                "\nWARNING: Schema errors were detected. This file was produced with an older REST "
+                "version.\n");
+            printf(
+                "Event browsing is disabled to prevent hanging. You can still use ana_tree and "
+                "metadata.\n\n");
         } else {
             run->GetEntry(0);
         }


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Ok: 22](https://badgen.net/badge/PR%20Size/Ok%3A%2022/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=cris_fix_old_file_hang)](https://github.com/rest-for-physics/framework/commits/cris_fix_old_file_hang) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

This PR prevents `restRoot` from hanging when opening files produced with older REST versions.

  ## Context
When a REST file is produced, each class (e.g. `TRestDetectorSignalToHitsProcess`) is saved with a specific internal layout: which fields, in which order, how many bytes. If the class changes in a newer version, this layout no longer matches. ROOT tries to reconcile the old data with the new layout, but in some cases gets stuck, causing `restRoot` to hang at `GetEntry(0)`. This fix detects those errors and skips the event loading, printing a warning instead. The analysis tree (`ana_tree`) and metadata remain accessible. Files produced with compatible versions are (or at least should be) unaffected.

How it works
- ROOT provides a function called `SetErrorHandler()` that allows replacing the default error printing with a custom function.
- We use this to temporarily install our own handler (`SchemaErrorHandler`) that does two things. It prints the error as usual, and sets a flag if the error is related to schema mismatches.
- Before calling `GetEntry(0)` (the line that causes the hang), we check the flag. If schema errors were found, we skip `GetEntry(0)` and print a warning instead.
- The custom handler is only active while the file is being opened. After that, ROOT's default handler is restored

Tested with two files:
- v2.3.6 file (schema mismatch): no longer hangs, warning printed, `ana_tree` accessible
- v2.4.0 file (compatible): works normally with full event browsing

  Relates to #542

  @rest-for-physics/core_dev 