### PR TITLE
Pr566 slim

### DIFF
--- a/doc/developer/Legacy detector signal recovery design.md
+++ b/doc/developer/Legacy detector signal recovery design.md
@@ -1,0 +1,57 @@
+# Legacy detector signal recovery design
+
+The recovery command is intentionally a worked solution for one known bad schema transition. It is
+not infrastructure for arbitrary migrations. Its two stages are separated by a process boundary
+because ROOT cannot safely load replica legacy classes and the current REST classes with the same
+C++ names in one process.
+
+## Architecture
+
+1. `recoverLegacySignalData.C` runs under plain ROOT with small replicas of
+   `TRestEvent`, `TRestDetectorSignal` v3, and `TRestDetectorSignalEvent`. It accepts only the
+   exact event branch and signal class versions 1 through 3 and writes a private, flattened
+   intermediate containing floats plus source UUID, file size, and counts.
+2. `restRoot` then loads the modern REST libraries, verifies that the intermediate identifies the
+   same source, and makes a byte-for-byte candidate copy beside the requested output.
+3. The candidate is opened through `TRestRootFileHandle::Open(Update)`, so the safe writable-I/O
+   rules in [Safe writable ROOT IO](Safe%20writable%20ROOT%20IO.md) apply. The incompatible
+   top-level signal branch is disabled and `TTree::CloneTree(-1, "fast")` copies all other active
+   branches as baskets. Only the modern signal branch is filled from the intermediate.
+4. Validation compares the unaffected recursive branch inventory, unrelated key inventory, source
+   identity and counts, and every reconstructed signal value. The candidate is atomically linked to
+   a previously absent output name only after these checks pass.
+
+The input and intermediate are local files. The private work directory is created on the output
+filesystem so publication does not cross filesystems. There is no in-place mode, partial mode,
+rollback protocol, arbitrary object copier, or user-visible intermediate format.
+
+## ROOT 6.26 fast-clone boundary
+
+Experiments with ROOT 6.26/10 established the useful boundary:
+
+| Process state | Operation on the canonical file | Result |
+| --- | --- | --- |
+| Plain ROOT; REST event dictionaries absent | Disable the signal branch, then `CloneTree(-1, "fast")` | `TBranchElement::InitInfo` errors for other event classes followed by exit signal 11 |
+| Modern REST libraries loaded | Same operation | 261 entries cloned; signal branch absent |
+| Modern REST libraries loaded; fixture includes an unavailable unsplit event class | Same operation | succeeds and preserves that branch's compressed basket payloads exactly |
+
+Thus plain ROOT is used only to deserialize the affected legacy branch. Fast cloning happens after
+REST libraries are loaded. ROOT can raw-copy an unavailable branch in this setup, but it cannot
+construct the complete canonical `TTree` in a process where nearly every event dictionary is
+missing.
+
+Other approaches were rejected:
+
+- `TTree::CopyTree` runs an entry loop and therefore deserializes branches rather than preserving
+  them opaquely.
+- Reading keys with `TKey::ReadObj` deserializes arbitrary metadata.
+- Manually rewriting `TKey`, `TBasket`, and `TTree` offsets would duplicate ROOT internals and be
+  substantially larger and more fragile than the supported fast-clone path.
+- Physically editing `TTree` branch and leaf arrays can work only if all related arrays remain
+  internally consistent; it is unnecessary when top-level branch status is used.
+
+For a future one-off migration, retain the same safety shape: exact schema recognition, isolated
+legacy extraction, supported raw cloning for unaffected data, construction only of the intended new
+branch, source/output separation, and focused value and structure validation. Do not generalize this
+command by adding recovery modes; add a separately reviewed migration for a separately understood
+transition.

--- a/doc/developer/Legacy detector signal recovery design.md
+++ b/doc/developer/Legacy detector signal recovery design.md
@@ -45,6 +45,11 @@ Other approaches were rejected:
 - `TTree::CopyTree` runs an entry loop and therefore deserializes branches rather than preserving
   them opaquely.
 - Reading keys with `TKey::ReadObj` deserializes arbitrary metadata.
+- In particular, a class removed from modern REST can still have a non-null emulated `TClass`
+  because its `StreamerInfo` remains in the file. That does not make it readable: on the canonical
+  file, `TKey::ReadObj` for `zS2Raw` (`TRestRawZeroSupressionToRawProcess`) exits with signal 11
+  while ROOT tries to instantiate an abstract compiled base. The recovery never reads unrelated
+  keys; the initial byte copy retains their keys and payloads exactly.
 - Manually rewriting `TKey`, `TBasket`, and `TTree` offsets would duplicate ROOT internals and be
   substantially larger and more fragile than the supported fast-clone path.
 - Physically editing `TTree` branch and leaf arrays can work only if all related arrays remain

--- a/doc/developer/Legacy detector signal recovery design.md
+++ b/doc/developer/Legacy detector signal recovery design.md
@@ -25,6 +25,12 @@ The input and intermediate are local files. The private work directory is create
 filesystem so publication does not cross filesystems. There is no in-place mode, partial mode,
 rollback protocol, arbitrary object copier, or user-visible intermediate format.
 
+Before its ordinary metadata or event setup, `TRestRun` inspects the split detector-signal branch.
+When a loaded v4 signal class meets an on-disk v1-v3 branch without the matching signal
+`StreamerInfo`, the complete open is rejected with the recovery command. Files with that
+`StreamerInfo` remain readable through ROOT's schema evolution. This fail-fast boundary avoids
+maintaining partially readable branch state inside `TRestRun`.
+
 ## ROOT 6.26 fast-clone boundary
 
 Experiments with ROOT 6.26/10 established the useful boundary:

--- a/doc/tutorials/List of REST Programs.md
+++ b/doc/tutorials/List of REST Programs.md
@@ -8,6 +8,10 @@ This is just an indexing list of existing programs included with REST compilatio
 
 **restManager** : The manager program of REST allowing to execute the REST event processes defined in TRestManager. Additional definitions allow to include additional metadata structures inside REST.
 
+**restRoot** : The ROOT interpreter with REST libraries loaded. It also provides the
+`--recover-legacy-signals` command for the known detector-signal v1-v3 recovery described in
+[Recovering legacy detector signal files](Recovering%20legacy%20detector%20signal%20files.md).
+
 **restPlots** : It uses the plot definitions given by RML configuration in a TRestAnalysisPlot section. It creates the plots from the variables at the TRestAnalysisTree and creates a PDF report and a ROOT file including the histograms created.
 
 ## Histogram and integration executables

--- a/doc/tutorials/Recovering legacy detector signal files.md
+++ b/doc/tutorials/Recovering legacy detector signal files.md
@@ -9,6 +9,11 @@ class. They can be converted once with:
 restRoot --recover-legacy-signals legacy.root
 ```
 
+`TRestRun` refuses to open an affected file before reading its metadata or events and prints this
+command. It does not offer partial access because accidentally reading the incompatible signal
+branch can cause excessive allocation or a crash. Legacy files that contain the required signal
+`StreamerInfo` continue through ROOT's normal schema evolution without requiring recovery.
+
 The default output is a new sibling named `legacy_Fixed.root`. Select another new local path with:
 
 ```console

--- a/doc/tutorials/Recovering legacy detector signal files.md
+++ b/doc/tutorials/Recovering legacy detector signal files.md
@@ -1,0 +1,31 @@
+# Recovering legacy detector signal files
+
+REST files written with `TRestDetectorSignal` schema versions 1 through 3 store signal times and
+charges as `Float_t`. Modern detectorlib uses `Double_t` (schema version 4). Files from the legacy
+period that do not contain usable ROOT `StreamerInfo` cannot be opened safely with the modern
+class. They can be converted once with:
+
+```console
+restRoot --recover-legacy-signals legacy.root
+```
+
+The default output is a new sibling named `legacy_Fixed.root`. Select another new local path with:
+
+```console
+restRoot --recover-legacy-signals legacy.root --output recovered.root
+```
+
+The command never modifies the input and never replaces an existing output. It first extracts only
+the affected branch in an isolated plain-ROOT process. It then starts from a byte-for-byte copy of
+the input, fast-clones every unaffected `EventTree` branch as ROOT baskets, and rebuilds only
+`TRestDetectorSignalEventBranch` with the modern class. Unrelated top-level objects are left in
+place without being deserialized. The output is published only after its structure and all recovered
+signal values have been checked.
+
+This is deliberately a recovery for the known `vector<Float_t>` to `vector<Double_t>` transition,
+not a generic schema migration tool. Inputs with another signal schema, malformed signal contents,
+ROOT URLs, in-place output, and existing output files are rejected. A failed command leaves the
+original untouched and produces no output file.
+
+The recovered file contains a `REST_LegacySignalRecovery` provenance key with the source UUID,
+legacy signal schema version, and recovered entry, signal, and point counts.

--- a/macros/legacy/LegacySignalRecoveryFormat.h
+++ b/macros/legacy/LegacySignalRecoveryFormat.h
@@ -1,0 +1,61 @@
+#ifndef REST_LEGACY_SIGNAL_RECOVERY_FORMAT_H
+#define REST_LEGACY_SIGNAL_RECOVERY_FORMAT_H
+
+#include <TBranch.h>
+#include <TBranchElement.h>
+#include <TDirectory.h>
+#include <TNamed.h>
+#include <TParameter.h>
+
+#include <string>
+
+namespace REST_LegacySignalRecovery {
+
+inline constexpr const char* kEventTree = "EventTree";
+inline constexpr const char* kSignalBranch = "TRestDetectorSignalEventBranch";
+inline constexpr const char* kDataTree = "LegacySignalData";
+
+inline int DetectSignalVersion(TBranch* branch) {
+    int time = -1;
+    int charge = -1;
+    const auto visit = [&](auto&& self, TBranch* current) -> void {
+        if (auto* element = dynamic_cast<TBranchElement*>(current)) {
+            const std::string name = current->GetName();
+            if (name == "fSignal.fSignalTime") time = element->GetClassVersion();
+            if (name == "fSignal.fSignalCharge") charge = element->GetClassVersion();
+        }
+        auto* children = current->GetListOfBranches();
+        for (int index = 0; index <= children->GetLast(); ++index)
+            self(self, static_cast<TBranch*>(children->At(index)));
+    };
+    if (branch != nullptr) visit(visit, branch);
+    return time == charge ? time : -2;
+}
+
+inline bool WriteText(TDirectory& directory, const char* key, const std::string& value) {
+    directory.cd();
+    return TNamed(key, value.c_str()).Write(key, TObject::kOverwrite) > 0;
+}
+
+inline bool WriteNumber(TDirectory& directory, const char* key, Long64_t value) {
+    directory.cd();
+    return TParameter<Long64_t>(key, value).Write(key, TObject::kOverwrite) > 0;
+}
+
+inline bool ReadText(TDirectory& directory, const char* key, std::string& value) {
+    auto* object = dynamic_cast<TNamed*>(directory.Get(key));
+    if (object == nullptr) return false;
+    value = object->GetTitle();
+    return true;
+}
+
+inline bool ReadNumber(TDirectory& directory, const char* key, Long64_t& value) {
+    auto* object = dynamic_cast<TParameter<Long64_t>*>(directory.Get(key));
+    if (object == nullptr) return false;
+    value = object->GetVal();
+    return true;
+}
+
+}  // namespace REST_LegacySignalRecovery
+
+#endif

--- a/macros/legacy/recoverLegacySignalData.C
+++ b/macros/legacy/recoverLegacySignalData.C
@@ -1,0 +1,173 @@
+// Extract the one unsafe legacy schema in an isolated plain-ROOT process.
+// The user-facing restRoot command launches this macro; do not run it in a
+// REST session because these replica class names intentionally match REST.
+
+#include <TFile.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <TTimeStamp.h>
+#include <TTree.h>
+
+#include <iostream>
+#include <limits>
+#include <string>
+#include <vector>
+
+#include "LegacySignalRecoveryFormat.h"
+
+class TRestEvent : public TObject {
+   public:
+    Int_t fRunOrigin = 0;
+    Int_t fSubRunOrigin = 0;
+    Int_t fEventID = 0;
+    Int_t fSubEventID = 0;
+    TString fSubEventTag;
+    TTimeStamp fEventTime;
+    Bool_t fOk = true;
+    ClassDef(TRestEvent, 1)
+};
+
+class TRestDetectorSignal {
+   public:
+    Int_t fSignalID = -1;
+    std::vector<Float_t> fSignalTime;
+    std::vector<Float_t> fSignalCharge;
+    std::string fName;
+    std::string fType;
+    ClassDef(TRestDetectorSignal, 3)
+};
+
+class TRestDetectorSignalEvent : public TRestEvent {
+   public:
+    std::vector<TRestDetectorSignal> fSignal;
+    ClassDef(TRestDetectorSignalEvent, 1)
+};
+
+namespace {
+
+bool Extract(const char* inputName, const char* outputName) {
+    using namespace REST_LegacySignalRecovery;
+    const TString libraries = gSystem->GetLibraries();
+    if (libraries.Contains("libRestFramework") || libraries.Contains("libRestDetector")) {
+        std::cerr << "ERROR: legacy extraction must run without REST libraries loaded.\n";
+        return false;
+    }
+
+    TFile input(inputName, "READ");
+    auto* tree = dynamic_cast<TTree*>(input.Get(kEventTree));
+    auto* branch = tree == nullptr ? nullptr : tree->GetBranch(kSignalBranch);
+    const int version = DetectSignalVersion(branch);
+    if (input.IsZombie() || tree == nullptr || branch == nullptr ||
+        std::string(branch->GetClassName()) != "TRestDetectorSignalEvent" || version < 1 || version > 3) {
+        std::cerr << "ERROR: input is not a supported TRestDetectorSignal v1-v3 file"
+                  << " (detected version " << version << ").\n";
+        return false;
+    }
+
+    auto* event = new TRestDetectorSignalEvent;
+    if (tree->SetBranchAddress(kSignalBranch, &event) < TTree::kMatch) {
+        std::cerr << "ERROR: cannot bind the legacy signal branch.\n";
+        return false;
+    }
+
+    TFile output(outputName, "CREATE");
+    if (output.IsZombie()) {
+        std::cerr << "ERROR: cannot create the private recovery intermediate.\n";
+        return false;
+    }
+    TTree data(kDataTree, "Legacy detector signal data");
+    Int_t runOrigin, subRunOrigin, eventID, subEventID, timeNanoSec;
+    Long64_t timeSec;
+    Bool_t ok;
+    TString subEventTag;
+    std::vector<Int_t> signalIDs, pointCounts;
+    std::vector<Float_t> times, charges;
+    std::vector<std::string> names, types;
+    data.Branch("runOrigin", &runOrigin);
+    data.Branch("subRunOrigin", &subRunOrigin);
+    data.Branch("eventID", &eventID);
+    data.Branch("subEventID", &subEventID);
+    data.Branch("timeSec", &timeSec);
+    data.Branch("timeNanoSec", &timeNanoSec);
+    data.Branch("ok", &ok);
+    data.Branch("subEventTag", &subEventTag);
+    data.Branch("signalIDs", &signalIDs);
+    data.Branch("pointCounts", &pointCounts);
+    data.Branch("times", &times);
+    data.Branch("charges", &charges);
+    data.Branch("names", &names);
+    data.Branch("types", &types);
+
+    Long64_t signalCount = 0;
+    Long64_t pointCount = 0;
+    for (Long64_t entry = 0; entry < tree->GetEntries(); ++entry) {
+        if (branch->GetEntry(entry) <= 0) {
+            std::cerr << "ERROR: cannot read legacy signal entry " << entry << ".\n";
+            return false;
+        }
+        runOrigin = event->fRunOrigin;
+        subRunOrigin = event->fSubRunOrigin;
+        eventID = event->fEventID;
+        subEventID = event->fSubEventID;
+        timeSec = event->fEventTime.GetSec();
+        timeNanoSec = event->fEventTime.GetNanoSec();
+        ok = event->fOk;
+        subEventTag = event->fSubEventTag;
+        signalIDs.clear();
+        pointCounts.clear();
+        times.clear();
+        charges.clear();
+        names.clear();
+        types.clear();
+        for (const auto& signal : event->fSignal) {
+            if (signal.fSignalTime.size() != signal.fSignalCharge.size() ||
+                signal.fSignalTime.size() > static_cast<std::size_t>(std::numeric_limits<Int_t>::max())) {
+                std::cerr << "ERROR: invalid legacy signal at entry " << entry << ".\n";
+                return false;
+            }
+            signalIDs.push_back(signal.fSignalID);
+            pointCounts.push_back(static_cast<Int_t>(signal.fSignalTime.size()));
+            names.push_back(signal.fName);
+            types.push_back(signal.fType);
+            for (std::size_t point = 0; point < signal.fSignalTime.size(); ++point) {
+                times.push_back(signal.fSignalTime[point]);
+                charges.push_back(signal.fSignalCharge[point]);
+            }
+        }
+        signalCount += signalIDs.size();
+        pointCount += times.size();
+        if (data.Fill() < 0) return false;
+    }
+
+    const Long64_t entries = tree->GetEntries();
+    const Long64_t sourceSize = input.GetSize();
+    const std::string sourceUuid = input.GetUUID().AsString();
+    output.cd();
+    const bool written = data.Write() > 0 && WriteText(output, "sourceUuid", sourceUuid) &&
+                         WriteNumber(output, "sourceSize", sourceSize) &&
+                         WriteNumber(output, "sourceEntries", entries) &&
+                         WriteNumber(output, "sourceSignalVersion", version) &&
+                         WriteNumber(output, "recoveredSignals", signalCount) &&
+                         WriteNumber(output, "recoveredPoints", pointCount);
+    output.Close();
+    if (!written || output.TestBit(TFile::kWriteError)) {
+        std::cerr << "ERROR: failed to write the recovery intermediate.\n";
+        return false;
+    }
+    std::cout << "Extracted " << entries << " events, " << signalCount << " signals and " << pointCount
+              << " points.\n";
+    return true;
+}
+
+}  // namespace
+
+void recoverLegacySignalData() {
+    const char* input = gSystem->Getenv("REST_LEGACY_RECOVERY_INPUT");
+    const char* output = gSystem->Getenv("REST_LEGACY_RECOVERY_INTERMEDIATE");
+    if (input == nullptr || output == nullptr) {
+        std::cerr << "ERROR: incomplete private recovery environment.\n";
+        gSystem->Exit(64);
+    } else {
+        gSystem->Exit(Extract(input, output) ? 0 : 1);
+    }
+}

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -102,6 +102,15 @@ foreach (dir ${dirs})
     endforeach ()
 endforeach ()
 
+# The legacy signal migration is intentionally available only when the modern
+# detector event dictionary is part of this build.
+if (TARGET RestDetector)
+    target_sources(restRoot PRIVATE bin/LegacySignalRecovery.cxx)
+    target_include_directories(restRoot PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libraries/detector/inc)
+    target_link_libraries(restRoot RestDetector)
+    target_compile_definitions(restRoot PRIVATE REST_LEGACY_SIGNAL_RECOVERY)
+endif ()
+
 # remove duplicates
 if (DEFINED rest_include_dirs)
     list(REMOVE_DUPLICATES rest_include_dirs)

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -106,7 +106,8 @@ endforeach ()
 # detector event dictionary is part of this build.
 if (TARGET RestDetector)
     target_sources(restRoot PRIVATE bin/LegacySignalRecovery.cxx)
-    target_include_directories(restRoot PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libraries/detector/inc)
+    target_include_directories(
+        restRoot PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/libraries/detector/inc)
     target_link_libraries(restRoot RestDetector)
     target_compile_definitions(restRoot PRIVATE REST_LEGACY_SIGNAL_RECOVERY)
 endif ()

--- a/source/bin/LegacySignalRecovery.cxx
+++ b/source/bin/LegacySignalRecovery.cxx
@@ -1,0 +1,384 @@
+#include "LegacySignalRecovery.h"
+
+#include <TBranch.h>
+#include <TFile.h>
+#include <TKey.h>
+#include <TRestDetectorSignalEvent.h>
+#include <TRestTools.h>
+#include <TString.h>
+#include <TSystem.h>
+#include <TTree.h>
+
+#include <cerrno>
+#include <cmath>
+#include <filesystem>
+#include <iostream>
+#include <set>
+#include <string>
+#include <system_error>
+#include <vector>
+
+#ifndef _WIN32
+#include <sys/wait.h>
+#include <unistd.h>
+#endif
+
+#include "../../macros/legacy/LegacySignalRecoveryFormat.h"
+
+namespace {
+namespace fs = std::filesystem;
+using namespace REST_LegacySignalRecovery;
+
+struct IntermediateEvent {
+    Int_t runOrigin = 0, subRunOrigin = 0, eventID = 0, subEventID = 0, timeNanoSec = 0;
+    Long64_t timeSec = 0;
+    Bool_t ok = false;
+    TString* subEventTag = nullptr;
+    std::vector<Int_t>* signalIDs = nullptr;
+    std::vector<Int_t>* pointCounts = nullptr;
+    std::vector<Float_t>* times = nullptr;
+    std::vector<Float_t>* charges = nullptr;
+    std::vector<std::string>* names = nullptr;
+    std::vector<std::string>* types = nullptr;
+
+    bool Bind(TTree& tree) {
+        return tree.SetBranchAddress("runOrigin", &runOrigin) >= TTree::kMatch &&
+               tree.SetBranchAddress("subRunOrigin", &subRunOrigin) >= TTree::kMatch &&
+               tree.SetBranchAddress("eventID", &eventID) >= TTree::kMatch &&
+               tree.SetBranchAddress("subEventID", &subEventID) >= TTree::kMatch &&
+               tree.SetBranchAddress("timeSec", &timeSec) >= TTree::kMatch &&
+               tree.SetBranchAddress("timeNanoSec", &timeNanoSec) >= TTree::kMatch &&
+               tree.SetBranchAddress("ok", &ok) >= TTree::kMatch &&
+               tree.SetBranchAddress("subEventTag", &subEventTag) >= TTree::kMatch &&
+               tree.SetBranchAddress("signalIDs", &signalIDs) >= TTree::kMatch &&
+               tree.SetBranchAddress("pointCounts", &pointCounts) >= TTree::kMatch &&
+               tree.SetBranchAddress("times", &times) >= TTree::kMatch &&
+               tree.SetBranchAddress("charges", &charges) >= TTree::kMatch &&
+               tree.SetBranchAddress("names", &names) >= TTree::kMatch &&
+               tree.SetBranchAddress("types", &types) >= TTree::kMatch;
+    }
+
+    bool Validate(Long64_t entry) const {
+        if (subEventTag == nullptr || signalIDs == nullptr || pointCounts == nullptr || times == nullptr ||
+            charges == nullptr || names == nullptr || types == nullptr ||
+            signalIDs->size() != pointCounts->size() || signalIDs->size() != names->size() ||
+            signalIDs->size() != types->size() || times->size() != charges->size()) {
+            std::cerr << "ERROR: malformed recovery intermediate at entry " << entry << ".\n";
+            return false;
+        }
+        std::size_t points = 0;
+        for (const Int_t count : *pointCounts) {
+            if (count < 0 || static_cast<std::size_t>(count) > times->size() - points) return false;
+            points += count;
+        }
+        return points == times->size();
+    }
+};
+
+std::set<std::string> BranchInventory(TTree& tree) {
+    std::set<std::string> result;
+    const auto visit = [&](auto&& self, TBranch* branch, const std::string& parent) -> void {
+        const std::string path = parent.empty() ? branch->GetName() : parent + "/" + branch->GetName();
+        result.insert(path);
+        auto* children = branch->GetListOfBranches();
+        for (int index = 0; index <= children->GetLast(); ++index)
+            self(self, static_cast<TBranch*>(children->At(index)), path);
+    };
+    auto* branches = tree.GetListOfBranches();
+    for (int index = 0; index <= branches->GetLast(); ++index) {
+        auto* branch = static_cast<TBranch*>(branches->At(index));
+        if (std::string(branch->GetName()) != kSignalBranch) visit(visit, branch, "");
+    }
+    return result;
+}
+
+std::multiset<std::string> OpaqueKeyInventory(TFile& file) {
+    std::multiset<std::string> result;
+    TIter next(file.GetListOfKeys());
+    while (auto* key = dynamic_cast<TKey*>(next())) {
+        const std::string name = key->GetName();
+        if (name != kEventTree && name != "REST_LegacySignalRecovery")
+            result.insert(name + ":" + key->GetClassName() + ":" + std::to_string(key->GetCycle()));
+    }
+    return result;
+}
+
+bool FillModernEvent(const IntermediateEvent& input, TRestDetectorSignalEvent& output) {
+    output.Initialize();
+    output.SetRunOrigin(input.runOrigin);
+    output.SetSubRunOrigin(input.subRunOrigin);
+    output.SetID(input.eventID);
+    output.SetSubID(input.subEventID);
+    output.SetTime(input.timeSec, input.timeNanoSec);
+    output.SetOK(input.ok);
+    output.SetSubEventTag(*input.subEventTag);
+    std::size_t point = 0;
+    for (std::size_t index = 0; index < input.signalIDs->size(); ++index) {
+        TRestDetectorSignal signal;
+        signal.SetSignalID(input.signalIDs->at(index));
+        signal.SetSignalName(input.names->at(index));
+        signal.SetSignalType(input.types->at(index));
+        for (Int_t offset = 0; offset < input.pointCounts->at(index); ++offset, ++point)
+            signal.NewPoint(input.times->at(point), input.charges->at(point));
+        output.AddSignal(signal);
+    }
+    return point == input.times->size();
+}
+
+bool SameModernEvent(const IntermediateEvent& input, TRestDetectorSignalEvent& output) {
+    const auto same = [](Float_t oldValue, Double_t newValue) {
+        return static_cast<Double_t>(oldValue) == newValue || (std::isnan(oldValue) && std::isnan(newValue));
+    };
+    if (output.GetRunOrigin() != input.runOrigin || output.GetSubRunOrigin() != input.subRunOrigin ||
+        output.GetID() != input.eventID || output.GetSubID() != input.subEventID ||
+        output.GetTimeStamp().GetSec() != input.timeSec ||
+        output.GetTimeStamp().GetNanoSec() != input.timeNanoSec || output.isOk() != input.ok ||
+        output.GetSubEventTag() != *input.subEventTag ||
+        output.GetNumberOfSignals() != static_cast<Int_t>(input.signalIDs->size()))
+        return false;
+    std::size_t point = 0;
+    for (std::size_t index = 0; index < input.signalIDs->size(); ++index) {
+        auto* signal = output.GetSignal(index);
+        if (signal->GetSignalID() != input.signalIDs->at(index) ||
+            signal->GetSignalName() != input.names->at(index) ||
+            signal->GetSignalType() != input.types->at(index) ||
+            signal->GetNumberOfPoints() != input.pointCounts->at(index))
+            return false;
+        for (Int_t offset = 0; offset < input.pointCounts->at(index); ++offset, ++point) {
+            if (!same(input.times->at(point), signal->GetTime(offset)) ||
+                !same(input.charges->at(point), signal->GetData(offset)))
+                return false;
+        }
+    }
+    return point == input.times->size();
+}
+
+bool ValidateOutput(const fs::path& outputName, const fs::path& intermediateName,
+                    const std::set<std::string>& branches, const std::multiset<std::string>& keys) {
+    TFile output(outputName.c_str(), "READ");
+    TFile intermediate(intermediateName.c_str(), "READ");
+    auto* tree = dynamic_cast<TTree*>(output.Get(kEventTree));
+    auto* data = dynamic_cast<TTree*>(intermediate.Get(kDataTree));
+    auto* signalBranch = tree == nullptr ? nullptr : tree->GetBranch(kSignalBranch);
+    if (output.IsZombie() || intermediate.IsZombie() || tree == nullptr || data == nullptr ||
+        signalBranch == nullptr || tree->GetEntries() != data->GetEntries() ||
+        DetectSignalVersion(signalBranch) < 4 || BranchInventory(*tree) != branches ||
+        OpaqueKeyInventory(output) != keys) {
+        std::cerr << "ERROR: recovered file structure failed validation.\n";
+        return false;
+    }
+
+    IntermediateEvent input;
+    auto* event = new TRestDetectorSignalEvent;
+    if (!input.Bind(*data) || tree->SetBranchAddress(kSignalBranch, &event) < TTree::kMatch) return false;
+    for (Long64_t entry = 0; entry < tree->GetEntries(); ++entry) {
+        if (data->GetEntry(entry) <= 0 || signalBranch->GetEntry(entry) <= 0 || !input.Validate(entry) ||
+            !SameModernEvent(input, *event)) {
+            std::cerr << "ERROR: recovered signal values differ at entry " << entry << ".\n";
+            return false;
+        }
+    }
+    return true;
+}
+
+bool Rebuild(const fs::path& sourceName, const fs::path& intermediateName, const fs::path& candidateName) {
+    TFile source(sourceName.c_str(), "READ");
+    TFile intermediate(intermediateName.c_str(), "READ");
+    auto* sourceTree = dynamic_cast<TTree*>(source.Get(kEventTree));
+    auto* data = dynamic_cast<TTree*>(intermediate.Get(kDataTree));
+    auto* sourceSignal = sourceTree == nullptr ? nullptr : sourceTree->GetBranch(kSignalBranch);
+    Long64_t sourceSize = -1, sourceEntries = -1, sourceVersion = -1, recoveredSignals = -1,
+             recoveredPoints = -1;
+    std::string sourceUuid;
+    if (source.IsZombie() || intermediate.IsZombie() || sourceTree == nullptr || data == nullptr ||
+        sourceSignal == nullptr || !ReadText(intermediate, "sourceUuid", sourceUuid) ||
+        !ReadNumber(intermediate, "sourceSize", sourceSize) ||
+        !ReadNumber(intermediate, "sourceEntries", sourceEntries) ||
+        !ReadNumber(intermediate, "sourceSignalVersion", sourceVersion) ||
+        !ReadNumber(intermediate, "recoveredSignals", recoveredSignals) ||
+        !ReadNumber(intermediate, "recoveredPoints", recoveredPoints) ||
+        sourceUuid != source.GetUUID().AsString() || sourceSize != source.GetSize() ||
+        sourceEntries != sourceTree->GetEntries() || sourceVersion != DetectSignalVersion(sourceSignal) ||
+        sourceVersion < 1 || sourceVersion > 3 || data->GetEntries() != sourceEntries) {
+        std::cerr << "ERROR: recovery intermediate does not match the source file.\n";
+        return false;
+    }
+    const auto branches = BranchInventory(*sourceTree);
+    const auto keys = OpaqueKeyInventory(source);
+    source.Close();
+
+    std::error_code error;
+    if (!fs::copy_file(sourceName, candidateName, fs::copy_options::none, error)) {
+        std::cerr << "ERROR: cannot copy source to recovery candidate: " << error.message() << ".\n";
+        return false;
+    }
+    fs::permissions(candidateName, fs::perms::owner_write, fs::perm_options::add, error);
+    if (error) {
+        std::cerr << "ERROR: cannot make recovery candidate writable: " << error.message() << ".\n";
+        return false;
+    }
+
+    auto candidate = TRestRootFileHandle::Open(candidateName.string(), TRestRootFileMode::Update);
+    if (!candidate) {
+        std::cerr << "ERROR: cannot safely update recovery candidate: " << candidate.Error() << ".\n";
+        return false;
+    }
+    auto* oldTree = dynamic_cast<TTree*>(candidate->Get(kEventTree));
+    auto* oldSignal = oldTree == nullptr ? nullptr : oldTree->GetBranch(kSignalBranch);
+    if (oldTree == nullptr || oldSignal == nullptr || oldTree->GetEntries() != sourceEntries ||
+        candidate->GetUUID().AsString() != sourceUuid)
+        return false;
+
+    // Clone every unaffected branch as raw baskets. Disabling the top-level
+    // signal branch makes ROOT omit its complete split subtree.
+    oldSignal->SetStatus(false);
+    oldTree->SetName("__RESTLegacySourceEventTree");
+    candidate->cd();
+    std::cerr << "Recovery: fast-cloning unaffected EventTree branches...\n";
+    auto* newTree = oldTree->CloneTree(-1, "fast");
+    if (newTree == nullptr || newTree->GetEntries() != sourceEntries) return false;
+    candidate->Delete("EventTree;*");
+    std::cerr << "Recovery: rebuilding detector signal branch...\n";
+    newTree->SetName(kEventTree);
+
+    IntermediateEvent input;
+    auto* event = new TRestDetectorSignalEvent;
+    auto* newSignal = newTree->Branch(kSignalBranch, &event);
+    if (!input.Bind(*data) || newSignal == nullptr) return false;
+    Long64_t signalCount = 0, pointCount = 0;
+    for (Long64_t entry = 0; entry < sourceEntries; ++entry) {
+        if (data->GetEntry(entry) <= 0 || !input.Validate(entry) || !FillModernEvent(input, *event) ||
+            newSignal->Fill() < 0)
+            return false;
+        signalCount += input.signalIDs->size();
+        pointCount += input.times->size();
+    }
+    if (signalCount != recoveredSignals || pointCount != recoveredPoints) return false;
+
+    candidate->cd();
+    const std::string provenance =
+        "source=" + sourceUuid + ";signalVersion=" + std::to_string(sourceVersion) +
+        ";entries=" + std::to_string(sourceEntries) + ";signals=" + std::to_string(signalCount) +
+        ";points=" + std::to_string(pointCount);
+    std::cerr << "Recovery: writing rebuilt EventTree...\n";
+    if (newTree->Write(kEventTree, TObject::kOverwrite) <= 0 ||
+        !WriteText(*candidate, "REST_LegacySignalRecovery", provenance) || !candidate.Close())
+        return false;
+    return ValidateOutput(candidateName, intermediateName, branches, keys);
+}
+
+fs::path DefaultOutput(fs::path input) {
+    if (input.extension() == ".root")
+        input.replace_filename(input.stem().string() + "_Fixed.root");
+    else
+        input += "_Fixed.root";
+    return input;
+}
+
+#ifndef _WIN32
+int RunExtractor(const fs::path& input, const fs::path& intermediate, const fs::path& directory) {
+    fs::path macro = fs::path(REST_PATH) / "macros/legacy/recoverLegacySignalData.C";
+#ifdef REST_TESTING_ENABLED
+    if (const char* overridePath = std::getenv("REST_LEGACY_RECOVERY_MACRO")) macro = overridePath;
+#endif
+    const pid_t child = fork();
+    if (child == 0) {
+        setenv("REST_LEGACY_RECOVERY_INPUT", input.c_str(), 1);
+        setenv("REST_LEGACY_RECOVERY_INTERMEDIATE", intermediate.c_str(), 1);
+        setenv("REST_LEGACY_RECOVERY_DIR", directory.c_str(), 1);
+        chdir(directory.c_str());
+        const std::string build = "gSystem->SetBuildDir(gSystem->Getenv(\"REST_LEGACY_RECOVERY_DIR\"),kTRUE)";
+        const std::string compiledMacro = macro.string() + "+";
+        execlp("root", "root", "-l", "-b", "-n", "-x", "-q", "-e", build.c_str(), compiledMacro.c_str(),
+               static_cast<char*>(nullptr));
+        _exit(127);
+    }
+    if (child < 0) return -1;
+    int status = 0;
+    while (waitpid(child, &status, 0) < 0 && errno == EINTR) {
+    }
+    return WIFEXITED(status) ? WEXITSTATUS(status) : 128;
+}
+#endif
+
+}  // namespace
+
+int RunLegacySignalRecoveryCommand(int argc, char* argv[]) {
+    int flag = -1;
+    for (int index = 1; index < argc; ++index)
+        if (std::string(argv[index]) == "--recover-legacy-signals") flag = index;
+    if (flag < 0) return -1;
+
+#ifdef _WIN32
+    std::cerr << "ERROR: legacy recovery is currently supported on POSIX systems only.\n";
+    return 2;
+#else
+    fs::path input, output;
+    for (int index = flag + 1; index < argc; ++index) {
+        const std::string argument = argv[index];
+        if (argument == "--output" && index + 1 < argc)
+            output = argv[++index];
+        else if (argument == "--help" || argument == "-h") {
+            std::cout << "Usage: restRoot --recover-legacy-signals INPUT [--output OUTPUT]\n";
+            return 0;
+        } else if (!argument.empty() && argument.front() == '-') {
+            std::cerr << "ERROR: unknown recovery option '" << argument << "'.\n";
+            return 2;
+        } else if (input.empty())
+            input = argument;
+        else {
+            std::cerr << "ERROR: recovery accepts exactly one input file.\n";
+            return 2;
+        }
+    }
+    if (input.empty() || TRestTools::IsRemoteRootPath(input.string())) {
+        std::cerr << "ERROR: recovery requires one local input ROOT file.\n";
+        return 2;
+    }
+    std::error_code error;
+    input = fs::canonical(input, error);
+    if (error) {
+        std::cerr << "ERROR: cannot resolve input file: " << error.message() << ".\n";
+        return 2;
+    }
+    if (!output.empty() && TRestTools::IsRemoteRootPath(output.string())) {
+        std::cerr << "ERROR: recovery output must be a local path.\n";
+        return 2;
+    }
+    output = output.empty() ? DefaultOutput(input) : fs::absolute(output, error);
+    if (error) {
+        std::cerr << "ERROR: cannot resolve output path: " << error.message() << ".\n";
+        return 2;
+    }
+    const bool outputExists = fs::exists(output, error);
+    if (error || TRestTools::IsRemoteRootPath(output.string()) || outputExists || output == input) {
+        std::cerr << "ERROR: output must be a new local file distinct from the input.\n";
+        return 2;
+    }
+
+    const fs::path work =
+        output.parent_path() / (".rest-legacy-signals-" + std::to_string(static_cast<long long>(getpid())));
+    const fs::path intermediate = work / "signals.root";
+    const fs::path candidate = work / "candidate.root";
+    if (!fs::create_directory(work, error)) {
+        std::cerr << "ERROR: cannot create recovery work directory"
+                  << (error ? ": " + error.message() : " because it already exists") << ".\n";
+        return 3;
+    }
+
+    const int extraction = RunExtractor(input, intermediate, work);
+    if (extraction == 0) TRestTools::LoadRESTLibrary(true);
+    const bool rebuilt = extraction == 0 && Rebuild(input, intermediate, candidate);
+    // The candidate shares the output filesystem. A hard link publishes it
+    // atomically and, unlike rename on POSIX, cannot replace a racing writer.
+    if (rebuilt) fs::create_hard_link(candidate, output, error);
+    const bool installed = rebuilt && !error;
+    fs::remove_all(work, error);
+    if (!installed) {
+        std::cerr << "ERROR: recovery failed; the original file was not modified.\n";
+        return extraction == 0 ? 4 : extraction;
+    }
+    std::cout << "Recovered file written to " << output << "\n";
+    return 0;
+#endif
+}

--- a/source/bin/LegacySignalRecovery.h
+++ b/source/bin/LegacySignalRecovery.h
@@ -1,0 +1,7 @@
+#ifndef REST_LEGACY_SIGNAL_RECOVERY_H
+#define REST_LEGACY_SIGNAL_RECOVERY_H
+
+// Returns -1 for an ordinary restRoot invocation, otherwise the recovery exit code.
+int RunLegacySignalRecoveryCommand(int argc, char* argv[]);
+
+#endif

--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -8,6 +8,10 @@
 #include "TRestTools.h"
 #include "TRestVersion.h"
 
+#ifdef REST_LEGACY_SIGNAL_RECOVERY
+#include "LegacySignalRecovery.h"
+#endif
+
 using namespace std;
 
 #ifdef WIN32
@@ -22,6 +26,11 @@ using namespace std;
 // Don't use cout in the main function!
 // This will make cout un-usable in the command line!
 int main(int argc, char* argv[]) {
+#ifdef REST_LEGACY_SIGNAL_RECOVERY
+    const int recoveryStatus = RunLegacySignalRecoveryCommand(argc, argv);
+    if (recoveryStatus >= 0) return recoveryStatus;
+#endif
+
     // set the env and debug status
     setenv("REST_VERSION", REST_RELEASE, 1);
 
@@ -62,6 +71,8 @@ int main(int argc, char* argv[]) {
                     printf(" restRoot --m [0,1]\n");
                     printf("\n");
                     printf(" Option 0 will disable macro loading. Option 0 is the default.\n");
+                    printf("\n Recover legacy detector signal files with:\n");
+                    printf(" restRoot --recover-legacy-signals INPUT [--output OUTPUT]\n");
                     printf("\n");
                     exit(0);
             }

--- a/source/bin/restRoot.cxx
+++ b/source/bin/restRoot.cxx
@@ -71,8 +71,10 @@ int main(int argc, char* argv[]) {
                     printf(" restRoot --m [0,1]\n");
                     printf("\n");
                     printf(" Option 0 will disable macro loading. Option 0 is the default.\n");
+#ifdef REST_LEGACY_SIGNAL_RECOVERY
                     printf("\n Recover legacy detector signal files with:\n");
                     printf(" restRoot --recover-legacy-signals INPUT [--output OUTPUT]\n");
+#endif
                     printf("\n");
                     exit(0);
             }

--- a/source/framework/core/src/TRestRun.cxx
+++ b/source/framework/core/src/TRestRun.cxx
@@ -36,7 +36,11 @@
 #include <unistd.h>
 #endif  // !WIN32
 
+#include <TBranchElement.h>
+#include <TStreamerInfo.h>
+
 #include <filesystem>
+#include <memory>
 
 #include "TRestDataBase.h"
 #include "TRestEventProcess.h"
@@ -47,6 +51,45 @@
 using namespace std;
 
 std::mutex mutex_read;
+
+namespace {
+Int_t GetDetectorSignalVersion(TBranch* branch) {
+    Int_t time = -1;
+    Int_t charge = -1;
+    const auto visit = [&](auto&& self, TBranch* current) -> void {
+        if (auto* element = dynamic_cast<TBranchElement*>(current)) {
+            const std::string name = current->GetName();
+            if (name == "fSignal.fSignalTime") time = element->GetClassVersion();
+            if (name == "fSignal.fSignalCharge") charge = element->GetClassVersion();
+        }
+        auto* children = current->GetListOfBranches();
+        for (int index = 0; index <= children->GetLast(); ++index)
+            self(self, static_cast<TBranch*>(children->At(index)));
+    };
+    if (branch != nullptr) visit(visit, branch);
+    return time == charge ? time : -1;
+}
+
+bool RequiresLegacySignalRecovery(TFile& file) {
+    auto* currentSignal = TClass::GetClass("TRestDetectorSignal");
+    auto* tree = dynamic_cast<TTree*>(file.Get("EventTree"));
+    auto* branch = tree == nullptr ? nullptr : tree->GetBranch("TRestDetectorSignalEventBranch");
+    const Int_t version = GetDetectorSignalVersion(branch);
+    if (currentSignal == nullptr || currentSignal->GetClassVersion() < 4 || version < 1 || version >= 4)
+        return false;
+
+    std::unique_ptr<TList> infos(file.GetStreamerInfoList());
+    if (infos == nullptr) return true;
+    TIter next(infos.get());
+    while (auto* object = next()) {
+        auto* info = dynamic_cast<TStreamerInfo*>(object);
+        if (info != nullptr && std::string(info->GetName()) == "TRestDetectorSignal" &&
+            info->GetClassVersion() == version)
+            return false;
+    }
+    return true;
+}
+}  // namespace
 
 ClassImp(TRestRun);
 
@@ -376,6 +419,15 @@ void TRestRun::OpenInputFile(const TString& filename, const string& mode) {
         }
         fInputFileOwner = std::move(inputFile);
         fInputFile = fInputFileOwner.Get();
+
+        if (RequiresLegacySignalRecovery(*fInputFile)) {
+            RESTError << "This file contains a legacy detector-signal schema that cannot be read safely "
+                         "with the loaded REST version."
+                      << RESTendl;
+            RESTError << "Recover it first with:" << RESTendl;
+            RESTError << "  restRoot --recover-legacy-signals " << filename << RESTendl;
+            exit(1);
+        }
 
         if (GetMetadataClass("TRestRun", fInputFile)) {
             // This should be the values in RML (if it was initialized using RML)


### PR DESCRIPTION
![Vindaar](https://badgen.net/badge/PR%20submitted%20by%3A/Vindaar/blue) ![Large: 808](https://badgen.net/badge/PR%20Size/Large%3A%20808/red) [![](https://github.com/rest-for-physics/framework/actions/workflows/validation.yml/badge.svg?branch=pr566-slim)](https://github.com/rest-for-physics/framework/commits/pr566-slim) [<img width="16" alt="Powered by Pull Request Badge" src="https://user-images.githubusercontent.com/1393946/111216524-d2bb8e00-85d4-11eb-821b-ed4c00989c02.png">](https://pullrequestbadge.com/?utm_medium=github&utm_source=rest-for-physics&utm_campaign=badge_info)<!-- PR-BADGE: PLEASE DO NOT REMOVE THIS COMMENT -->  

This is a reimplementation of the ideas from PR #566, but in a much more focused and succinct way. 

The recovery workflow that is added now fully embraces that it is *entirely specific to the* `vector<float> -> vector<double>` schema change and nothing else. And instead of building a full blown REST ROOT file copy mechanism that iterates a file to copy everything, we now essentially make an opaque copy and only mutate the parts of the file that actually changed.

This PR depends on some minor additions to detectorlib for the CI to make sure the changes are actually working as expected. That is PR https://github.com/rest-for-physics/detectorlib/pull/132.

For the moment this also targets the branch of #567, because this code now depends on that. So either way, we should focus on merging 567 first now. 

I'll update the description at a later point.