### PR TITLE
Disable unused event branches to prevent memory leak

### DIFF
--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -618,6 +618,9 @@ void TRestRun::ReadInputFileTrees() {
                         fInputEvent->InitializeWithMetadata(this);
                         fEventTree->SetBranchAddress(br->GetName(), &fInputEvent);
                         fEventBranchLoc = branches->GetLast();
+                        // Disable unused event branches to prevent memory leak
+                        fEventTree->SetBranchStatus("*", 0);
+                        fEventTree->SetBranchStatus((string(br->GetName()) + "*").c_str(), 1);
                         RESTDebug << "found event branch of event type: " << fInputEvent->ClassName()
                                   << RESTendl;
                     }

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -1277,8 +1277,14 @@ void TRestRun::SetInputEvent(TRestEvent* event) {
                     RESTDebug << "Setting input event.. Type: " << event->ClassName() << " Address: " << event
                               << RESTendl;
                     fInputEvent = event;
-                    fEventTree->SetBranchAddress(branchName.c_str(), &fInputEvent);
                     SetBranchStatusRecursive(branch, 1);
+                    // Reset sub-branch addresses so ROOT re-derives them from the fresh top-level bind.
+                    auto subs = branch->GetListOfBranches();
+                    for (int j = 0; j <= subs->GetLast(); j++) {
+                        ((TBranch*)subs->At(j))->ResetAddress();
+                    }
+                    branch->ResetAddress();
+                    fEventTree->SetBranchAddress(branchName.c_str(), &fInputEvent);
                     fEventBranchLoc = i;
                     break;
                 } else if (i == branches->GetLast()) {

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -48,7 +48,8 @@ using namespace std;
 std::mutex mutex_read;
 
 namespace {
-// TTree::SetBranchStatus by name does not reliably reach sub-branches; recurse via TBranch::SetStatus instead.
+// TTree::SetBranchStatus by name does not reliably reach sub-branches; recurse via TBranch::SetStatus
+// instead.
 void SetBranchStatusRecursive(TBranch* b, int status) {
     if (!b) return;
     b->SetStatus(status);

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -47,6 +47,18 @@ using namespace std;
 
 std::mutex mutex_read;
 
+namespace {
+// TTree::SetBranchStatus by name does not reliably reach sub-branches; recurse via TBranch::SetStatus instead.
+void SetBranchStatusRecursive(TBranch* b, int status) {
+    if (!b) return;
+    b->SetStatus(status);
+    auto subs = b->GetListOfBranches();
+    for (int i = 0; i <= subs->GetLast(); i++) {
+        SetBranchStatusRecursive((TBranch*)subs->At(i), status);
+    }
+}
+}  // namespace
+
 ClassImp(TRestRun);
 
 TRestRun::TRestRun() { Initialize(); }
@@ -618,9 +630,12 @@ void TRestRun::ReadInputFileTrees() {
                         fInputEvent->InitializeWithMetadata(this);
                         fEventTree->SetBranchAddress(br->GetName(), &fInputEvent);
                         fEventBranchLoc = branches->GetLast();
-                        // Disable unused event branches to prevent memory leak
-                        fEventTree->SetBranchStatus("*", 0);
-                        fEventTree->SetBranchStatus((string(br->GetName()) + "*").c_str(), 1);
+                        // Disable the other event branches to prevent a memory leak when they are unused.
+                        for (int i = 0; i <= branches->GetLast(); i++) {
+                            auto otherBr = (TBranch*)branches->At(i);
+                            if (otherBr == br || Count(otherBr->GetName(), "EventBranch") == 0) continue;
+                            SetBranchStatusRecursive(otherBr, 0);
+                        }
                         RESTDebug << "found event branch of event type: " << fInputEvent->ClassName()
                                   << RESTendl;
                     }
@@ -1249,8 +1264,9 @@ void TRestRun::SetInputEvent(TRestEvent* event) {
     if (event != nullptr) {
         if (fEventTree != nullptr) {
             if (fInputEvent != nullptr) {
-                fEventTree->SetBranchAddress((TString)fInputEvent->ClassName() + "Branch", nullptr);
-                fEventTree->SetBranchStatus((TString)fInputEvent->ClassName() + "Branch", false);
+                string oldName = string(fInputEvent->ClassName()) + "Branch";
+                fEventTree->SetBranchAddress(oldName.c_str(), nullptr);
+                SetBranchStatusRecursive(fEventTree->GetBranch(oldName.c_str()), 0);
             }
             TObjArray* branches = fEventTree->GetListOfBranches();
             string branchName = (string)event->ClassName() + "Branch";
@@ -1261,7 +1277,7 @@ void TRestRun::SetInputEvent(TRestEvent* event) {
                               << RESTendl;
                     fInputEvent = event;
                     fEventTree->SetBranchAddress(branchName.c_str(), &fInputEvent);
-                    fEventTree->SetBranchStatus(branchName.c_str(), false);
+                    SetBranchStatusRecursive(branch, 1);
                     fEventBranchLoc = i;
                     break;
                 } else if (i == branches->GetLast()) {


### PR DESCRIPTION
![cmargalejo](https://badgen.net/badge/PR%20submitted%20by%3A/cmargalejo/blue) ![Ok: 3](https://badgen.net/badge/PR%20Size/Ok%3A%203/green) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=cris_fix_event_branch_memory_leak)](https://github.com/rest-for-physics/framework/commits/cris_fix_event_branch_memory_leak) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

Investigation started from rest-for-physics/detectorlib#124, where @AlvaroEzq reported the leak from #542 was still present after the destructor fix.

When a REST file stores multiple event types (e.g. Raw → Signal → Hits → Track), only the last one is actually used. But all event branches in the tree were left enabled. Each time `GetEntry()` reads the tree, ROOT creates internal objects for the unused branches that never get freed. This causes memory to grow. The fix consists on, after opening the file, disabling all event branches except the one being used.

Fixes #542 (hopefully...) 